### PR TITLE
Proxy API for file share paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,27 @@ If everything has worked so far, you should see the React Widget on the Launcher
 
 ![Screenshot of the JupyterLab Launcher panel. In the bottom section, titled "Other", the square tile with the title "React Widget" is circled](./assets/img/JupyterLab-launcher.png)
 
-### Development uninstall
+
+## Configuration
+
+You can configure the URL of the [Fileglance Central](https://github.com/JaneliaSciComp/fileglancer-central) server with traitlets, in several ways:
+
+### Command line
+
+```bash
+pixi run dev-launch --Fileglancer.central_url=http://your-central-server:7000
+```
+
+### Config file
+
+You can create a file at `~/.jupyter/jupyter_server_config.py` (or in any of the paths reported by `pixi run jupyter --paths`) and add your configuration there:
+
+```python
+c.Fileglancer.central_url='http://your-central-server:7000'
+```
+
+
+## Development Uninstall
 
 ```bash
 pixi run uninstall

--- a/README.md
+++ b/README.md
@@ -47,20 +47,21 @@ If everything has worked so far, you should see the React Widget on the Launcher
 
 ## Configuration
 
-You can configure the URL of the [Fileglance Central](https://github.com/JaneliaSciComp/fileglancer-central) server with traitlets, in several ways:
+By default, no [Fileglance Central](https://github.com/JaneliaSciComp/fileglancer-central) server will be used. 
+You can configure the URL of a Fileglancer Central server with traitlets, in several ways:
 
 ### Command line
 
 ```bash
-pixi run dev-launch --Fileglancer.central_url=http://your-central-server:7000
+pixi run dev-launch --Fileglancer.central_url=http://0.0.0.0:7878
 ```
 
 ### Config file
 
-You can create a file at `~/.jupyter/jupyter_server_config.py` (or in any of the paths reported by `pixi run jupyter --paths`) and add your configuration there:
+You can create a file at `~/.jupyter/jupyter_server_config.py` (or in any of the paths reported by `pixi run jupyter --paths`) and add your configuration there, e.g.:
 
 ```python
-c.Fileglancer.central_url='http://your-central-server:7000'
+c.Fileglancer.central_url='http://0.0.0.0:7878'
 ```
 
 ## Development Uninstall

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ You can create a file at `~/.jupyter/jupyter_server_config.py` (or in any of the
 c.Fileglancer.central_url='http://your-central-server:7000'
 ```
 
-
 ## Development Uninstall
 
 ```bash
@@ -74,26 +73,32 @@ In development mode, you will also need to remove the symlink created by `jupyte
 command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
 folder is located. Then you can remove the symlink named `fileglancer` within that folder.
 
-### Testing the extension
+## Testing 
 
-#### Frontend tests
+### Backend tests
+
+To run backend tests using pytest:
+
+```bash
+pixi run pytest
+```
+
+### Frontend tests
 
 This extension is using [Jest](https://jestjs.io/) for JavaScript code testing.
 
 To execute them, execute:
 
-```sh
-jlpm
-jlpm test
+```bash
+npm test
 ```
 
-#### Integration tests
+### Integration tests
 
 This extension uses [Playwright](https://playwright.dev/docs/intro) for the integration tests (aka user level tests).
 More precisely, the JupyterLab helper [Galata](https://github.com/jupyterlab/jupyterlab/tree/master/galata) is used to handle testing the extension in JupyterLab.
-
 More information are provided within the [ui-tests](./ui-tests/README.md) README.
 
-### Packaging the extension
+## Packaging and Releases
 
 See [RELEASE](RELEASE.md)

--- a/fileglancer/__init__.py
+++ b/fileglancer/__init__.py
@@ -34,7 +34,7 @@ class Fileglancer(Configurable):
     """
     central_url = Unicode(
         help="The URL of the central server",
-        default_value="http://0.0.0.0:7878",
+        default_value="",
         config=True,
     )
 

--- a/fileglancer/__init__.py
+++ b/fileglancer/__init__.py
@@ -1,3 +1,7 @@
+"""Initialize the backend server extension"""
+from traitlets import CFloat, List, Dict, Unicode, default
+from traitlets.config import Configurable
+
 try:
     from ._version import __version__
 except ImportError:
@@ -7,6 +11,7 @@ except ImportError:
     import warnings
     warnings.warn("Importing 'fileglancer' outside a proper installation.")
     __version__ = "dev"
+
 from .handlers import setup_handlers
 
 
@@ -23,6 +28,17 @@ def _jupyter_server_extension_points():
     }]
 
 
+class Fileglancer(Configurable):
+    """
+    Configuration for the Fileglancer extension
+    """
+    central_url = Unicode(
+        help="The URL of the central server",
+        default_value="http://0.0.0.0:7878",
+        config=True,
+    )
+
+
 def _load_jupyter_server_extension(server_app):
     """Registers the API handler to receive HTTP requests from the frontend extension.
 
@@ -31,6 +47,8 @@ def _load_jupyter_server_extension(server_app):
     server_app: jupyterlab.labapp.LabApp
         JupyterLab application instance
     """
+    config = Fileglancer(config=server_app.config)
+    server_app.web_app.settings["fileglancer"] = config
     setup_handlers(server_app.web_app)
     name = "fileglancer"
     server_app.log.info(f"Registered {name} server extension")

--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -59,7 +59,7 @@ class FileSharePathsHandler(StreamingProxy, ServerRootMixin):
 
         if not central_url:
             server_root_dir = self.get_server_root_dir()
-            self.log.error("No central URL found, using local path")
+            self.log.warning("No central URL found, using local path")
             file_share_paths = [
             {
                 "zone": "Local",

--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -34,18 +34,6 @@ class StreamingProxy(APIHandler):
             }))
 
 
-class RouteHandler(APIHandler):
-    # The following decorator should be present on all verb methods (head, get, post,
-    # patch, put, delete, options) to ensure only authorized user can request the
-    # Jupyter server
-    @web.authenticated
-    def get(self):
-        self.log.info("GET /fileglancer/get-example")
-        self.finish(json.dumps({
-            "data": "This is /fileglancer/get-example endpoint!"
-        }))
-
-
 class FileSharePathsHandler(StreamingProxy):
     
     """
@@ -55,7 +43,6 @@ class FileSharePathsHandler(StreamingProxy):
     def get(self):
         self.log.info("GET /fileglancer/file-share-paths")
         self.stream_response(f"{CENTRAL_URL}/file-share-paths")
-
 
 
 class FilestoreHandler(APIHandler):
@@ -185,7 +172,6 @@ def setup_handlers(web_app):
     """
     base_url = web_app.settings["base_url"]
     handlers = [
-        (url_path_join(base_url, "fileglancer", "get-example"), RouteHandler), 
         (url_path_join(base_url, "fileglancer", "file-share-paths"), FileSharePathsHandler),
         (url_path_join(base_url, "fileglancer", "files", "(.*)"), FilestoreHandler),
         (url_path_join(base_url, "fileglancer", "files"), FilestoreHandler),

--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -26,14 +26,14 @@ class StreamingProxy(APIHandler):
             self.finish()
 
         except requests.exceptions.RequestException as e:
+            self.log.error(f"Error fetching {url}: {str(e)}")
             self.set_status(500)
             self.finish(json.dumps({
-                "error": f"Error fetching {url}: {str(e)}"
+                "error": f"Error streaming response"
             }))
 
 
-class FileSharePathsHandler(StreamingProxy):
-    
+class FileSharePathsHandler(StreamingProxy): 
     """
     API handler for file share paths
     """
@@ -41,6 +41,7 @@ class FileSharePathsHandler(StreamingProxy):
     def get(self):
         self.log.info("GET /fileglancer/file-share-paths")
         central_url = self.settings["fileglancer"].central_url
+        self.log.info(f"Central URL: {central_url}")
         self.stream_response(f"{central_url}/file-share-paths")
 
 

--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -6,8 +6,6 @@ from jupyter_server.utils import url_path_join
 from tornado import web
 from fileglancer.filestore import Filestore
 
-CENTRAL_URL = "http://0.0.0.0:7878"
-
 
 class StreamingProxy(APIHandler):
     """
@@ -42,7 +40,8 @@ class FileSharePathsHandler(StreamingProxy):
     @web.authenticated
     def get(self):
         self.log.info("GET /fileglancer/file-share-paths")
-        self.stream_response(f"{CENTRAL_URL}/file-share-paths")
+        central_url = self.settings["fileglancer"].central_url
+        self.stream_response(f"{central_url}/file-share-paths")
 
 
 class FilestoreHandler(APIHandler):

--- a/fileglancer/tests/test_handlers.py
+++ b/fileglancer/tests/test_handlers.py
@@ -1,16 +1,32 @@
 import json
+import pytest
+import asyncio
+import multiprocessing as mp
+from traitlets.config import Config
+
+import tornado.web
+import tornado.httpserver
+import tornado.ioloop
+import tornado.gen
 
 
-async def test_get_example(jp_fetch):
-    # When
-    response = await jp_fetch("fileglancer", "get-example")
+TEST_SERVER_PORT = 18788
+TEST_MESSAGE = {"paths": ["/path1", "/path2"]}
 
-    # Then
-    assert response.code == 200
-    payload = json.loads(response.body)
-    assert payload == {
-        "data": "This is /fileglancer/get-example endpoint!"
+@pytest.fixture
+def jp_server_config():
+    """Allows tests to setup their specific configuration values."""
+    config = {
+        "ServerApp": {
+            "jpserver_extensions": {
+                "fileglancer": True
+            }
+        },
+        "Fileglancer": {
+            "central_url": f"http://localhost:{TEST_SERVER_PORT}",
+        }
     }
+    return Config(config)
 
 
 async def test_get_files(jp_fetch):
@@ -47,3 +63,33 @@ async def test_patch_files(jp_fetch):
     response = await jp_fetch("fileglancer/files/newdir", method="DELETE")
     assert response.code == 204
 
+
+def run_mock_central_server():
+    """Run a mock central server that returns test data."""
+    class MockHandler(tornado.web.RequestHandler):
+        def get(self):
+            self.write(TEST_MESSAGE)
+    
+    app = tornado.web.Application([
+        (r"/file-share-paths", MockHandler),
+    ])
+    http_server = tornado.httpserver.HTTPServer(app)
+    http_server.listen(TEST_SERVER_PORT)
+    tornado.ioloop.IOLoop.current().start()
+
+
+async def test_get_file_share_paths(jp_fetch):
+    
+    server_process = mp.Process(target=run_mock_central_server)
+    server_process.start()
+    
+    try:
+        await asyncio.sleep(1) # Wait for server to start
+        response = await jp_fetch("fileglancer", "file-share-paths")
+        assert response.code == 200
+        assert json.loads(response.body) == TEST_MESSAGE
+
+    finally:
+        # Stop the mock HTTP server
+        server_process.terminate()
+    

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,15 +60,27 @@ const plugin: JupyterFrontEndPlugin<void> = {
         );
       });
 
-    console.log('Calling listing API...');
-    requestAPI<any>('files/src')
+    console.log('Calling file share paths API...');
+    requestAPI<any>('file-share-paths')
       .then(data => {
-        console.log('listing API call succeeded');
+        console.log('File share paths:');
         console.log(data);
       })
       .catch(reason => {
         console.error(
-          `The fileglancer server extension appears to be missing.\n${reason}`
+          `Problem calling file-share-paths API:\n${reason}`
+        );
+      });
+      
+    console.log('Calling listing API...');
+    requestAPI<any>('files/src')
+      .then(data => {
+        console.log('File listing:');
+        console.log(data);
+      })
+      .catch(reason => {
+        console.error(
+          `Problem getting file listing:\n${reason}`
         );
       });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,18 +48,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
       launcher.add({ command });
     }
 
-    console.log('Calling get-example API...');
-    requestAPI<any>('get-example')
-      .then(data => {
-        console.log('get-example API call succeeded');
-        console.log(data);
-      })
-      .catch(reason => {
-        console.error(
-          `The fileglancer server extension appears to be missing.\n${reason}`
-        );
-      });
-
     console.log('Calling file share paths API...');
     requestAPI<any>('file-share-paths')
       .then(data => {


### PR DESCRIPTION
This PR adds a server handler for retrieving file share paths from the new [central server](https://github.com/JaneliaSciComp/fileglancer-central). I added docs in the README to describe how to configure it. 

@neomorphic @allison-truhlar @StephanPreibisch 