### PR TITLE
refactor: Converts backend extension to an ExtensionApp class

### DIFF
--- a/fileglancer/__init__.py
+++ b/fileglancer/__init__.py
@@ -1,6 +1,4 @@
 """Initialize the backend server extension"""
-from traitlets import CFloat, List, Dict, Unicode, Bool, default
-from traitlets.config import Configurable
 
 try:
     from ._version import __version__
@@ -12,8 +10,8 @@ except ImportError:
     warnings.warn("Importing 'fileglancer' outside a proper installation.")
     __version__ = "dev"
 
-from .handlers import setup_handlers
-
+import os
+from fileglancer.app import Fileglancer
 
 def _jupyter_labextension_paths():
     return [{
@@ -21,39 +19,14 @@ def _jupyter_labextension_paths():
         "dest": "fileglancer"
     }]
 
-
 def _jupyter_server_extension_points():
-    return [{
-        "module": "fileglancer"
-    }]
-
-
-class Fileglancer(Configurable):
     """
-    Configuration for the Fileglancer extension
+    Returns a list of dictionaries with metadata describing
+    where to find the `_load_jupyter_server_extension` function.
     """
-    central_url = Unicode(
-        help="The URL of the central server",
-        default_value="",
-        config=True,
-    )
-    dev_mode = Bool(
-        help="Whether to run in dev mode",
-        default_value=False,
-        config=True,
-    )
-
-
-def _load_jupyter_server_extension(server_app):
-    """Registers the API handler to receive HTTP requests from the frontend extension.
-
-    Parameters
-    ----------
-    server_app: jupyterlab.labapp.LabApp
-        JupyterLab application instance
-    """
-    config = Fileglancer(config=server_app.config)
-    server_app.web_app.settings["fileglancer"] = config
-    setup_handlers(server_app.web_app)
-    name = "fileglancer"
-    server_app.log.info(f"Registered {name} server extension")
+    return [
+        {
+            "module": "fileglancer.app",
+            "app": Fileglancer
+        }
+    ]

--- a/fileglancer/app.py
+++ b/fileglancer/app.py
@@ -1,0 +1,93 @@
+from jupyter_server.extension.application import ExtensionApp
+from fileglancer.handlers import (
+    FileSharePathsHandler,
+    FileShareHandler,
+    VersionHandler,
+    StaticHandler,
+    PreferencesHandler,
+    TicketHandler,
+)
+from pathlib import Path, PurePath
+from traitlets import (
+    TraitType,
+    Undefined,
+    Unicode,
+    Bool,
+)
+
+class PathType(TraitType):
+    """A pathlib traitlet type which allows string and undefined values."""
+
+    @property
+    def info_text(self):
+        return 'a pathlib.PurePath object'
+
+    def validate(self, obj, value):
+        if isinstance(value, str):
+            return Path(value).expanduser()
+        if isinstance(value, PurePath):
+            return value
+        if value == Undefined:
+            return value
+        self.error(obj, value)
+
+
+class Fileglancer(ExtensionApp):
+
+    name = "fileglancer"
+    app_name = "fileglancer-server"
+    load_other_extensions = True
+    default_url = "/fg"
+
+    ui_path = PathType(
+        default_value=Path(__file__).parent / "ui",
+        config=False,
+        help="Path to the UI files.",
+    )
+
+    central_url = Unicode(
+        None,
+        allow_none=True,
+        config=True,
+        help="The URL of the central server",
+    )
+
+    dev_mode = Bool(
+        default_value=False,
+        config=True,
+        help="Enable development mode.",
+    )
+
+    def initialize_settings(self):
+        """Update extension settings.
+
+        Update the self.settings trait to pass extra settings to the underlying
+        Tornado Web Application.
+
+        self.settings.update({'<trait>':...})
+        """
+        super().initialize_settings()
+
+        # startup messages
+        self.log.info("Starting Fileglancer server...")
+        self.log.info(f'Serving UI from: {self.ui_path}')
+        self.log.debug(
+            'FileGlancerServer config:\n' + '\n'.join(
+                f'  * {key} = {repr(value)}'
+                for key, value in self.config['Fileglancer'].items()
+            )
+        )
+
+    def initialize_handlers(self):
+        self.handlers.extend([
+            (r"/api/fileglancer/file-share-paths", FileSharePathsHandler),
+            (r"/api/fileglancer/files/(.*)", FileShareHandler),
+            (r"/api/fileglancer/files", FileShareHandler),
+            (r"/api/fileglancer/version", VersionHandler),
+            (r"/api/fileglancer/preference", PreferencesHandler),
+            (r"/api/fileglancer/ticket", TicketHandler),
+            (r"/fg/(.*)", StaticHandler, {
+                "path": str(self.ui_path),
+                "default_filename": "index.html",
+            }),
+        ])


### PR DESCRIPTION
Initialization of settings and handlers has been moved from the __init__
and handlers files into the app.py file to centralize configuration.

Adds the '/fg' url to the server, which will be the future home of the
SPA version of the fileglancer UI.

Adds a StaticHandler to serve up static content. This will be used by the
UI when it is compiled as a stand alone single page application.

Adds a VersionHandler to serve up the extension version number, which is
helpful when debugging during deployment.

@krokicki  @allison-truhlar 
