### PR TITLE
Refactor file share paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ You can create a file at `~/.jupyter/jupyter_server_config.py` (or in any of the
 c.Fileglancer.central_url='http://0.0.0.0:7878'
 ```
 
+To configure "Dev Mode" which simulates many zones and file share paths, add this to your config:
+
+```python
+c.Fileglancer.dev_mode=True
+```
+
+
 ## Development Uninstall
 
 ```bash

--- a/fileglancer/__init__.py
+++ b/fileglancer/__init__.py
@@ -1,5 +1,5 @@
 """Initialize the backend server extension"""
-from traitlets import CFloat, List, Dict, Unicode, default
+from traitlets import CFloat, List, Dict, Unicode, Bool, default
 from traitlets.config import Configurable
 
 try:
@@ -35,6 +35,11 @@ class Fileglancer(Configurable):
     central_url = Unicode(
         help="The URL of the central server",
         default_value="",
+        config=True,
+    )
+    dev_mode = Bool(
+        help="Whether to run in dev mode",
+        default_value=False,
         config=True,
     )
 

--- a/fileglancer/filestore.py
+++ b/fileglancer/filestore.py
@@ -70,11 +70,11 @@ class Filestore:
     rooted at a specific directory.
     """
 
-    def __init__(self, root_path: FileSharePath):
+    def __init__(self, file_share_path: FileSharePath):
         """
         Create a Filestore with the given root path.
         """
-        self.root_path = os.path.abspath(root_path.linux_path)
+        self.root_path = os.path.abspath(file_share_path.mount_path)
 
 
     def _check_path_in_root(self, path: str) -> str:

--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -100,12 +100,9 @@ class FileShareHandler(APIHandler):
         subpath = self.get_argument("subpath", '')
         self.log.info(f"GET /api/fileglancer/files/{path} subpath={subpath}")
 
-        
         filestore = self._get_filestore(path)
         if filestore is None:
-            self.log.info("WTFFFFFFFFFF2"+path)
             return
-        
         
         try:
             # Check if subpath is a directory by getting file info

--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -73,20 +73,20 @@ class FileShareHandler(APIHandler):
         """
         Get a filestore for the given path.
         """
-        canonical_path = f"/{path}"
-        fsp = get_fsp_manager(self.settings).get_file_share_path(canonical_path)
+        filestore_path = f"/{path}"
+        fsp = get_fsp_manager(self.settings).get_file_share_path(filestore_path)
         if fsp is None:
             self.set_status(404)
-            self.finish(json.dumps({"error": f"File share path '{canonical_path}' not found"}))
-            self.log.error(f"File share path '{canonical_path}' not found")
+            self.finish(json.dumps({"error": f"File share path '{filestore_path}' not found"}))
+            self.log.error(f"File share path '{filestore_path}' not found")
             return None
         
         # Create a filestore for the file share path
         filestore = _get_mounted_filestore(fsp)
         if filestore is None:
             self.set_status(500)
-            self.finish(json.dumps({"error": f"File share path '{canonical_path}' is not mounted"}))
-            self.log.error(f"File share path '{canonical_path}' is not mounted")
+            self.finish(json.dumps({"error": f"File share path '{filestore_path}' is not mounted"}))
+            self.log.error(f"File share path '{filestore_path}' is not mounted")
             return None
 
         return filestore

--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -69,24 +69,23 @@ class FileShareHandler(APIHandler):
     API handler for file access using the Filestore class
     """
 
-    def _get_filestore(self, path):
+    def _get_filestore(self, path_name):
         """
         Get a filestore for the given path.
         """
-        filestore_path = f"/{path}"
-        fsp = get_fsp_manager(self.settings).get_file_share_path(filestore_path)
+        fsp = get_fsp_manager(self.settings).get_file_share_path(path_name)
         if fsp is None:
             self.set_status(404)
-            self.finish(json.dumps({"error": f"File share path '{filestore_path}' not found"}))
-            self.log.error(f"File share path '{filestore_path}' not found")
+            self.finish(json.dumps({"error": f"File share path '{path_name}' not found"}))
+            self.log.error(f"File share path '{path_name}' not found")
             return None
         
         # Create a filestore for the file share path
         filestore = _get_mounted_filestore(fsp)
         if filestore is None:
             self.set_status(500)
-            self.finish(json.dumps({"error": f"File share path '{filestore_path}' is not mounted"}))
-            self.log.error(f"File share path '{filestore_path}' is not mounted")
+            self.finish(json.dumps({"error": f"File share path '{path_name}' is not mounted"}))
+            self.log.error(f"File share path '{path_name}' is not mounted")
             return None
 
         return filestore

--- a/fileglancer/paths.py
+++ b/fileglancer/paths.py
@@ -12,11 +12,11 @@ log = logging.getLogger("tornado.application")
 # TODO: consider extracting this to a shared library
 class FileSharePath(BaseModel):
     """A file share path from the database"""
+    name: str = Field(
+        description="The name of the file share, which uniquely identifies the file share."
+    )
     zone: str = Field(
         description="The zone of the file share, for grouping paths in the UI."
-    )
-    canonical_path: str = Field(
-        description="The canonical path to the file share, which uniquely identifies the file share."
     )
     group: Optional[str] = Field(
         description="The group that owns the file share",
@@ -25,6 +25,9 @@ class FileSharePath(BaseModel):
     storage: Optional[str] = Field(
         description="The storage type of the file share (home, primary, scratch, etc.)",
         default=None
+    )
+    mount_path: str = Field(
+        description="The path where the file share is mounted on the local machine"
     )
     mac_path: Optional[str] = Field(
         description="The path used to mount the file share on Mac (e.g. smb://server/share)",
@@ -63,10 +66,10 @@ class FileSharePathManager:
             self._file_share_paths = [
                 FileSharePath(
                     zone="Local",
-                    canonical_path="/local",
+                    name="local",
                     group="local",
                     storage="home",
-                    linux_path=root_dir_expanded
+                    mount_path=root_dir_expanded,
                 )
             ]
             n = len(self._file_share_paths)
@@ -90,10 +93,10 @@ class FileSharePathManager:
         return self._file_share_paths
     
 
-    def get_file_share_path(self, canonical_path: str) -> Optional[FileSharePath]:
+    def get_file_share_path(self, name: str) -> Optional[FileSharePath]:
         """Lookup a file share path by its canonical path."""
         for fsp in self._file_share_paths:
-            if canonical_path == fsp.canonical_path:
+            if name == fsp.name:
                 return fsp
         return None
 

--- a/fileglancer/paths.py
+++ b/fileglancer/paths.py
@@ -50,7 +50,7 @@ class FileSharePathManager:
     It is used to get the file share paths from the central server and to cache them for a short time.
     """
     
-    def __init__(self, central_url: str, jupyter_root_dir: str):
+    def __init__(self, central_url: str, dev_mode: bool, jupyter_root_dir: str):
         """Initialize the file share path manager."""
         self.central_url = central_url
         if self.central_url:
@@ -60,20 +60,58 @@ class FileSharePathManager:
             n = len(self.get_file_share_paths())
             log.info(f"Configured {n} file share paths")
         else:
-            log.warning("Central URL is not set, using local file share config")
             root_dir_expanded = os.path.abspath(os.path.expanduser(jupyter_root_dir))
             log.debug(f"Jupyter absolute directory: {root_dir_expanded}")
-            self._file_share_paths = [
-                FileSharePath(
-                    zone="Local",
-                    name="local",
-                    group="local",
-                    storage="home",
-                    mount_path=root_dir_expanded,
-                )
-            ]
-            n = len(self._file_share_paths)
-            log.info(f"Configured {n} file share paths")
+            
+            if dev_mode:
+                log.warning("Dev mode is enabled, using fake file share config")
+                import random
+                
+                # Lists of words to generate random zone and path names
+                adjectives = ["Red", "Blue", "Green", "Purple", "Golden", "Silver", "Crystal", "Mystic", "Ancient", "Cosmic"]
+                nouns = ["Forest", "Mountain", "Ocean", "Desert", "Valley", "Canyon", "River", "Cave", "Plains", "Ridge"]
+                path_types = ["Data", "Projects", "Archive", "Scratch", "Storage"]
+                
+                # Generate 10 zones with 5 paths each
+                zones = []
+                while len(zones) < 10:
+                    adj = random.choice(adjectives)
+                    noun = random.choice(nouns)
+                    zone = f"{adj} {noun}"
+                    if zone not in zones:  # Avoid duplicates
+                        zones.append(zone)
+                
+                self._file_share_paths = []
+                for zone in zones:
+                    for path_type in path_types:
+                        name = f"{zone.lower().replace(' ', '-')}-{path_type.lower()}"
+                        self._file_share_paths.append(
+                            FileSharePath(
+                                zone=zone,
+                                name=name,
+                                group=zone.lower().replace(' ', '_'),
+                                storage=path_type.lower(),
+                                mount_path=root_dir_expanded,
+                                mac_path=f"smb://dev-server/{name}",
+                                windows_path=f"\\\\dev-server\\{name}",
+                                linux_path=f"/mnt/dev/{name}"
+                            )
+                        )
+                n = len(self._file_share_paths)
+                log.info(f"Configured {n} file share paths in dev mode")
+            else:
+                log.warning("Central URL is not set but dev mode is not enabled. Using simple local file share config.")
+                self._file_share_paths = [
+                    FileSharePath(
+                        zone="Local",
+                        name="local",
+                        group="local",
+                        storage="home",
+                        mount_path=root_dir_expanded,
+                    )
+                ]
+                n = len(self._file_share_paths)
+                log.info(f"Configured {n} file share paths")
     
 
     def get_file_share_paths(self) -> list[FileSharePath]:
@@ -102,10 +140,13 @@ class FileSharePathManager:
 
 
 @cache
-def _get_fsp_manager(central_url: str, jupyter_root_dir: str):
-    return FileSharePathManager(central_url, jupyter_root_dir)
+def _get_fsp_manager(central_url: str, dev_mode: bool, jupyter_root_dir: str):
+    return FileSharePathManager(central_url, dev_mode, jupyter_root_dir)
 
 def get_fsp_manager(settings):
     # Extract the relevant settings from the settings dictionary, 
     # since it's not serializable and can't be passed to a @cache method
-    return _get_fsp_manager(settings["fileglancer"].central_url, settings.get("server_root_dir", os.getcwd()))
+    jupyter_root_dir = settings.get("server_root_dir", os.getcwd())
+    central_url = settings["fileglancer"].central_url
+    dev_mode = settings["fileglancer"].dev_mode
+    return _get_fsp_manager(central_url, dev_mode, jupyter_root_dir)

--- a/fileglancer/tests/test_filestore.py
+++ b/fileglancer/tests/test_filestore.py
@@ -34,13 +34,13 @@ def test_dir():
 
 @pytest.fixture
 def filestore(test_dir):
-    file_share_path = FileSharePath(zone="test", canonical_path="/test", linux_path=test_dir)
+    file_share_path = FileSharePath(zone="test", name="test", mount_path=test_dir)
     return Filestore(file_share_path)
 
 
 def test_unmounted_filestore():
     test_dir = "/not/a/real/path"
-    file_share_path = FileSharePath(zone="test", canonical_path="/test", linux_path=test_dir)
+    file_share_path = FileSharePath(zone="test", name="test", mount_path=test_dir)
     filestore = Filestore(file_share_path)
     with pytest.raises(FileNotFoundError):
         filestore.get_file_info(None)

--- a/fileglancer/tests/test_handlers.py
+++ b/fileglancer/tests/test_handlers.py
@@ -46,4 +46,4 @@ async def test_get_file_share_paths(jp_fetch):
     assert isinstance(payload, dict)
     assert "paths" in payload
     assert isinstance(payload["paths"], list)
-    assert payload["paths"][0]["canonical_path"] == "/local"
+    assert payload["paths"][0]["name"] == "local"

--- a/fileglancer/tests/test_mock_server.py
+++ b/fileglancer/tests/test_mock_server.py
@@ -10,7 +10,7 @@ import tornado.gen
 
 
 TEST_SERVER_PORT = 18788
-TEST_MESSAGE = {"paths": [{"zone": "local", "canonical_path": "/local", "linux_path": "/"}]}
+TEST_MESSAGE = {"paths": [{"zone": "local", "name": "local", "mount_path": "/"}]}
 
 
 @pytest.fixture
@@ -55,7 +55,7 @@ async def test_get_file_share_paths(jp_fetch):
         assert response.code == 200
         rj = json.loads(response.body)
         assert rj["paths"][0]["zone"] == TEST_MESSAGE["paths"][0]["zone"]
-        assert rj["paths"][0]["canonical_path"] == TEST_MESSAGE["paths"][0]["canonical_path"]
+        assert rj["paths"][0]["name"] == TEST_MESSAGE["paths"][0]["name"]
 
     finally:
         # Stop the mock HTTP server

--- a/src/components/ui/FileSidebar.tsx
+++ b/src/components/ui/FileSidebar.tsx
@@ -63,7 +63,7 @@ export default function FileSidebar({
           </List.Item>
         </List>
         <List className="bg-background overflow-y-auto">
-          {Object.entries(displayPaths).map(([zone, paths], index) => {
+          {Object.entries(displayPaths).map(([zone, pathItems], index) => {
             const isOpen = openZones[zone] || false;
             return (
               <React.Fragment key={zone}>
@@ -83,18 +83,24 @@ export default function FileSidebar({
                 </List.Item>
                 <Collapse open={isOpen}>
                   <List className="bg-background">
-                    {paths.map((path: string, index) => (
+                    {pathItems.map((pathItem, pathIndex) => (
                       <List.Item
-                        key={`${zone}-${path}`}
-                        onClick={() => handlePathClick(path)}
-                        className={`pl-5 rounded-none cursor-pointer hover:bg-primary-light/30 focus:bg-primary-light/30 hover:!text-foreground focus:!text-foreground ${index % 2 === 0 ? 'bg-surface/50' : 'bg-background'}`}
+                        key={`${zone}-${pathItem.name}`}
+                        onClick={() => handlePathClick(pathItem.name)}
+                        className={`pl-5 rounded-none cursor-pointer hover:bg-primary-light/30 focus:bg-primary-light/30 hover:!text-foreground focus:!text-foreground ${pathIndex % 2 === 0 ? 'bg-surface/50' : 'bg-background'}`}
                         as={Link}
                         to="/files"
                       >
                         <List.ItemStart>
                           <Folder className="h-[18px] w-[18px]" />
                         </List.ItemStart>
-                        {path}
+                        <div className="flex flex-col">
+                          <span className="text-sm font-medium">{pathItem.storage}</span>
+                          <span className="text-xs text-gray-500">{
+                            /* TODO: use the user's preferred address for the path 
+                            (mac_path, windows_path, linux_path) */
+                            pathItem.linux_path}</span>
+                        </div>
                       </List.Item>
                     ))}
                   </List>

--- a/src/hooks/useFileBrowser.ts
+++ b/src/hooks/useFileBrowser.ts
@@ -14,10 +14,11 @@ export type File = {
 
 export type FileSharePathItem = {
   zone: string;
+  name: string;
   group: string;
   storage: string;
+  mount_path: string;
   linux_path: string;
-  canonical_path: string;
   mac_path: string | null;
   windows_path: string | null;
 };
@@ -142,8 +143,12 @@ export default function useFileBrowser() {
           unsortedPaths[item.zone] = [];
         }
 
-        if (!unsortedPaths[item.zone].includes(item.canonical_path)) {
-          unsortedPaths[item.zone].push(item.canonical_path);
+        // TODO: use the user's preferred address for the path 
+        //      (mac_path, windows_path, linux_path)
+        const item_name = item.linux_path;
+
+        if (!unsortedPaths[item.zone].includes(item_name)) {
+          unsortedPaths[item.zone].push(item_name);
         }
       });
 

--- a/src/hooks/useZoneFilter.ts
+++ b/src/hooks/useZoneFilter.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { FileSharePaths } from './useFileBrowser';
+import { FileSharePaths, FileSharePathItem } from './useFileBrowser';
 
 export default function useZoneFilter() {
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -17,16 +17,17 @@ export default function useZoneFilter() {
       const query = searchQuery.toLowerCase();
       const filteredPaths: FileSharePaths = {};
 
-      Object.entries(fileSharePaths).forEach(([zone, paths]) => {
+      Object.entries(fileSharePaths).forEach(([zone, pathItems]) => {
         const zoneMatches = zone.toLowerCase().includes(query);
-        const matchingPaths = paths.filter(path =>
-          path.toLowerCase().includes(query)
+        const matchingPathItems = pathItems.filter((pathItem: FileSharePathItem) =>
+          pathItem.name.toLowerCase().includes(query) || 
+          pathItem.linux_path.toLowerCase().includes(query)
         );
 
         if (zoneMatches) {
-          filteredPaths[zone] = paths;
-        } else if (matchingPaths.length > 0) {
-          filteredPaths[zone] = matchingPaths;
+          filteredPaths[zone] = pathItems;
+        } else if (matchingPathItems.length > 0) {
+          filteredPaths[zone] = matchingPathItems;
         }
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
         console.error(`Problem calling get preference API:\n${reason}`);
       });
 
-
+    // The following demo is commented out because it creates a new ticket 
+    // every time the browser is reloaded.
+    /* 
     const ticketValue = {
       "project_key": "FT",
       "issue_type": "Service Request",
@@ -131,6 +133,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
             
         }); 
       });
+    */
 
   }
 };


### PR DESCRIPTION
@neomorphic @allison-truhlar @StephanPreibisch 

This PR was developed in concert with [fileglancer-central#6](https://github.com/JaneliaSciComp/fileglancer-central/pull/6) and addresses those API changes on this end. 

In addition, I've refactored the client side to use `FileSharePathItem` instead of `string`, so that we can pull out whatever information is needed for display purposes. I use this to display the storage type next to each file share path. 

Finally, I added a dev mode which generates fake zones and file share paths for testing on macOS. 