### PR TITLE
chore: Adds src path alias to vite config.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,10 @@ import { BrowserRouter, Route, Routes } from 'react-router';
 import { CookiesProvider } from 'react-cookie';
 import { MainLayout } from './layouts/MainLayout';
 import { FilesLayout } from './layouts/FilesLayout';
-import Home from './components/Home';
-import Files from './components/Files';
-import Help from './components/Help';
-import Jobs from './components/Jobs';
+import Home from '@/components/Home';
+import Files from '@/components/Files';
+import Help from '@/components/Help';
+import Jobs from '@/components/Jobs';
 
 function Profile() {
   return (

--- a/src/components/Files.tsx
+++ b/src/components/Files.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import useContextMenu from '../hooks/useContextMenu';
-import useShowPropertiesDrawer from '../hooks/useShowPropertiesDrawer';
-import usePropertiesTarget from '../hooks/usePropertiesTarget';
-import useHideDotFiles from '../hooks/useHideDotFiles';
-import useSelectedFiles from '../hooks/useSelectedFiles';
-import { useFileBrowserContext } from '../contexts/FileBrowserContext';
+import useContextMenu from '@/hooks/useContextMenu';
+import useShowPropertiesDrawer from '@/hooks/useShowPropertiesDrawer';
+import usePropertiesTarget from '@/hooks/usePropertiesTarget';
+import useHideDotFiles from '@/hooks/useHideDotFiles';
+import useSelectedFiles from '@/hooks/useSelectedFiles';
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 
 import FileList from './ui/FileBrowser/FileList';
 import PropertiesDrawer from './ui/PropertiesDrawer/PropertiesDrawer';

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Alert, Button, Card, Typography } from '@material-tailwind/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import { usePreferencesContext } from '../contexts/PreferencesContext';
-import useLocalPathPreference from '../hooks/useLocalPathPreference';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
+import useLocalPathPreference from '@/hooks/useLocalPathPreference';
 
 export default function Preferences() {
   const {

--- a/src/components/ui/FileBrowser/ContextMenu.tsx
+++ b/src/components/ui/FileBrowser/ContextMenu.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Typography } from '@material-tailwind/react';
 
-import type { File } from '../../../shared.types';
-import { useZoneBrowserContext } from '../../../contexts/ZoneBrowserContext';
-import { usePreferencesContext } from '../../../contexts/PreferencesContext';
+import type { File } from '@/shared.types';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
 
 type ContextMenuProps = {
   x: number;

--- a/src/components/ui/FileBrowser/Crumbs.tsx
+++ b/src/components/ui/FileBrowser/Crumbs.tsx
@@ -11,8 +11,8 @@ import {
   Squares2X2Icon
 } from '@heroicons/react/24/outline';
 
-import { useFileBrowserContext } from '../../../contexts/FileBrowserContext';
-import { useZoneBrowserContext } from '../../../contexts/ZoneBrowserContext';
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
 
 export default function Crumbs(): ReactNode {
   const { dirArray, fetchAndFormatFilesForDisplay } = useFileBrowserContext();

--- a/src/components/ui/FileBrowser/Dialogs/ChangePermissions.tsx
+++ b/src/components/ui/FileBrowser/Dialogs/ChangePermissions.tsx
@@ -7,8 +7,8 @@ import {
   Typography
 } from '@material-tailwind/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import usePermissionsDialog from '../../../../hooks/usePermissionsDialog';
-import type { File } from '../../../../shared.types';
+import usePermissionsDialog from '@/hooks/usePermissionsDialog';
+import type { File } from '@/shared.types';
 
 type ChangePermissionsProps = {
   targetItem: File | null;

--- a/src/components/ui/FileBrowser/Dialogs/Delete.tsx
+++ b/src/components/ui/FileBrowser/Dialogs/Delete.tsx
@@ -7,9 +7,9 @@ import {
   Typography
 } from '@material-tailwind/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import useDeleteDialog from '../../../../hooks/useDeleteDialog';
-import type { File } from '../../../../shared.types';
-import { useZoneBrowserContext } from '../../../../contexts/ZoneBrowserContext';
+import useDeleteDialog from '@/hooks/useDeleteDialog';
+import type { File } from '@/shared.types';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
 
 type DeleteDialogProps = {
   targetItem: File;

--- a/src/components/ui/FileBrowser/Dialogs/NewFolderDialog.tsx
+++ b/src/components/ui/FileBrowser/Dialogs/NewFolderDialog.tsx
@@ -7,8 +7,8 @@ import {
   Typography
 } from '@material-tailwind/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import { useFileBrowserContext } from '../../../../contexts/FileBrowserContext';
-import useNewFolderDialog from '../../../../hooks/useNewFolderDialog';
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
+import useNewFolderDialog from '@/hooks/useNewFolderDialog';
 
 type ItemNamingDialogProps = {
   showNewFolderDialog: boolean;

--- a/src/components/ui/FileBrowser/Dialogs/RenameDialog.tsx
+++ b/src/components/ui/FileBrowser/Dialogs/RenameDialog.tsx
@@ -7,8 +7,8 @@ import {
   Typography
 } from '@material-tailwind/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import type { File } from '../../../../shared.types';
-import useRenameDialog from '../../../../hooks/useRenameDialog';
+import type { File } from '@/shared.types';
+import useRenameDialog from '@/hooks/useRenameDialog';
 
 type ItemNamingDialogProps = {
   propertiesTarget: File | null;

--- a/src/components/ui/FileBrowser/FileList.tsx
+++ b/src/components/ui/FileBrowser/FileList.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { Typography } from '@material-tailwind/react';
 
-import * as zarr from 'zarrita';
-import * as omezarr from 'ome-zarr.js';
-
-import type { File } from '../../../shared.types';
+import type { File } from '@/shared.types';
 import FileListCrumbs from './Crumbs';
 import FileRow from './FileRow';
-import { useZoneBrowserContext } from '../../../contexts/ZoneBrowserContext';
-import { useFileBrowserContext } from '../../../contexts/FileBrowserContext';
-import { getOmeZarrMetadata } from '../../../omezarr-helper';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
+import { getOmeZarrMetadata } from '@/omezarr-helper';
 
 type FileListProps = {
   files: File[];

--- a/src/components/ui/FileBrowser/FileRow.tsx
+++ b/src/components/ui/FileBrowser/FileRow.tsx
@@ -7,11 +7,11 @@ import {
   FolderIcon
 } from '@heroicons/react/24/outline';
 
-import type { File } from '../../../shared.types';
-import { useFileBrowserContext } from '../../../contexts/FileBrowserContext';
-import { useZoneBrowserContext } from '../../../contexts/ZoneBrowserContext';
-import useHandleLeftClick from '../../../hooks/useHandleLeftClick';
-import { formatDate, formatFileSize } from '../../../utils';
+import type { File } from '@/shared.types';
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
+import useHandleLeftClick from '@/hooks/useHandleLeftClick';
+import { formatDate, formatFileSize } from '@/utils';
 
 type FileRowProps = {
   file: File;

--- a/src/components/ui/FileList.tsx
+++ b/src/components/ui/FileList.tsx
@@ -4,8 +4,8 @@ import { EmptyPage, Folder } from 'iconoir-react';
 
 import FileListCrumbs from './FileListCrumbs';
 
-import { File } from '../../hooks/useFileBrowser';
-import { formatDate, formatFileSize } from '../../utils';
+import { File } from '@/hooks/useFileBrowser';
+import { formatDate, formatFileSize } from '@/utils';
 
 type FileListProps = {
   displayFiles: File[];

--- a/src/components/ui/FileOverviewTable.tsx
+++ b/src/components/ui/FileOverviewTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { File } from '../../hooks/useFileBrowser';
-import { formatDate, formatFileSize } from '../../utils';
+import { File } from '@/hooks/useFileBrowser';
+import { formatDate, formatFileSize } from '@/utils';
 
 type FileOverviewTableProps = {
   file: File | null;

--- a/src/components/ui/FilePermissionTable.tsx
+++ b/src/components/ui/FilePermissionTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Check, Minus } from 'iconoir-react';
-import { File } from '../../hooks/useFileBrowser';
+import { File } from '@/hooks/useFileBrowser';
 
 type FileTableProps = {
   file: File | null;

--- a/src/components/ui/FilePropertiesDrawer.tsx
+++ b/src/components/ui/FilePropertiesDrawer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Button, IconButton, Typography, Tabs } from '@material-tailwind/react';
 import { EmptyPage, Folder, Xmark } from 'iconoir-react';
 
-import { File } from '../../hooks/useFileBrowser';
+import { File } from '@/hooks/useFileBrowser';
 
 import FilePermissionTable from './FilePermissionTable';
 import FileOverviewTable from './FileOverviewTable';

--- a/src/components/ui/FileSidebar.tsx
+++ b/src/components/ui/FileSidebar.tsx
@@ -9,8 +9,8 @@ import {
 } from '@material-tailwind/react';
 import { Folder, FilterList, NavArrowRight, Server } from 'iconoir-react';
 
-import useZoneFilter from '../../hooks/useZoneFilter';
-import { FileSharePaths } from '../../hooks/useFileBrowser';
+import useZoneFilter from '@/hooks/useZoneFilter';
+import { FileSharePaths } from '@/hooks/useFileBrowser';
 
 type FileSidebarProps = {
   fileSharePaths: FileSharePaths;

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -21,7 +21,7 @@ import {
   SunIcon
 } from '@heroicons/react/24/outline';
 
-import useTheme from '../../hooks/useTheme';
+import useTheme from '@/hooks/useTheme';
 
 const LINKS = [
   {

--- a/src/components/ui/PropertiesDrawer/OverviewTable.tsx
+++ b/src/components/ui/PropertiesDrawer/OverviewTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { File } from '../../../shared.types';
-import { formatDate, formatFileSize } from '../../../utils';
+import { File } from '@/shared.types';
+import { formatDate, formatFileSize } from '@/utils';
 
 export default function OverviewTable({ file }: { file: File | null }) {
   return (

--- a/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
+++ b/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CheckIcon, MinusIcon } from '@heroicons/react/24/outline';
-import { File } from '../../../shared.types';
-import { parsePermissions } from '../../../utils';
+import { File } from '@/shared.types';
+import { parsePermissions } from '@/utils';
 
 export default function PermissionsTable({ file }: { file: File | null }) {
   const permissions = file ? parsePermissions(file.permissions) : null;

--- a/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
+++ b/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
@@ -13,11 +13,11 @@ import {
   XMarkIcon
 } from '@heroicons/react/24/outline';
 
-import type { File } from '../../../shared.types';
+import type { File } from '@/shared.types';
 import PermissionsTable from './PermissionsTable';
 import OverviewTable from './OverviewTable';
-import useCopyPath from '../../../hooks/useCopyPath';
-import { useZoneBrowserContext } from '../../../contexts/ZoneBrowserContext';
+import useCopyPath from '@/hooks/useCopyPath';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
 
 type PropertiesDrawerProps = {
   propertiesTarget: File | null;

--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -22,10 +22,7 @@ import {
 import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
 import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 import useToggleOpenFavorites from '@/hooks/useToggleOpenFavorites';
-import {
-  FileSharePathItem,
-  ZonesAndFileSharePaths
-} from '@/shared.types';
+import { FileSharePathItem, ZonesAndFileSharePaths } from '@/shared.types';
 
 export default function FavoritesBrowser({
   searchQuery,

--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -18,14 +18,14 @@ import FileSharePath from './FileSharePath';
 import {
   DirectoryFavorite,
   usePreferencesContext
-} from '../../../contexts/PreferencesContext';
-import { useZoneBrowserContext } from '../../../contexts/ZoneBrowserContext';
-import { useFileBrowserContext } from '../../../contexts/FileBrowserContext';
-import useToggleOpenFavorites from '../../../hooks/useToggleOpenFavorites';
+} from '@/contexts/PreferencesContext';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
+import useToggleOpenFavorites from '@/hooks/useToggleOpenFavorites';
 import {
   FileSharePathItem,
   ZonesAndFileSharePaths
-} from '../../../shared.types';
+} from '@/shared.types';
 
 export default function FavoritesBrowser({
   searchQuery,

--- a/src/components/ui/Sidebar/FileSharePath.tsx
+++ b/src/components/ui/Sidebar/FileSharePath.tsx
@@ -7,10 +7,10 @@ import {
 } from '@heroicons/react/24/outline';
 import { StarIcon as StarFilled } from '@heroicons/react/24/solid';
 
-import type { FileSharePathItem } from '../../../shared.types';
-import { useZoneBrowserContext } from '../../../contexts/ZoneBrowserContext';
-import { useFileBrowserContext } from '../../../contexts/FileBrowserContext';
-import { usePreferencesContext } from '../../../contexts/PreferencesContext';
+import type { FileSharePathItem } from '@/shared.types';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
 
 export default function FileSharePath({
   pathItem,

--- a/src/components/ui/Sidebar/Sidebar.tsx
+++ b/src/components/ui/Sidebar/Sidebar.tsx
@@ -4,8 +4,8 @@ import { FunnelIcon } from '@heroicons/react/24/outline';
 
 import FavoritesBrowser from './FavoritesBrowser';
 import ZonesBrowser from './ZonesBrowser';
-import useSearchFilter from '../../../hooks/useSearchFilter';
-import useOpenZones from '../../../hooks/useOpenZones';
+import useSearchFilter from '@/hooks/useSearchFilter';
+import useOpenZones from '@/hooks/useOpenZones';
 
 export default function Sidebar() {
   const { openZones, setOpenZones, toggleOpenZones } = useOpenZones();

--- a/src/components/ui/Sidebar/Zone.tsx
+++ b/src/components/ui/Sidebar/Zone.tsx
@@ -13,8 +13,8 @@ import {
 import { StarIcon as StarFilled } from '@heroicons/react/24/solid';
 
 import FileSharePath from './FileSharePath';
-import type { FileSharePathItem } from '../../../shared.types';
-import { usePreferencesContext } from '../../../contexts/PreferencesContext';
+import type { FileSharePathItem } from '@/shared.types';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
 
 export default function Zone({
   zoneName,

--- a/src/components/ui/Sidebar/ZonesBrowser.tsx
+++ b/src/components/ui/Sidebar/ZonesBrowser.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Collapse, Typography, List } from '@material-tailwind/react';
 import { ChevronRightIcon, Squares2X2Icon } from '@heroicons/react/24/outline';
 
-import { ZonesAndFileSharePaths } from '../../../shared.types';
-import { useZoneBrowserContext } from '../../../contexts/ZoneBrowserContext';
+import { ZonesAndFileSharePaths } from '@/shared.types';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
 import Zone from './Zone';
 
 export default function ZonesBrowser({

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
-import type {
-  FileSharePathItem,
-  ZonesAndFileSharePaths
-} from '../shared.types';
-import { useCookiesContext } from '../contexts/CookiesContext';
-import { getAPIPathRoot, sendFetchRequest } from '../utils';
+import type { FileSharePathItem, ZonesAndFileSharePaths } from '@/shared.types';
+import { useCookiesContext } from '@/contexts/CookiesContext';
+import { getAPIPathRoot, sendFetchRequest } from '@/utils';
 
 export type DirectoryFavorite = {
   fileSharePath: FileSharePathItem;

--- a/src/hooks/useSearchFilter.ts
+++ b/src/hooks/useSearchFilter.ts
@@ -1,11 +1,8 @@
 import React from 'react';
-import type {
-  ZonesAndFileSharePaths,
-  FileSharePathItem
-} from '../shared.types';
-import type { DirectoryFavorite } from '../contexts/PreferencesContext';
-import { useZoneBrowserContext } from '../contexts/ZoneBrowserContext';
-import { usePreferencesContext } from '../contexts/PreferencesContext';
+import type { ZonesAndFileSharePaths, FileSharePathItem } from '@/shared.types';
+import type { DirectoryFavorite } from '@/contexts/PreferencesContext';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
 
 export default function useSearchFilter() {
   const { zonesAndFileSharePaths } = useZoneBrowserContext();

--- a/src/layouts/FilesLayout.tsx
+++ b/src/layouts/FilesLayout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Outlet } from 'react-router';
-import Sidebar from '../components/ui/Sidebar/Sidebar';
-import { ZoneBrowserContextProvider } from '../contexts/ZoneBrowserContext';
+import Sidebar from '@/components/ui/Sidebar/Sidebar';
+import { ZoneBrowserContextProvider } from '@/contexts/ZoneBrowserContext';
 
 export const FilesLayout = () => {
   return (

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Outlet } from 'react-router';
-import { CookiesProvider } from '../contexts/CookiesContext';
-import { FileBrowserContextProvider } from '../contexts/FileBrowserContext';
-import FileglancerNavbar from '../components/ui/Navbar';
-import { PreferencesProvider } from '../contexts/PreferencesContext';
+import { CookiesProvider } from '@/contexts/CookiesContext';
+import { FileBrowserContextProvider } from '@/contexts/FileBrowserContext';
+import FileglancerNavbar from '@/components/ui/Navbar';
+import { PreferencesProvider } from '@/contexts/PreferencesContext';
 
 export const MainLayout = () => {
   return (

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,10 @@
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,6 +4,10 @@
     "target": "ES2022",
     "lib": ["ES2023"],
     "module": "ESNext",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vite';
+import path from 'path';
 import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   base: '',
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  },
   build: {
     sourcemap: true,
     outDir: 'fileglancer/ui'


### PR DESCRIPTION
This adds the '@' alias to the build configuration, so that we no longer
have to figure out how far down the component tree we are when
importing another component. eg:

import { useZoneBrowserContext } from '../../../contexts/ZoneBrowserContext';

becomes

import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';

@krokicki 