### PR TITLE
Adds missing folder favorite dialog and a refresh btn

### DIFF
--- a/src/components/ui/FileBrowser/ContextMenu.tsx
+++ b/src/components/ui/FileBrowser/ContextMenu.tsx
@@ -29,9 +29,9 @@ export default function ContextMenu({
   setShowDeleteDialog,
   setShowPermissionsDialog
 }: ContextMenuProps): React.ReactNode {
-  const { currentNavigationZone, currentFileSharePath } =
-    useZoneBrowserContext();
+  const { currentFileSharePath } = useZoneBrowserContext();
   const { handleFavoriteChange } = usePreferencesContext();
+
   return ReactDOM.createPortal(
     <div
       ref={menuRef}
@@ -67,6 +67,7 @@ export default function ContextMenu({
                   'folder'
                 );
               }
+              setShowContextMenu(false);
             }}
           >
             Set/unset as favorite

--- a/src/components/ui/FileBrowser/ContextMenu.tsx
+++ b/src/components/ui/FileBrowser/ContextMenu.tsx
@@ -60,7 +60,8 @@ export default function ContextMenu({
               if (currentFileSharePath) {
                 handleFavoriteChange(
                   {
-                    folderPath: selectedFiles[0].path,
+                    type: 'folder',
+                    folderPath: `${currentFileSharePath.name}/${selectedFiles[0].path}`,
                     fsp: currentFileSharePath
                   },
                   'folder'

--- a/src/components/ui/FileBrowser/Dialogs/Delete.tsx
+++ b/src/components/ui/FileBrowser/Dialogs/Delete.tsx
@@ -51,6 +51,7 @@ export default function DeleteDialog({
             ?
           </Typography>
           <Button
+            color="error"
             className="!rounded-md"
             onClick={() => {
               handleDelete(targetItem);

--- a/src/components/ui/FileBrowser/Toolbar.tsx
+++ b/src/components/ui/FileBrowser/Toolbar.tsx
@@ -6,11 +6,13 @@ import {
   Typography
 } from '@material-tailwind/react';
 import {
+  ArrowPathIcon,
   EyeIcon,
   EyeSlashIcon,
   FolderPlusIcon,
   ListBulletIcon
 } from '@heroicons/react/24/solid';
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 
 type ToolbarProps = {
   hideDotFiles: boolean;
@@ -25,6 +27,8 @@ export default function Toolbar({
   setShowPropertiesDrawer,
   setShowNewFolderDialog
 }: ToolbarProps): JSX.Element {
+  const { fetchAndFormatFilesForDisplay, currentNavigationPath } =
+    useFileBrowserContext();
   return (
     <div className="flex flex-col min-w-full p-2 border-b border-surface">
       <ButtonGroup className="self-start">
@@ -79,6 +83,23 @@ export default function Toolbar({
             <Tooltip.Content className="px-2.5 py-1.5 text-primary-foreground">
               <Typography type="small" className="opacity-90">
                 View file properties
+              </Typography>
+              <Tooltip.Arrow />
+            </Tooltip.Content>
+          </Tooltip.Trigger>
+        </Tooltip>
+
+        {/* Refresh browser contents */}
+        <Tooltip placement="top">
+          <Tooltip.Trigger
+            as={IconButton}
+            variant="outline"
+            onClick={() => fetchAndFormatFilesForDisplay(currentNavigationPath)}
+          >
+            <ArrowPathIcon className="icon-default" />
+            <Tooltip.Content className="px-2.5 py-1.5 text-primary-foreground">
+              <Typography type="small" className="opacity-90">
+                Refresh file browser
               </Typography>
               <Tooltip.Arrow />
             </Tooltip.Content>

--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -6,11 +6,7 @@ import {
   Typography,
   List
 } from '@material-tailwind/react';
-import {
-  ChevronRightIcon,
-  FolderIcon,
-  StarIcon as StarOutline
-} from '@heroicons/react/24/outline';
+import { ChevronRightIcon, FolderIcon } from '@heroicons/react/24/outline';
 import { StarIcon as StarFilled } from '@heroicons/react/24/solid';
 
 import ZoneComponent from './Zone';
@@ -45,7 +41,6 @@ export default function FavoritesBrowser({
     zoneFavorites,
     fileSharePathFavorites,
     folderFavorites,
-    folderPreferenceMap,
     pathPreference,
     handleFavoriteChange
   } = usePreferencesContext();
@@ -126,7 +121,6 @@ export default function FavoritesBrowser({
                 'folder',
                 `${folderFavorite.fsp.name}_${folderFavorite.folderPath}`
               ) as string;
-              const isFavoriteDir = folderPreferenceMap[mapKey] ? true : false;
               const splitPath = folderFavorite.folderPath.split('/');
               const folderName = splitPath[splitPath.length - 1];
 
@@ -174,11 +168,7 @@ export default function FavoritesBrowser({
                         handleFavoriteChange(folderFavorite, 'folder');
                       }}
                     >
-                      {isFavoriteDir ? (
-                        <StarFilled className="icon-small x-short:icon-xsmall mb-[2px]" />
-                      ) : (
-                        <StarOutline className="icon-small x-short:icon-xsmall mb-[2px]" />
-                      )}
+                      <StarFilled className="icon-small x-short:icon-xsmall mb-[2px]" />
                     </IconButton>
                   </div>
                 </List.Item>

--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -1,25 +1,17 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import {
-  Collapse,
-  IconButton,
-  Typography,
-  List
-} from '@material-tailwind/react';
-import { ChevronRightIcon, FolderIcon } from '@heroicons/react/24/outline';
+import { Collapse, Typography, List } from '@material-tailwind/react';
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import { StarIcon as StarFilled } from '@heroicons/react/24/solid';
 
 import ZoneComponent from './Zone';
 import FileSharePathComponent from './FileSharePath';
+import Folder from './Folder';
 import {
   FolderFavorite,
   usePreferencesContext
 } from '@/contexts/PreferencesContext';
-import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
-import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 import useToggleOpenFavorites from '@/hooks/useToggleOpenFavorites';
 import { FileSharePath, Zone } from '@/shared.types';
-import { makeMapKey } from '@/utils';
 
 type FavoritesBrowserProps = {
   searchQuery: string;
@@ -37,20 +29,8 @@ export default function FavoritesBrowser({
   filteredFolderFavorites
 }: FavoritesBrowserProps) {
   const { openFavorites, toggleOpenFavorites } = useToggleOpenFavorites();
-  const {
-    zoneFavorites,
-    fileSharePathFavorites,
-    folderFavorites,
-    pathPreference,
-    handleFavoriteChange
-  } = usePreferencesContext();
-
-  const { currentDir, fetchAndFormatFilesForDisplay } = useFileBrowserContext();
-  const {
-    setCurrentNavigationZone,
-    currentFileSharePath,
-    setCurrentFileSharePath
-  } = useZoneBrowserContext();
+  const { zoneFavorites, fileSharePathFavorites, folderFavorites } =
+    usePreferencesContext();
 
   const displayZones =
     filteredZoneFavorites.length > 0 || searchQuery.length > 0
@@ -108,70 +88,11 @@ export default function FavoritesBrowser({
 
             {/* Directory favorites */}
             {displayFolders.map(folderFavorite => {
-              const fileSharePath =
-                pathPreference[0] === 'linux_path'
-                  ? folderFavorite.fsp.linux_path
-                  : pathPreference[0] === 'windows_path'
-                    ? folderFavorite.fsp.windows_path
-                    : pathPreference[0] === 'mac_path'
-                      ? folderFavorite.fsp.mac_path
-                      : folderFavorite.fsp.linux_path;
-
-              const mapKey = makeMapKey(
-                'folder',
-                `${folderFavorite.fsp.name}_${folderFavorite.folderPath}`
-              ) as string;
-              const splitPath = folderFavorite.folderPath.split('/');
-              const folderName = splitPath[splitPath.length - 1];
-
               return (
-                <List.Item
-                  key={mapKey}
-                  onClick={() => {
-                    setOpenZones({
-                      all: true,
-                      [folderFavorite.fsp.zone]: true
-                    });
-                    setCurrentNavigationZone(folderFavorite.fsp.zone);
-                    setCurrentFileSharePath(folderFavorite.fsp);
-                    fetchAndFormatFilesForDisplay(
-                      `${folderFavorite.fsp.name}?subpath=${folderFavorite.folderPath}`
-                    );
-                  }}
-                  className={`overflow-x-auto x-short:py-0 flex gap-2 items-center justify-between rounded-none cursor-pointer text-foreground hover:bg-primary-light/30 focus:bg-primary-light/30 ${folderFavorite.fsp === currentFileSharePath && folderFavorite.fsp.name === currentDir ? '!bg-primary-light/30' : '!bg-background'}`}
-                >
-                  <Link
-                    to="/browse"
-                    className="flex flex-col gap-2 x-short:gap-1 !text-foreground hover:!text-black focus:!text-black hover:dark:!text-white focus:dark:!text-white"
-                  >
-                    <div className="flex gap-1 items-center">
-                      <FolderIcon className="icon-small x-short:icon-xsmall" />
-                      <Typography className="text-sm font-medium leading-4 x-short:text-xs">
-                        {folderName}
-                      </Typography>
-                    </div>
-                    <Typography className="text-xs">
-                      {`${fileSharePath}/${folderFavorite.folderPath}`}
-                    </Typography>
-                  </Link>
-                  <div
-                    onClick={e => {
-                      e.stopPropagation();
-                      e.preventDefault();
-                    }}
-                  >
-                    <IconButton
-                      variant="ghost"
-                      isCircular
-                      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                        e.stopPropagation();
-                        handleFavoriteChange(folderFavorite, 'folder');
-                      }}
-                    >
-                      <StarFilled className="icon-small x-short:icon-xsmall mb-[2px]" />
-                    </IconButton>
-                  </div>
-                </List.Item>
+                <Folder
+                  folderFavorite={folderFavorite}
+                  setOpenZones={setOpenZones}
+                />
               );
             })}
           </List>

--- a/src/components/ui/Sidebar/Folder.tsx
+++ b/src/components/ui/Sidebar/Folder.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { IconButton, List, Typography } from '@material-tailwind/react';
+import { FolderIcon } from '@heroicons/react/24/outline';
+import { StarIcon as StarFilled } from '@heroicons/react/24/solid';
+
+import { makeMapKey, getFileFetchPath, sendFetchRequest } from '@/utils';
+import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
+import { useCookiesContext } from '@/contexts/CookiesContext';
+import MissingFolderFavoriteDialog from './MissingFolderFavoriteDialog';
+
+import {
+  FolderFavorite,
+  usePreferencesContext
+} from '@/contexts/PreferencesContext';
+
+type FolderProps = {
+  folderFavorite: FolderFavorite;
+  setOpenZones: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
+};
+
+export default function Folder({ folderFavorite, setOpenZones }: FolderProps) {
+  const [showMissingFolderFavoriteDialog, setShowMissingFolderFavoriteDialog] =
+    React.useState(false);
+  const {
+    setCurrentNavigationZone,
+    currentFileSharePath,
+    setCurrentFileSharePath
+  } = useZoneBrowserContext();
+  const { currentDir, fetchAndFormatFilesForDisplay } = useFileBrowserContext();
+  const { pathPreference, handleFavoriteChange } = usePreferencesContext();
+  const { cookies } = useCookiesContext();
+
+  // '' is for fsp=local, where linux, max, and windows paths are null
+  const fileSharePath =
+    pathPreference[0] === 'linux_path'
+      ? folderFavorite.fsp.linux_path || ''
+      : pathPreference[0] === 'windows_path'
+        ? folderFavorite.fsp.windows_path || ''
+        : pathPreference[0] === 'mac_path'
+          ? folderFavorite.fsp.mac_path || ''
+          : folderFavorite.fsp.linux_path || '';
+
+  const mapKey = makeMapKey(
+    'folder',
+    `${folderFavorite.fsp.name}_${folderFavorite.folderPath}`
+  ) as string;
+  const splitPath = folderFavorite.folderPath.split('/');
+  const folderName = splitPath[splitPath.length - 1];
+
+  async function checkFolderExists(folderFavorite: FolderFavorite) {
+    try {
+      const folderPath = getFileFetchPath(
+        `${folderFavorite.fsp.name}?subpath=${folderFavorite.folderPath}`
+      );
+      const response = await sendFetchRequest(
+        folderPath,
+        'GET',
+        cookies['_xsrf']
+      );
+      const data = await response.json();
+      if (data.status === 200) {
+        return true;
+      } else {
+        return false;
+      }
+    } catch (error) {
+      console.error('Error checking folder existence:', error);
+      return false;
+    }
+  }
+
+  return (
+    <>
+      <List.Item
+        key={mapKey}
+        onClick={async () => {
+          let folderExists;
+          try {
+            folderExists = await checkFolderExists(folderFavorite);
+          } catch (error) {
+            console.error('Error checking folder existence:', error);
+          }
+          if (folderExists) {
+            setOpenZones({
+              all: true,
+              [folderFavorite.fsp.zone]: true
+            });
+            setCurrentNavigationZone(folderFavorite.fsp.zone);
+            setCurrentFileSharePath(folderFavorite.fsp);
+            fetchAndFormatFilesForDisplay(
+              `${folderFavorite.fsp.name}?subpath=${folderFavorite.folderPath}`
+            );
+          } else if (folderExists === false) {
+            setShowMissingFolderFavoriteDialog(true);
+          }
+        }}
+        className={`overflow-x-auto x-short:py-0 flex gap-2 items-center justify-between rounded-none cursor-pointer text-foreground hover:bg-primary-light/30 focus:bg-primary-light/30 ${folderFavorite.fsp === currentFileSharePath && folderFavorite.fsp.name === currentDir ? '!bg-primary-light/30' : '!bg-background'}`}
+      >
+        <Link
+          to="/browse"
+          className="flex flex-col gap-2 x-short:gap-1 !text-foreground hover:!text-black focus:!text-black hover:dark:!text-white focus:dark:!text-white"
+        >
+          <div className="flex gap-1 items-center">
+            <FolderIcon className="icon-small x-short:icon-xsmall" />
+            <Typography className="text-sm font-medium leading-4 x-short:text-xs">
+              {folderName}
+            </Typography>
+          </div>
+          <Typography className="text-xs">
+            {`${fileSharePath}/${folderFavorite.folderPath}`}
+          </Typography>
+        </Link>
+        <div
+          onClick={e => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+        >
+          <IconButton
+            variant="ghost"
+            isCircular
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.stopPropagation();
+              handleFavoriteChange(folderFavorite, 'folder');
+            }}
+          >
+            <StarFilled className="icon-small x-short:icon-xsmall mb-[2px]" />
+          </IconButton>
+        </div>
+      </List.Item>
+      {showMissingFolderFavoriteDialog ? (
+        <MissingFolderFavoriteDialog
+          folderFavorite={folderFavorite}
+          showMissingFolderFavoriteDialog={showMissingFolderFavoriteDialog}
+          setShowMissingFolderFavoriteDialog={
+            setShowMissingFolderFavoriteDialog
+          }
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/components/ui/Sidebar/MissingFolderFavoriteDialog.tsx
+++ b/src/components/ui/Sidebar/MissingFolderFavoriteDialog.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+  Alert,
+  Button,
+  Dialog,
+  IconButton,
+  Typography
+} from '@material-tailwind/react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+
+import {
+  FolderFavorite,
+  usePreferencesContext
+} from '@/contexts/PreferencesContext';
+import { X } from 'iconoir-react';
+
+type MissingFolderFavoriteDialogProps = {
+  folderFavorite: FolderFavorite;
+  showMissingFolderFavoriteDialog: boolean;
+  setShowMissingFolderFavoriteDialog: React.Dispatch<
+    React.SetStateAction<boolean>
+  >;
+};
+
+export default function MissingFolderFavoriteDialog({
+  folderFavorite,
+  showMissingFolderFavoriteDialog,
+  setShowMissingFolderFavoriteDialog
+}: MissingFolderFavoriteDialogProps): JSX.Element {
+  const [showAlert, setShowAlert] = React.useState<boolean>(false);
+  const [alertContent, setAlertContent] = React.useState<string>('');
+  const { handleFavoriteChange } = usePreferencesContext();
+
+  return (
+    <Dialog open={showMissingFolderFavoriteDialog}>
+      <Dialog.Overlay>
+        <Dialog.Content>
+          <IconButton
+            size="sm"
+            variant="outline"
+            color="secondary"
+            className="absolute right-2 top-2 text-secondary hover:text-background"
+            isCircular
+            onClick={() => {
+              setShowMissingFolderFavoriteDialog(false);
+              setShowAlert(false);
+            }}
+          >
+            <XMarkIcon className="icon-default" />
+          </IconButton>
+          <Typography className="my-8 text-large">
+            Folder{' '}
+            <span className="font-semibold">{folderFavorite.folderPath}</span>{' '}
+            does not exist. Do you want to delete it from your favorites?
+          </Typography>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              color="error"
+              className="!rounded-md flex items-center gap-2"
+              onClick={() => {
+                try {
+                  handleFavoriteChange(folderFavorite, 'folder');
+                } catch (error) {
+                  setAlertContent(
+                    `Error deleting favorite folder ${folderFavorite.folderPath}: ${
+                      error instanceof Error ? error.message : 'Unknown error'
+                    }`
+                  );
+                  setShowAlert(true);
+                }
+              }}
+            >
+              Delete
+            </Button>
+            <Button
+              variant="outline"
+              className="!rounded-md flex items-center gap-2"
+              onClick={() => {
+                setShowMissingFolderFavoriteDialog(false);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+          {showAlert === true ? (
+            <Alert
+              className={`flex items-center gap-6 mt-6 border-none ${alertContent.startsWith('Error') ? 'bg-error-light/90' : 'bg-secondary-light/70'}`}
+            >
+              <Alert.Content>{alertContent}</Alert.Content>
+              <XMarkIcon
+                className="icon-default cursor-pointer"
+                onClick={() => {
+                  setShowAlert(false);
+                  setShowMissingFolderFavoriteDialog(false);
+                }}
+              />
+            </Alert>
+          ) : null}
+        </Dialog.Content>
+      </Dialog.Overlay>
+    </Dialog>
+  );
+}

--- a/src/components/ui/Sidebar/Zone.tsx
+++ b/src/components/ui/Sidebar/Zone.tsx
@@ -13,7 +13,7 @@ import {
 import { StarIcon as StarFilled } from '@heroicons/react/24/solid';
 
 import FileSharePathComponent from './FileSharePath';
-import type { Zone, FileSharePath } from '@/shared.types';
+import type { Zone } from '@/shared.types';
 import { usePreferencesContext } from '@/contexts/PreferencesContext';
 import { makeMapKey } from '@/utils';
 

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -143,7 +143,7 @@ export const PreferencesProvider = ({
   ) {
     setFolderPreferenceMap(updatedMap);
     const updatedFolderFavorites = Object.entries(updatedMap).map(
-      ([, value]) => {
+      ([_, value]) => {
         const fspKey = makeMapKey('fsp', value.fspName);
         const fsp = zonesAndFileSharePathsMap[fspKey];
         return { type: 'folder', folderPath: value.folderPath, fsp: fsp };
@@ -175,10 +175,11 @@ export const PreferencesProvider = ({
 
     (async function () {
       const backendPrefs = await fetchPreferences('zone');
-      const zoneMap = backendPrefs.map((pref: ZonePreference) => {
+      const zoneArray = backendPrefs.map((pref: ZonePreference) => {
         const key = makeMapKey(pref.type, pref.name);
         return { [key]: pref };
       });
+      const zoneMap = Object.assign({}, ...zoneArray);
       if (zoneMap) {
         updateLocalZonePreferenceStates(zoneMap);
       }
@@ -209,12 +210,13 @@ export const PreferencesProvider = ({
 
     (async function () {
       const backendPrefs = await fetchPreferences('folder');
-      const fspMap = backendPrefs.map((pref: FolderPreference) => {
+      const folderArray = backendPrefs.map((pref: FolderPreference) => {
         const key = makeMapKey(pref.type, `${pref.fspName}_${pref.folderPath}`);
         return { [key]: pref };
       });
-      if (fspMap) {
-        updateLocalFolderPreferenceStates(fspMap);
+      const folderMap = Object.assign({}, ...folderArray);
+      if (folderMap) {
+        updateLocalFolderPreferenceStates(folderMap);
       }
     })();
   }, [isZonesMapReady]);

--- a/src/hooks/useNewFolderDialog.ts
+++ b/src/hooks/useNewFolderDialog.ts
@@ -15,7 +15,7 @@ export default function useNewFolderDialog() {
 
   async function addNewFolder(subpath: string) {
     await sendFetchRequest(
-      `${getAPIPathRoot()}api/fileglancer/files/${currentFileSharePath?.name}?subpath=${subpath}/${newName}`,
+      `${getAPIPathRoot()}api/fileglancer/files/${currentFileSharePath?.name}?subpath=${subpath}${newName}`,
       'POST',
       cookies['_xsrf'],
       { type: 'directory' }


### PR DESCRIPTION
Completes final task on this [clickup ticket](https://app.clickup.com/t/86a8exxrw); also adds a "refresh" button to the file browser toolbar, which was discussed but I don't think I recorded it in a ticket.

You can test the missing folder favorite dialog:

1. Right-click on a folder (either a test one or one you don't mind deleting) to use the context menu add it to favorites 
2. Delete the folder (can also be done from the Fileglancer context menu)
3. Click on the folder in the favorites browser - this brings up the dialog indicating the folder is missing and asking if you want to delete it from your favorites