### PR TITLE
Remove Dev Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,6 @@ You can create a file at `~/.jupyter/jupyter_server_config.py` (or in any of the
 c.Fileglancer.central_url='http://0.0.0.0:7878'
 ```
 
-To configure "Dev Mode" which simulates many zones and file share paths, add this to your config:
-
-```python
-c.Fileglancer.dev_mode=True
-```
-
 ## Development Uninstall
 
 ```bash

--- a/fileglancer/app.py
+++ b/fileglancer/app.py
@@ -52,13 +52,7 @@ class Fileglancer(ExtensionApp):
         config=True,
         help="The URL of the central server",
     )
-
-    dev_mode = Bool(
-        default_value=False,
-        config=True,
-        help="Enable development mode.",
-    )
-
+    
     def initialize_settings(self):
         """Update extension settings.
 


### PR DESCRIPTION
This removes Dev Mode™ which we don't need because we can configure static local paths in fileglancer-central.

@allison-truhlar @neomorphic 