### PR TITLE
Feat: adds ability to navigate through user's working directory

### DIFF
--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -34,7 +34,7 @@ export const FileList = (): JSX.Element => {
               <ListItem key={item.name} disablePadding disableGutters>
                 <ListItemButton
                   role={undefined}
-                  onClick={handleToggle(item.name)}
+                  onClick={(e: React.MouseEvent) => handleToggle(e, item.name)}
                   dense
                 >
                   <ListItemIcon>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -11,7 +11,7 @@ import FolderIcon from '@mui/icons-material/Folder';
 import useFileList from '../hooks/useFileList';
 
 export const FileList = (): JSX.Element => {
-  const { checked, content, handleToggle, getContents } = useFileList();
+  const { checked, content, handleClick, getContents } = useFileList();
 
   React.useEffect(() => {
     if (content.length === 0) {
@@ -34,7 +34,7 @@ export const FileList = (): JSX.Element => {
               <ListItem key={item.name} disablePadding disableGutters>
                 <ListItemButton
                   role={undefined}
-                  onClick={(e: React.MouseEvent) => handleToggle(e, item.name)}
+                  onClick={(e: React.MouseEvent) => handleClick(e, item)}
                   dense
                 >
                   <ListItemIcon>

--- a/src/components/FileList.tsx
+++ b/src/components/FileList.tsx
@@ -8,10 +8,12 @@ import Checkbox from '@mui/material/Checkbox';
 import InsertDriveFileOutlinedIcon from '@mui/icons-material/InsertDriveFileOutlined';
 import FolderIcon from '@mui/icons-material/Folder';
 
+import FileListCrumbs from './file-list/FileListCrumbs';
 import useFileList from '../hooks/useFileList';
 
 export const FileList = (): JSX.Element => {
-  const { checked, content, handleClick, getContents } = useFileList();
+  const { checked, content, currentPath, handleClick, getContents } =
+    useFileList();
 
   React.useEffect(() => {
     if (content.length === 0) {
@@ -22,6 +24,8 @@ export const FileList = (): JSX.Element => {
 
   return (
     <>
+      <FileListCrumbs currentPath={currentPath} getContents={getContents} />
+      {/* TODO: add breadcrumbs */}
       <List
         sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}
         dense

--- a/src/components/file-list/FileListCrumbs.tsx
+++ b/src/components/file-list/FileListCrumbs.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import Typography from '@mui/material/Typography';
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Link from '@mui/material/Link';
+import FolderIcon from '@mui/icons-material/Folder';
+
+import { Content } from '../../hooks/useFileList';
+
+type FileListCrumbsProps = {
+  currentPath: string;
+  getContents: (path: Content['path']) => void;
+};
+
+export default function FileListCrumbs({
+  currentPath,
+  getContents
+}: FileListCrumbsProps): JSX.Element {
+  const dirArray = currentPath.split('/');
+  const dirDepth = dirArray.length;
+  return (
+    <Breadcrumbs aria-label="breadcrumb">
+      <Link
+        component="button"
+        underline="hover"
+        color="inherit"
+        onClick={() => getContents('')}
+      >
+        <FolderIcon />
+      </Link>
+      {dirArray.map((item, index) => {
+        if (index < dirDepth - 1) {
+          return (
+            <Link
+              key={item}
+              component="button"
+              underline="hover"
+              color="inherit"
+              onClick={() =>
+                getContents(dirArray.slice(0, index + 1).join('/'))
+              }
+            >
+              {item}
+            </Link>
+          );
+        } else if (index === dirDepth - 1) {
+          return (
+            <Typography key={item} color="text.primary">
+              {item}
+            </Typography>
+          );
+        }
+      })}
+    </Breadcrumbs>
+  );
+}

--- a/src/components/file-list/FileListCrumbs.tsx
+++ b/src/components/file-list/FileListCrumbs.tsx
@@ -18,11 +18,20 @@ export default function FileListCrumbs({
   const dirArray = currentPath.split('/');
   const dirDepth = dirArray.length;
   return (
-    <Breadcrumbs aria-label="breadcrumb">
+    <Breadcrumbs
+      aria-label="breadcrumb"
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '2px',
+        padding: '16px'
+      }}
+    >
       <Link
         component="button"
         underline="hover"
         color="inherit"
+        sx={{ display: 'flex', alignItems: 'center' }}
         onClick={() => getContents('')}
       >
         <FolderIcon />

--- a/src/hooks/useFileList.tsx
+++ b/src/hooks/useFileList.tsx
@@ -20,25 +20,26 @@ export default function useFileList() {
   const [content, setContent] = React.useState<Content[]>([]);
 
   // e = event
-  const handleToggle = (e: React.MouseEvent, value: string) => {
+  const handleClick = (e: React.MouseEvent, item: Content) => {
     if (e.detail === 1) {
-      const currentIndex = checked.indexOf(value);
+      const currentIndex = checked.indexOf(item.name);
       const newChecked = [...checked];
 
       if (currentIndex === -1) {
-        newChecked.push(value);
+        newChecked.push(item.name);
       } else {
         newChecked.splice(currentIndex, 1);
       }
 
       setChecked(newChecked);
     } else if (e.detail === 2) {
-      console.log('double click', value);
+      console.log('double click', item.name);
+      getContents(item.path);
     }
   };
 
-  async function getContents(): Promise<void> {
-    const url = 'http://localhost:8888/api/contents/?content=1';
+  async function getContents(path?: Content['path']): Promise<void> {
+    const url = `http://localhost:8888/api/contents/${path ? path + '/' : ''}?content=1`;
     let data = [];
     try {
       const response = await fetch(url);
@@ -70,7 +71,7 @@ export default function useFileList() {
   return {
     checked,
     content,
-    handleToggle,
+    handleClick,
     getContents
   };
 }

--- a/src/hooks/useFileList.tsx
+++ b/src/hooks/useFileList.tsx
@@ -18,22 +18,20 @@ export type Content = {
 export default function useFileList() {
   const [checked, setChecked] = React.useState<string[]>([]);
   const [content, setContent] = React.useState<Content[]>([]);
+  const [currentPath, setCurrentPath] = React.useState<string>('');
 
   // e = event
   const handleClick = (e: React.MouseEvent, item: Content) => {
     if (e.detail === 1) {
       const currentIndex = checked.indexOf(item.name);
       const newChecked = [...checked];
-
       if (currentIndex === -1) {
         newChecked.push(item.name);
       } else {
         newChecked.splice(currentIndex, 1);
       }
-
       setChecked(newChecked);
     } else if (e.detail === 2) {
-      console.log('double click', item.name);
       getContents(item.path);
     }
   };
@@ -48,6 +46,9 @@ export default function useFileList() {
       }
 
       data = await response.json();
+      if (data.path) {
+        setCurrentPath(data.path);
+      }
       if (data.content) {
         // display directories first, then files
         // within a type (directories or files), display alphabetically
@@ -71,6 +72,7 @@ export default function useFileList() {
   return {
     checked,
     content,
+    currentPath,
     handleClick,
     getContents
   };

--- a/src/hooks/useFileList.tsx
+++ b/src/hooks/useFileList.tsx
@@ -19,17 +19,22 @@ export default function useFileList() {
   const [checked, setChecked] = React.useState<string[]>([]);
   const [content, setContent] = React.useState<Content[]>([]);
 
-  const handleToggle = (value: string) => () => {
-    const currentIndex = checked.indexOf(value);
-    const newChecked = [...checked];
+  // e = event
+  const handleToggle = (e: React.MouseEvent, value: string) => {
+    if (e.detail === 1) {
+      const currentIndex = checked.indexOf(value);
+      const newChecked = [...checked];
 
-    if (currentIndex === -1) {
-      newChecked.push(value);
-    } else {
-      newChecked.splice(currentIndex, 1);
+      if (currentIndex === -1) {
+        newChecked.push(value);
+      } else {
+        newChecked.splice(currentIndex, 1);
+      }
+
+      setChecked(newChecked);
+    } else if (e.detail === 2) {
+      console.log('double click', value);
     }
-
-    setChecked(newChecked);
   };
 
   async function getContents(): Promise<void> {

--- a/style/base.css
+++ b/style/base.css
@@ -24,10 +24,3 @@
   padding: 0;
   box-sizing: border-box;
 }
-
-.jp-react-widget button {
-  padding: 8px 16px;
-  margin: 8px;
-  font-size: 14px;
-  cursor: pointer;
-}


### PR DESCRIPTION
- Mimicking the JupyterLab interface, double-clicking on a directory navigates into the directory. Single-clicking just checks/unchecks the directory.
- Includes breadcrumbs at the top of the file list to navigate back to higher directory levels.

Note that no functionality exists when double-clicking on a file. This will be addressed through issue #7. 