### PR TITLE
Fix breadcrumbs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      with:
+        node_version: "22.13.0"
 
     - name: Install dependencies
       run: python -m pip install -U "jupyterlab>=4.0.0,<5"

--- a/src/components/ui/FileListCrumbs.tsx
+++ b/src/components/ui/FileListCrumbs.tsx
@@ -41,10 +41,7 @@ export default function FileListCrumbs({
   return (
     <div className="w-full py-2 px-3">
       <Breadcrumb className="bg-transparent p-0">
-        <div
-          className="flex items-center gap-1 h-5 rounded-md hover:bg-primary-light/20 transition-colors cursor-pointer"
-          onClick={() => selectedZone && getFiles(selectedZone)}
-        >
+        <div className="flex items-center gap-1 h-5">
           <Squares2X2Icon className="h-5 w-5 text-primary-light" />
           <ChevronRightIcon className="h-5 w-5" />
         </div>

--- a/src/components/ui/FileListCrumbs.tsx
+++ b/src/components/ui/FileListCrumbs.tsx
@@ -22,24 +22,20 @@ export default function FileListCrumbs({
   selectedZone,
   getFiles
 }: FileListCrumbsProps): JSX.Element {
-  function getStringAfterSubstring(str: string, substring: string) {
-    const index = str.indexOf(substring);
-    if (index === -1) {
-      return ''; // Substring not found
+  function makeDirArray(path: string) {
+    if (currentPath.includes('?subpath=')) {
+      const firstSegment = currentPath.split('?subpath=')[0];
+      const subpathSegment = currentPath.split('?subpath=')[1];
+      const subpathArray = subpathSegment
+        .split('/')
+        .filter(item => item !== '');
+      return [firstSegment, ...subpathArray];
+    } else {
+      return [path];
     }
-    return str.substring(index + substring.length);
   }
 
-  const dirArray = currentPath
-    .split('/')
-    .filter(item => item !== '')
-    .map(segment => {
-      if (segment.includes('?subpath=')) {
-        return getStringAfterSubstring(segment, '?subpath=');
-      }
-      return segment;
-    });
-  console.log('FileListCrumbs dirArray', dirArray);
+  const dirArray = makeDirArray(currentPath);
   const dirDepth = dirArray.length;
 
   return (
@@ -61,11 +57,15 @@ export default function FileListCrumbs({
               <BreadcrumbLink
                 variant="text"
                 className="rounded-md hover:bg-primary-light/20 hover:!text-black focus:!text-black transition-colors cursor-pointer"
-                onClick={() =>
-                  getFiles(
-                    `${selectedZone}?subpath=${dirArray.slice(0, index + 1).join('/')}`
-                  )
-                }
+                onClick={() => {
+                  if (index === 0) {
+                    getFiles(`${selectedZone}`);
+                  } else {
+                    getFiles(
+                      `${selectedZone}?subpath=${dirArray.slice(1, index + 1).join('/')}`
+                    );
+                  }
+                }}
               >
                 <Typography
                   variant="small"


### PR DESCRIPTION
@krokicki @neomorphic 
A small fix I forgot to include in my file list UI improvement PR last week. The breadcrumbs now correctly include the file zone name as a breadcrumb link in addition to the file path segment links. Further, following Starfish, the squares icon no longer functions as the link for the file zone. 