### PR TITLE
Code fixes

### DIFF
--- a/src/components/ui/FileList.tsx
+++ b/src/components/ui/FileList.tsx
@@ -115,9 +115,9 @@ export default function FileList({
                   )
                 }
                 onDoubleClick={() => {
-                  if (file.is_dir) {
+                  if (file.is_dir && currentFileSharePath) {
                     fetchAndFormatFilesForDisplay(
-                      `${currentFileSharePath}?subpath=${file.path}`
+                      `${currentFileSharePath.name}?subpath=${file.path}`
                     );
                   }
                 }}
@@ -131,7 +131,7 @@ export default function FileList({
                       e.stopPropagation();
                       if (file.is_dir) {
                         fetchAndFormatFilesForDisplay(
-                          `${currentFileSharePath}?subpath=${file.path}`
+                          `${currentFileSharePath?.name}?subpath=${file.path}`
                         );
                         setPropertiesTarget({
                           targetFile: file,

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -143,14 +143,7 @@ export const PreferencesProvider = ({
     fetchPreferences();
   }, []);
 
-  const updatePreferences = async (
-    key: string,
-    keyValue:
-      | [string]
-      | ZonesAndFileSharePaths[]
-      | FileSharePathItem[]
-      | DirectoryFavorite[]
-  ) => {
+  async function updatePreferences<T>(key: string, keyValue: T) {
     try {
       await sendPutRequest(
         `${getAPIPathRoot()}api/fileglancer/preference?key=${key}`,
@@ -160,7 +153,7 @@ export const PreferencesProvider = ({
     } catch (error) {
       console.error(`Error updating ${key}:`, error);
     }
-  };
+  }
 
   function handlePathPreferenceSubmit(
     event: React.FormEvent<HTMLFormElement>,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,3 @@
-import type { ZonesAndFileSharePaths, FileSharePathItem } from './shared.types';
-import type { DirectoryFavorite } from './contexts/PreferencesContext';
-
 const formatFileSize = (sizeInBytes: number): string => {
   if (sizeInBytes < 1024) {
     return `${sizeInBytes} bytes`;
@@ -46,15 +43,11 @@ async function sendGetRequest(
   return response;
 }
 
-async function sendPutRequest(
+async function sendPutRequest<T>(
   url: string,
   xrsfCookie: string,
   body: {
-    value:
-      | [string]
-      | ZonesAndFileSharePaths[]
-      | FileSharePathItem[]
-      | DirectoryFavorite[];
+    value: T;
   }
 ): Promise<Response> {
   const response = await fetch(url, {


### PR DESCRIPTION
This PR addresses the issues flagged by @krokicki in my last PR. Some changes were informed by discussion with @neomorphic: 
1. [Comment](https://github.com/JaneliaSciComp/fileglancer/pull/39#discussion_r2065314761); commit 92858e5f3d7287843140e8aa74d80e09dbac579f: changes `sendPutRequest` and `updatePreferences` function to use generic type variables
2. [Comment](https://github.com/JaneliaSciComp/fileglancer/pull/39#discussion_r2065338406); commit e57a605e4f1d2d6f9058b715696f92403cd29315: changes the initial useEffect to load preferences into four separate useEffects, rather than using `Promise.allSettled`. Also refactors the four useEffects to all use a common function, `fetchPreferences`, which makes use of a generic type variable.
3. [Comment](https://github.com/JaneliaSciComp/fileglancer/pull/39#discussion_r2065326065); commit 8a241521db3def7979d895e32a49ca72baefe9d7: removes the `isZonesAndFileSharePaths` method. This type checking is no longer needed to satisfy the linter because I am now using the `type` variable passed to `handleFavoriteChange` to call four separate methods, based on type, and each method defines the type of the `item`.
4. [Comment](https://github.com/JaneliaSciComp/fileglancer/pull/39#discussion_r2065328498), commit 8a241521db3def7979d895e32a49ca72baefe9d7: removes incorrect usage of spread operators with splice