### PR TITLE
Fix sidebar scroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,5 +134,8 @@ dmypy.json
 pixi.lock
 package-lock.json
 
+# Zarr files
+*.zarr
+
 # Converted Tailwind CSS
 style/tailwind_converted.css

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -106,7 +106,7 @@ export default function Preferences() {
               <Alert className="flex items-center gap-6 mt-6 bg-secondary-light/70 border-none">
                 <Alert.Content>Preference updated!</Alert.Content>
                 <XMarkIcon
-                  className="h-5 w-5 cursor-pointer"
+                  className="icon-default cursor-pointer"
                   onClick={() => setShowPathPrefAlert(false)}
                 />
               </Alert>

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -36,7 +36,7 @@ export default function Preferences() {
           <Card.Body className="flex flex-col gap-4 pb-4">
             <div className="flex items-center gap-2">
               <input
-                className="w-4 h-4 checked:accent-secondary-light"
+                className="icon-small checked:accent-secondary-light"
                 type="radio"
                 id="linux_path"
                 value="linux_path"
@@ -58,7 +58,7 @@ export default function Preferences() {
 
             <div className="flex items-center gap-2">
               <input
-                className="w-4 h-4 checked:accent-secondary-light"
+                className="icon-small checked:accent-secondary-light"
                 type="radio"
                 id="windows_path"
                 value="windows_path"
@@ -79,7 +79,7 @@ export default function Preferences() {
 
             <div className="flex items-center gap-2">
               <input
-                className="w-4 h-4 checked:accent-secondary-light"
+                className="icon-small checked:accent-secondary-light"
                 type="radio"
                 id="mac_path"
                 value="mac_path"

--- a/src/components/ui/FileBrowser/Crumbs.tsx
+++ b/src/components/ui/FileBrowser/Crumbs.tsx
@@ -23,8 +23,8 @@ export default function Crumbs(): ReactNode {
     <div className="w-full py-2 px-3">
       <Breadcrumb className="bg-transparent p-0">
         <div className="flex items-center gap-1 h-5">
-          <Squares2X2Icon className="h-5 w-5 text-primary-light" />
-          <ChevronRightIcon className="h-5 w-5" />
+          <Squares2X2Icon className="icon-default text-primary-light" />
+          <ChevronRightIcon className="icon-default" />
         </div>
 
         {/* Path segments */}
@@ -57,7 +57,7 @@ export default function Crumbs(): ReactNode {
                 </BreadcrumbLink>
                 {/* Add separator since is not the last segment */}
                 <BreadcrumbSeparator>
-                  <SlashIcon className="h-5 w-5" />
+                  <SlashIcon className="icon-default" />
                 </BreadcrumbSeparator>
               </React.Fragment>
             );

--- a/src/components/ui/FileBrowser/Dialogs/ChangePermissions.tsx
+++ b/src/components/ui/FileBrowser/Dialogs/ChangePermissions.tsx
@@ -67,7 +67,7 @@ export default function ChangePermissions({
               setShowAlert(false);
             }}
           >
-            <XMarkIcon className="h-5 w-5" />
+            <XMarkIcon className="icon-default" />
           </IconButton>
           {targetItem ? (
             <form
@@ -181,7 +181,7 @@ export default function ChangePermissions({
             >
               <Alert.Content>{alertContent}</Alert.Content>
               <XMarkIcon
-                className="h-5 w-5 cursor-pointer"
+                className="icon-default cursor-pointer"
                 onClick={() => {
                   setShowAlert(false);
                 }}

--- a/src/components/ui/FileBrowser/Dialogs/Delete.tsx
+++ b/src/components/ui/FileBrowser/Dialogs/Delete.tsx
@@ -40,7 +40,7 @@ export default function DeleteDialog({
               setShowAlert(false);
             }}
           >
-            <XMarkIcon className="h-5 w-5" />
+            <XMarkIcon className="icon-default" />
           </IconButton>
           <Typography className="my-8 text-large">
             Are you sure you want to delete{' '}
@@ -63,7 +63,7 @@ export default function DeleteDialog({
             >
               <Alert.Content>{alertContent}</Alert.Content>
               <XMarkIcon
-                className="h-5 w-5 cursor-pointer"
+                className="icon-default cursor-pointer"
                 onClick={() => {
                   setShowAlert(false);
                   setShowDeleteDialog(false);

--- a/src/components/ui/FileBrowser/Dialogs/NewFolderDialog.tsx
+++ b/src/components/ui/FileBrowser/Dialogs/NewFolderDialog.tsx
@@ -46,7 +46,7 @@ export default function NewFolderDialog({
               setShowAlert(false);
             }}
           >
-            <XMarkIcon className="h-5 w-5" />
+            <XMarkIcon className="icon-default" />
           </IconButton>
           <form
             onSubmit={event => {
@@ -83,7 +83,7 @@ export default function NewFolderDialog({
               >
                 <Alert.Content>{alertContent}</Alert.Content>
                 <XMarkIcon
-                  className="h-5 w-5 cursor-pointer"
+                  className="icon-default cursor-pointer"
                   onClick={() => setShowAlert(false)}
                 />
               </Alert>

--- a/src/components/ui/FileBrowser/Dialogs/RenameDialog.tsx
+++ b/src/components/ui/FileBrowser/Dialogs/RenameDialog.tsx
@@ -46,7 +46,7 @@ export default function RenameDialog({
               setShowAlert(false);
             }}
           >
-            <XMarkIcon className="h-5 w-5" />
+            <XMarkIcon className="icon-default" />
           </IconButton>
           <form
             onSubmit={event => {
@@ -83,7 +83,7 @@ export default function RenameDialog({
               >
                 <Alert.Content>{alertContent}</Alert.Content>
                 <XMarkIcon
-                  className="h-5 w-5 cursor-pointer"
+                  className="icon-default cursor-pointer"
                   onClick={() => setShowAlert(false)}
                 />
               </Alert>

--- a/src/components/ui/FileBrowser/FileRow.tsx
+++ b/src/components/ui/FileBrowser/FileRow.tsx
@@ -100,9 +100,9 @@ export default function FileRow({
       {/* Type column */}
       <div className="flex items-center w-full gap-3 py-1 text-grey-700 overflow-x-auto">
         {file.is_dir ? (
-          <FolderIcon className="text-foreground h-5 w-5" />
+          <FolderIcon className="text-foreground icon-default" />
         ) : (
-          <DocumentIcon className="text-foreground h-5 w-5" />
+          <DocumentIcon className="text-foreground icon-default" />
         )}
         <Typography variant="small" className="font-medium">
           {file.is_dir ? 'Folder' : 'File'}
@@ -137,7 +137,7 @@ export default function FileRow({
         }}
       >
         <IconButton variant="ghost">
-          <EllipsisHorizontalCircleIcon className="h-5 w-5 text-foreground" />
+          <EllipsisHorizontalCircleIcon className="icon-default text-foreground" />
         </IconButton>
       </div>
     </div>

--- a/src/components/ui/FileBrowser/Toolbar.tsx
+++ b/src/components/ui/FileBrowser/Toolbar.tsx
@@ -36,9 +36,9 @@ export default function Toolbar({
             onClick={() => setHideDotFiles((prev: boolean) => !prev)}
           >
             {hideDotFiles ? (
-              <EyeSlashIcon className="h-5 w-5" />
+              <EyeSlashIcon className="icon-default" />
             ) : (
-              <EyeIcon className="h-5 w-5" />
+              <EyeIcon className="icon-default" />
             )}
             <Tooltip.Content className="px-2.5 py-1.5 text-primary-foreground">
               <Typography type="small" className="opacity-90">
@@ -58,7 +58,7 @@ export default function Toolbar({
               setShowNewFolderDialog(true);
             }}
           >
-            <FolderPlusIcon className="h-5 w-5" />
+            <FolderPlusIcon className="icon-default" />
           </Tooltip.Trigger>
           <Tooltip.Content className="px-2.5 py-1.5 text-primary-foreground">
             <Typography type="small" className="opacity-90">
@@ -75,7 +75,7 @@ export default function Toolbar({
             variant="outline"
             onClick={() => setShowPropertiesDrawer((prev: boolean) => !prev)}
           >
-            <ListBulletIcon className="h-5 w-5" />
+            <ListBulletIcon className="icon-default" />
             <Tooltip.Content className="px-2.5 py-1.5 text-primary-foreground">
               <Typography type="small" className="opacity-90">
                 View file properties

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -53,7 +53,7 @@ function NavList() {
           className="flex items-center dark:!text-foreground hover:bg-hover-gradient hover:dark:bg-hover-gradient-dark focus:bg-hover-gradient focus:dark:bg-hover-gradient-dark hover:!text-foreground focus:!text-foreground"
         >
           <List.ItemStart className="flex items-center mr-1.5">
-            <Icon className="h-5 w-5" />
+            <Icon className="icon-default" />
           </List.ItemStart>
           <Typography type="small">{title}</Typography>
         </List.Item>

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -53,9 +53,11 @@ function NavList() {
           className="flex items-center dark:!text-foreground hover:bg-hover-gradient hover:dark:bg-hover-gradient-dark focus:bg-hover-gradient focus:dark:bg-hover-gradient-dark hover:!text-foreground focus:!text-foreground"
         >
           <List.ItemStart className="flex items-center mr-1.5">
-            <Icon className="icon-default" />
+            <Icon className="icon-default x-short:icon-xsmall short-icon-xsmall" />
           </List.ItemStart>
-          <Typography type="small">{title}</Typography>
+          <Typography type="small" className="x-short:text-xs">
+            {title}
+          </Typography>
         </List.Item>
       ))}
     </>
@@ -71,9 +73,9 @@ function ProfileMenu() {
         size="sm"
         variant="ghost"
         color="secondary"
-        className="flex items-center justify-center p-1 rounded-full h-8 w-8 text-foreground dark:text-foreground hover:!text-foreground focus:!text-foreground hover:bg-hover-gradient focus:bg-hover-gradient focus:dark:bg-hover-gradient-dark"
+        className="flex items-center justify-center p-1 rounded-full h-8 w-8 x-short:h-6 x-short:w-6 text-foreground dark:text-foreground hover:!text-foreground focus:!text-foreground hover:bg-hover-gradient focus:bg-hover-gradient focus:dark:bg-hover-gradient-dark"
       >
-        <UserCircleIcon className="h-6 w-6" />
+        <UserCircleIcon className="icon-large x-short:icon-default" />
       </Menu.Trigger>
       <Menu.Content>
         <Menu.Item
@@ -81,14 +83,14 @@ function ProfileMenu() {
           to="/profile"
           className="dark:text-foreground hover:bg-hover-gradient hover:dark:bg-hover-gradient-dark focus:bg-hover-gradient focus:dark:bg-hover-gradient-dark hover:!text-foreground focus:!text-foreground"
         >
-          <UserCircleIcon className="mr-2 h-[18px] w-[18px]" /> Profile
+          <UserCircleIcon className="mr-2 icon-default" /> Profile
         </Menu.Item>
         <Menu.Item
           as={Link}
           to="/preferences"
           className="dark:text-foreground hover:bg-hover-gradient hover:dark:bg-hover-gradient-dark focus:bg-hover-gradient focus:dark:bg-hover-gradient-dark hover:!text-foreground focus:!text-foreground"
         >
-          <AdjustmentsHorizontalIcon className="mr-2 h-[18px] w-[18px]" />{' '}
+          <AdjustmentsHorizontalIcon className="mr-2 icon-default" />{' '}
           Preferences
         </Menu.Item>
         <hr className="!my-1 -mx-1 border-surface" />
@@ -124,13 +126,13 @@ export default function FileglancerNavbar() {
   }, []);
 
   return (
-    <Navbar className="mx-auto w-full rounded-none bg-background p-4 dark:shadow-surface">
+    <Navbar className="mx-auto w-full rounded-none bg-background p-4 short:py-3 x-short:py-1 dark:shadow-surface">
       <div className="flex items-center justify-between ">
         {/* Logo */}
         <Link to="/">
           <div className="bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent flex items-center">
             <svg
-              className="w-6 h-6 text-primary"
+              className="icon-large x-short:icon-small text-primary"
               viewBox="0 0 18 24"
               version="1.1"
               xmlns="http://www.w3.org/2000/svg"
@@ -158,7 +160,7 @@ export default function FileglancerNavbar() {
             </svg>
             <Typography
               type="h6"
-              className="ml-2 mr-2 block font-semibold pointer-events-none"
+              className="ml-2 mr-2 block font-semibold pointer-events-none x-short:text-base"
             >
               Janelia Fileglancer
             </Typography>
@@ -182,9 +184,9 @@ export default function FileglancerNavbar() {
             onClick={toggleTheme}
           >
             {isLightTheme ? (
-              <SunIcon className="h-6 w-6" />
+              <SunIcon className="icon-large x-short:icon-default" />
             ) : (
-              <MoonIcon className="h-6 w-6" />
+              <MoonIcon className="icon-large x-short:icon-default" />
             )}
           </IconButton>
           <ProfileMenu />
@@ -197,9 +199,9 @@ export default function FileglancerNavbar() {
             className="mr-2 grid ml-auto text-foreground dark:text-foreground hover:!text-foreground focus:!text-foreground lg:hidden hover:bg-hover-gradient hover:dark:bg-hover-gradient-dark focus:bg-hover-gradient focus:dark:bg-hover-gradient-dark"
           >
             {openNav ? (
-              <XMarkIcon className="h-6 w-6" />
+              <XMarkIcon className="icon-large x-short:icon-default" />
             ) : (
-              <MenuIcon className="h-6 w-6" />
+              <MenuIcon className="icon-large x-short:icon-default" />
             )}
           </IconButton>
         </div>

--- a/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
+++ b/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
@@ -8,9 +8,9 @@ export default function PermissionsTable({ file }: { file: File | null }) {
 
   const PermissionIcon = ({ hasPermission }: { hasPermission: boolean }) =>
     hasPermission ? (
-      <CheckIcon className="h-5 w-5" />
+      <CheckIcon className="icon-default" />
     ) : (
-      <MinusIcon className="h-5 w-5" />
+      <MinusIcon className="icon-default" />
     );
 
   return (

--- a/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
+++ b/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
@@ -121,7 +121,7 @@ export default function PropertiesDrawer({
                     }
                   }}
                 >
-                  <Square2StackIcon className="h-4 w-4" />
+                  <Square2StackIcon className="icon-small" />
                 </IconButton>
               </div>
               {copiedText.value === fullPath &&

--- a/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
+++ b/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
@@ -62,16 +62,16 @@ export default function PropertiesDrawer({
               setShowPropertiesDrawer((prev: boolean) => !prev);
             }}
           >
-            <XMarkIcon className="h-5 w-5" />
+            <XMarkIcon className="icon-default" />
           </IconButton>
         </div>
 
         {propertiesTarget ? (
           <div className="flex items-center gap-2 mt-3 mb-4 max-h-min">
             {propertiesTarget.is_dir ? (
-              <FolderIcon className="h-5 w-5" />
+              <FolderIcon className="icon-default" />
             ) : (
-              <DocumentIcon className="h-5 w-5" />
+              <DocumentIcon className="icon-default" />
             )}{' '}
             <Typography className="font-semibold">
               {propertiesTarget?.name}
@@ -130,7 +130,7 @@ export default function PropertiesDrawer({
                 <Alert className="flex items-center justify-between bg-secondary-light/70 border-none">
                   <Alert.Content>Path copied to clipboard!</Alert.Content>
                   <XMarkIcon
-                    className="h-5 w-5 cursor-pointer"
+                    className="icon-default cursor-pointer"
                     onClick={dismissCopyAlert}
                   />
                 </Alert>

--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -78,7 +78,7 @@ export default function FavoritesBrowser({
           className="cursor-pointer rounded-none py-3 bg-surface/50 hover:!bg-surface-light focus:!bg-surface-light"
         >
           <List.ItemStart>
-            <StarFilled className="h-5 w-5 text-surface-foreground" />
+            <StarFilled className="icon-default text-surface-foreground" />
           </List.ItemStart>
           <Typography className="font-semibold text-surface-foreground">
             Favorites

--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -71,21 +71,21 @@ export default function FavoritesBrowser({
       : directoryFavorites;
 
   return (
-    <div className="w-[calc(100%-1.5rem)] min-h-fit flex flex-col overflow-hidden h-full mt-3 mx-3 pb-1">
+    <div className="w-[calc(100%-1.5rem)] min-h-fit flex flex-col overflow-hidden h-full mt-3 x-short:mt-1 mx-3 pb-1">
       <List className="bg-background">
         <List.Item
           onClick={() => toggleOpenFavorites('all')}
-          className="cursor-pointer rounded-none py-3 bg-surface/50 hover:!bg-surface-light focus:!bg-surface-light"
+          className="cursor-pointer rounded-none py-3 x-short:py-1 bg-surface/50 hover:!bg-surface-light focus:!bg-surface-light"
         >
           <List.ItemStart>
-            <StarFilled className="icon-default text-surface-foreground" />
+            <StarFilled className="icon-default x-short:icon-xsmall text-surface-foreground" />
           </List.ItemStart>
-          <Typography className="font-semibold text-surface-foreground">
+          <Typography className="font-semibold text-surface-foreground x-short:text-xs short:text-xs">
             Favorites
           </Typography>
           <List.ItemEnd className="pr-2">
             <ChevronRightIcon
-              className={`h-4 w-4 ${openFavorites['all'] ? 'rotate-90' : ''}`}
+              className={`icon-small x-short:icon-xsmall ${openFavorites['all'] ? 'rotate-90' : ''}`}
             />
           </List.ItemEnd>
         </List.Item>
@@ -145,15 +145,15 @@ export default function FavoritesBrowser({
                       `${directoryItem.fileSharePath.name}?subpath=${directoryItem.path}`
                     );
                   }}
-                  className={`flex gap-2 items-center justify-between rounded-none cursor-pointer text-foreground hover:bg-primary-light/30 focus:bg-primary-light/30 ${directoryItem.fileSharePath === currentFileSharePath && directoryItem.name === currentDir ? '!bg-primary-light/30' : '!bg-background'}`}
+                  className={`x-short:py-0 flex gap-2 items-center justify-between rounded-none cursor-pointer text-foreground hover:bg-primary-light/30 focus:bg-primary-light/30 ${directoryItem.fileSharePath === currentFileSharePath && directoryItem.name === currentDir ? '!bg-primary-light/30' : '!bg-background'}`}
                 >
                   <Link
                     to="/files"
-                    className="flex flex-col gap-2 !text-foreground hover:!text-black focus:!text-black hover:dark:!text-white focus:dark:!text-white"
+                    className="flex flex-col gap-2 x-short:gap-1 !text-foreground hover:!text-black focus:!text-black hover:dark:!text-white focus:dark:!text-white"
                   >
                     <div className="flex gap-1 items-center">
-                      <FolderIcon className="h-4 w-4" />
-                      <Typography className="text-sm font-medium leading-4">
+                      <FolderIcon className="icon-small x-short:icon-xsmall" />
+                      <Typography className="text-sm font-medium leading-4 x-short:text-xs">
                         {directoryItem.name}
                       </Typography>
                     </div>
@@ -176,9 +176,9 @@ export default function FavoritesBrowser({
                       }}
                     >
                       {isFavoriteDir ? (
-                        <StarFilled className="h-4 w-4 mb-[2px]" />
+                        <StarFilled className="icon-small x-short:icon-xsmall mb-[2px]" />
                       ) : (
-                        <StarOutline className="h-4 w-4 mb-[2px]" />
+                        <StarOutline className="icon-small x-short:icon-xsmall mb-[2px]" />
                       )}
                     </IconButton>
                   </div>

--- a/src/components/ui/Sidebar/FileSharePath.tsx
+++ b/src/components/ui/Sidebar/FileSharePath.tsx
@@ -42,15 +42,15 @@ export default function FileSharePath({
         setCurrentFileSharePath(pathItem);
         fetchAndFormatFilesForDisplay(pathItem.name);
       }}
-      className={`flex gap-2 items-center justify-between rounded-none cursor-pointer text-foreground hover:!bg-primary-light/30 focus:!bg-primary-light/30 ${isCurrentPath ? '!bg-primary-light/30' : pathIndex % 2 !== 0 ? '!bg-background' : '!bg-surface/50'}`}
+      className={`x-short:py-0 flex gap-2 items-center justify-between rounded-none cursor-pointer text-foreground hover:!bg-primary-light/30 focus:!bg-primary-light/30 ${isCurrentPath ? '!bg-primary-light/30' : pathIndex % 2 !== 0 ? '!bg-background' : '!bg-surface/50'}`}
     >
       <Link
         to="/files"
         className="grow flex flex-col gap-2 !text-foreground hover:!text-black focus:!text-black dark:hover:!text-white dark:focus:!text-white"
       >
         <div className="flex gap-1 items-center">
-          <RectangleStackIcon className="h-4 w-4" />
-          <Typography className="text-sm font-medium leading-4">
+          <RectangleStackIcon className="icon-small x-short:icon-xsmall" />
+          <Typography className="text-sm font-medium leading-4 x-short:text-xs">
             {pathItem.storage}
           </Typography>
         </div>
@@ -83,9 +83,9 @@ export default function FileSharePath({
           }}
         >
           {isFavoritePath ? (
-            <StarFilled className="h-4 w-4 mb-[2px]" />
+            <StarFilled className="icon-small x-short:icon-xsmall mb-[2px]" />
           ) : (
-            <StarOutline className="h-4 w-4 mb-[2px]" />
+            <StarOutline className="icon-small x-short:icon-xsmall mb-[2px]" />
           )}
         </IconButton>
       </div>

--- a/src/components/ui/Sidebar/Sidebar.tsx
+++ b/src/components/ui/Sidebar/Sidebar.tsx
@@ -19,9 +19,9 @@ export default function Sidebar() {
   } = useSearchFilter();
   return (
     <Card className="max-w-[280px] max-h-full overflow-hidden rounded-none bg-surface shadow-lg flex flex-col">
-      <div className="w-[calc(100%-1.5rem)] mx-3 my-3">
+      <div className="w-[calc(100%-1.5rem)] mx-3 my-3 x-short:my-1">
         <Input
-          className="bg-background text-foreground"
+          className="bg-background text-foreground x-short:text-xs"
           type="search"
           placeholder="Type to filter zones"
           value={searchQuery}
@@ -34,7 +34,7 @@ export default function Sidebar() {
           </Input.Icon>
         </Input>
       </div>
-      <div className="flex flex-col overflow-hidden flex-grow mb-3 gap-3">
+      <div className="flex flex-col overflow-hidden flex-grow mb-3 gap-3 x-short:gap-1">
         <div
           className={`flex-shrink ${openZones['all'] ? 'max-h-[50%]' : 'max-h-[100%]'}`}
         >

--- a/src/components/ui/Sidebar/Zone.tsx
+++ b/src/components/ui/Sidebar/Zone.tsx
@@ -40,13 +40,15 @@ export default function Zone({
     <React.Fragment>
       <List.Item
         onClick={() => toggleOpenZones(zoneName)}
-        className="cursor-pointer rounded-none py-1 flex-shrink-0 hover:!bg-primary-light/30 focus:!bg-primary-light/30  !bg-background"
+        className="cursor-pointer rounded-none py-1 x-short:py-0 short:py-0 flex-shrink-0 hover:!bg-primary-light/30 focus:!bg-primary-light/30 !bg-background"
       >
         <List.ItemStart>
-          <Squares2X2Icon className="h-4 w-4" />
+          <Squares2X2Icon className="icon-small x-short:icon-xsmall" />
         </List.ItemStart>
         <div className="flex-1 min-w-0 flex items-center gap-1">
-          <Typography className="text-sm">{zoneName}</Typography>
+          <Typography className="x-short:text-xs short:text-xs text-sm">
+            {zoneName}
+          </Typography>
           <div className="flex items-center" onClick={e => e.stopPropagation()}>
             <IconButton
               variant="ghost"
@@ -56,16 +58,16 @@ export default function Zone({
               }
             >
               {isFavoriteZone ? (
-                <StarFilled className="h-4 w-4 mb-[2px]" />
+                <StarFilled className="icon-small x-short:icon-xsmall mb-[2px]" />
               ) : (
-                <StarOutline className="h-4 w-4 mb-[2px]" />
+                <StarOutline className="icon-small x-short:icon-xsmall mb-[2px]" />
               )}
             </IconButton>
           </div>
         </div>
         <List.ItemEnd>
           <ChevronRightIcon
-            className={`h-4 w-4 ${isOpen ? 'rotate-90' : ''}`}
+            className={`icon-small x-short:icon-xsmall ${isOpen ? 'rotate-90' : ''}`}
           />
         </List.ItemEnd>
       </List.Item>

--- a/src/components/ui/Sidebar/ZonesBrowser.tsx
+++ b/src/components/ui/Sidebar/ZonesBrowser.tsx
@@ -33,7 +33,7 @@ export default function ZonesBrowser({
           className="cursor-pointer rounded-none py-3 bg-surface/50 hover:!bg-surface-light focus:!bg-surface-light"
         >
           <List.ItemStart>
-            <Squares2X2Icon className="h-5 w-5 text-surface-foreground" />
+            <Squares2X2Icon className="icon-default text-surface-foreground" />
           </List.ItemStart>
           <Typography className="font-semibold text-surface-foreground">
             Zones

--- a/src/components/ui/Sidebar/ZonesBrowser.tsx
+++ b/src/components/ui/Sidebar/ZonesBrowser.tsx
@@ -26,21 +26,21 @@ export default function ZonesBrowser({
       : zonesAndFileSharePaths;
 
   return (
-    <div className="flex flex-col h-full overflow-hidden w-[calc(100%-1.5rem)] my-3 mx-3 bg-surface/50">
+    <div className="flex flex-col h-full overflow-hidden w-[calc(100%-1.5rem)] my-3 x-short:my-1 mx-3 bg-surface/50">
       <List className="bg-background py-0">
         <List.Item
           onClick={() => toggleOpenZones('all')}
-          className="cursor-pointer rounded-none py-3 bg-surface/50 hover:!bg-surface-light focus:!bg-surface-light"
+          className="cursor-pointer rounded-none py-3 x-short:py-1 bg-surface/50 hover:!bg-surface-light focus:!bg-surface-light"
         >
           <List.ItemStart>
-            <Squares2X2Icon className="icon-default text-surface-foreground" />
+            <Squares2X2Icon className="icon-default x-short:icon-xsmall text-surface-foreground" />
           </List.ItemStart>
-          <Typography className="font-semibold text-surface-foreground">
+          <Typography className="x-short:text-xs short:text-xs font-semibold text-surface-foreground">
             Zones
           </Typography>
           <List.ItemEnd className="pr-2">
             <ChevronRightIcon
-              className={`h-4 w-4 ${openZones['all'] ? 'rotate-90' : ''}`}
+              className={`icon-small x-short:icon-xsmall ${openZones['all'] ? 'rotate-90' : ''}`}
             />
           </List.ItemEnd>
         </List.Item>

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@
     @apply w-5 h-5;
   }
   .icon-small {
-    @apply icon-small;
+    @apply w-4 h-4;
   }
   .icon-xsmall {
     @apply w-3 h-3;

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,21 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .icon-large {
+    @apply w-6 h-6;
+  }
+  .icon-default {
+    @apply w-5 h-5;
+  }
+  .icon-small {
+    @apply icon-small;
+  }
+  .icon-xsmall {
+    @apply w-3 h-3;
+  }
+}
+
 /* Override built-in Jupyter Lab extension CSS */
 .jp-ThemedContainer a:hover {
   color: rgb(var(--color-primary-foreground) / var(--tw-text-opacity, 1));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,9 @@ const config = {
           'linear-gradient(120deg, rgb(var(--color-primary-light) / 0.2) , rgb(var(--color-secondary-light) / 0.2))',
         'hover-gradient-dark':
           'linear-gradient(120deg, rgb(var(--color-primary-dark) / 0.4), rgb(var(--color-secondary-dark) / 0.4))'
+      },
+      screens: {
+        'x-short': { raw: '(min-height: 0px) and (max-height: 420px)' }
       }
     }
   },


### PR DESCRIPTION
In this PR, I add a custom media query for short screens and then apply styles to get extra vertical space in the sidebar. 

It saves enough space to make the scroll in the favorites and zone browser still usable at the height at which the Starfish zone browser is no longer usable (around 290px).

Fileglancer at 284px screen height:
<img width="1351" alt="fileglancer zone browser at 284px" src="https://github.com/user-attachments/assets/58857ce2-3175-42f8-b382-20740a14af6e" />

Starfish at 284px screen height:
<img width="1243" alt="starfish zone browser at 284px" src="https://github.com/user-attachments/assets/47f4c170-73da-4c50-9bec-b631ad4a8260" />
