### PR TITLE
fix: adds pydantic as a test depedency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         sudo rm -rf $(which node)
         sudo rm -rf $(which node)
 
-        pip install "jupyterlab>=4.0.0,<5" fileglancer*.whl
+        pip install "jupyterlab>=4.0.0,<5" pydantic fileglancer*.whl
 
 
         jupyter server extension list

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Install the extension
       run: |
         set -eux
-        python -m pip install "jupyterlab>=4.0.0,<5" fileglancer*.whl
+        python -m pip install "jupyterlab>=4.0.0,<5" pydantic fileglancer*.whl
 
     - name: Install dependencies
       working-directory: ui-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches: main
   pull_request:

--- a/pixi.lock
+++ b/pixi.lock
@@ -1618,10 +1618,11 @@ packages:
   name: fileglancer
   version: 0.1.0
   path: .
-  sha256: 7bf9eeac887fc33f9beedf30f68091750baf8f1ea86b8697b1dbc8c0a1689428
+  sha256: f4d3ce4c2ec198665299c62ab2294229e28b687ea7668d17526c110a4bebec5d
   requires_dist:
   - jupyter-server<3,>=2.4.0
   - coverage ; extra == 'test'
+  - pydantic ; extra == 'test'
   - pytest ; extra == 'test'
   - pytest-asyncio ; extra == 'test'
   - pytest-cov ; extra == 'test'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,8 @@ clean-dev-install = { depends-on = ["clean", "initialize", "dev-install"] }
 overwrite-ext = "jupyter labextension develop . --overwrite"
 enable-ext = { cmd = "jupyter server extension enable fileglancer", depends-on = ["overwrite-ext"] }
 build = "jlpm build"
-dev-launch = "jupyter lab --autoreload"
 dev-build = {cmd = "jlpm watch", depends-on = ["enable-ext"]}
+dev-launch = "jupyter lab --autoreload"
 uninstall = "pip uninstall fileglancer"
 
 [tool.pixi.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,4 +122,5 @@ pytest-check-links = ">=0.10.1,<0.11"
 pytest-jupyter = ">=0.10.1,<0.11"
 python = ">=3.13.2,<4"
 pip = ">=25.0.1,<26"
+pydantic = ">=2.10.6,<3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ test = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
-    "pytest-jupyter[server]>=0.6.0"
+    "pytest-jupyter[server]>=0.6.0",
+    "pydantic"
 ]
 
 [tool.hatch.version]

--- a/ui-tests/tests/fileglancer.spec.ts
+++ b/ui-tests/tests/fileglancer.spec.ts
@@ -16,6 +16,6 @@ test('should emit an activation console message', async ({ page }) => {
   await page.goto();
 
   expect(
-    logs.filter(s => s === 'JupyterLab extension fileglancer-server is activated!')
+    logs.filter(s => s === 'JupyterLab extension fileglancer is activated!')
   ).toHaveLength(1);
 });


### PR DESCRIPTION
pydantic is used by the filestore. it is installed in the pixi environment through copier, but it does not get automatically installed in the github action test environment, so we must make that explicit