### PR TITLE
feat: Adds alerts via react-hot-toast.

### DIFF
--- a/src/components/ui/Dialogs/SharingDialog.tsx
+++ b/src/components/ui/Dialogs/SharingDialog.tsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import {
-  Alert,
   Button,
   Dialog,
   IconButton,
   Typography
 } from '@material-tailwind/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
+import toast from 'react-hot-toast';
 
 import { useProxiedPathContext } from '@/contexts/ProxiedPathContext';
 import { useZoneBrowserContext } from '@/contexts/ZoneBrowserContext';
-import { set } from 'node_modules/zarrita/dist/src/indexing/set';
 
 type SharingDialogProps = {
   isImageShared: boolean;
@@ -27,8 +26,6 @@ export default function SharingDialog({
   showSharingDialog,
   setShowSharingDialog
 }: SharingDialogProps): JSX.Element {
-  const [showAlert, setShowAlert] = React.useState<boolean>(false);
-  const [alertContent, setAlertContent] = React.useState<string>('');
   const { createProxiedPath, deleteProxiedPath } = useProxiedPathContext();
   const { currentFileSharePath } = useZoneBrowserContext();
   const fullPath = `${currentFileSharePath?.mount_path}/${filePathWithoutFsp}`;
@@ -45,7 +42,6 @@ export default function SharingDialog({
             isCircular
             onClick={() => {
               setShowSharingDialog(false);
-              setShowAlert(false);
             }}
           >
             <XMarkIcon className="icon-default" />
@@ -83,19 +79,18 @@ export default function SharingDialog({
                   try {
                     const newProxiedPath = await createProxiedPath(fullPath);
                     if (newProxiedPath) {
-                      setAlertContent(`Successfully shared ${fullPath}`);
+                      toast.success(`Successfully shared ${fullPath}`);
                     } else {
-                      setAlertContent(`Error sharing ${fullPath}`);
+                      toast.error(`Error sharing ${fullPath}`);
                     }
                     setIsImageShared(true);
                     setShowSharingDialog(false);
                   } catch (error) {
-                    setAlertContent(
+                    toast.error(
                       `Error sharing ${fullPath}: ${
                         error instanceof Error ? error.message : 'Unknown error'
                       }`
                     );
-                    setShowAlert(true);
                   }
                 }}
               >
@@ -111,15 +106,14 @@ export default function SharingDialog({
                   try {
                     await deleteProxiedPath();
                     setIsImageShared(false);
-                    setAlertContent(`Successfully unshared ${fullPath}`);
+                    toast.success(`Successfully unshared ${fullPath}`);
                     setShowSharingDialog(false);
                   } catch (error) {
-                    setAlertContent(
+                    toast.error(
                       `Error unsharing ${fullPath}: ${
                         error instanceof Error ? error.message : 'Unknown error'
                       }`
                     );
-                    setShowAlert(true);
                   }
                 }}
               >
@@ -136,20 +130,6 @@ export default function SharingDialog({
               Cancel
             </Button>
           </div>
-          {showAlert === true ? (
-            <Alert
-              className={`flex items-center gap-6 mt-6 border-none ${alertContent.startsWith('Error') ? 'bg-error-light/90' : 'bg-secondary-light/70'}`}
-            >
-              <Alert.Content>{alertContent}</Alert.Content>
-              <XMarkIcon
-                className="icon-default cursor-pointer"
-                onClick={() => {
-                  setShowAlert(false);
-                  setShowSharingDialog(false);
-                }}
-              />
-            </Alert>
-          ) : null}
         </Dialog.Content>
       </Dialog.Overlay>
     </Dialog>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from 'react-router';
+import { Toaster } from 'react-hot-toast';
 
 import { CookiesProvider } from '@/contexts/CookiesContext';
 import { ZoneBrowserContextProvider } from '@/contexts/ZoneBrowserContext';
@@ -14,6 +15,7 @@ export const MainLayout = () => {
         <PreferencesProvider>
           <FileBrowserContextProvider>
             <ProxiedPathProvider>
+              <Toaster />
               <div className="flex flex-col items-center h-full w-full overflow-y-hidden bg-background text-foreground box-border">
                 <FileglancerNavbar />
                 <Outlet />


### PR DESCRIPTION
This is an example update to show how alerts can be added to the page,
without having to be embedded in the component where the causative
action has occurred. If this library is used, then we can change all
instances of the Alert component into calls to toast.
