### PR TITLE
chore: Adds ui directory to dist artifacts.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,16 @@ source = "nodejs"
 fields = ["description", "authors", "urls", "keywords"]
 
 [tool.hatch.build.targets.sdist]
-artifacts = ["fileglancer/labextension"]
+artifacts = [
+  "fileglancer/labextension",
+  "fileglancer/ui"
+]
 exclude = [".github", "binder"]
+
+[tool.hatch.build.targets.wheel]
+artifacts = [
+  "fileglancer/ui"
+]
 
 [tool.hatch.build.targets.wheel.shared-data]
 "fileglancer/labextension" = "share/jupyter/labextensions/fileglancer"


### PR DESCRIPTION
Without this, the ui directory is not packaged with the dist and doesn't
show up when installed in a production setting.
