### PR TITLE
Use new proxied path API

### DIFF
--- a/fileglancer/proxiedpath.py
+++ b/fileglancer/proxiedpath.py
@@ -20,19 +20,24 @@ class ProxiedPathManager:
         log.info(f"Retrieve proxied path {sharing_key} for user {username} from {self.central_url}")
         return requests.get(f"{self.central_url}/proxied-path/{username}/{sharing_key}")
 
-    def get_proxied_paths(self, username: str, mount_path: Optional[str] = None) -> ProxiedPathResponse:
-        """Retrieve user proxied paths, optionally filtered by mount path."""
+    def get_proxied_paths(self, username: str, fsp_mount_path: Optional[str] = None, path: Optional[str] = None) -> ProxiedPathResponse:
+        """Retrieve user proxied paths, optionally filtered by fsp_mount_path and path."""
         log.info(f"Retrieve all proxied paths for user {username} from {self.central_url}")
-        return requests.get(f"{self.central_url}/proxied-path/{username}", params = {
-            "mount_path": mount_path
-        })
+        return requests.get(
+            f"{self.central_url}/proxied-path/{username}", 
+            params = {
+                "fsp_mount_path": fsp_mount_path,
+                "path": path
+            }
+        )
 
-    def create_proxied_path(self, username: str, mount_path: str) -> requests.Response:
-        """Create a proxied path for the given mount path."""
+    def create_proxied_path(self, username: str, fsp_mount_path: str, path: str) -> requests.Response:
+        """Create a proxied path for the given fsp_mount_path and path."""
         return requests.post(
             f"{self.central_url}/proxied-path/{username}",
             params = {
-                "mount_path": mount_path
+                "fsp_mount_path": fsp_mount_path,
+                "path": path
             }
         )
 
@@ -42,11 +47,13 @@ class ProxiedPathManager:
             f"{self.central_url}/proxied-path/{username}/{sharing_key}"
         )
 
-    def update_proxied_path(self, username: str, sharing_key, new_path: Optional[str], new_name: Optional[str]) -> requests.Response:
-        """Update a proxied path with the given mount path and sharing name."""
+    def update_proxied_path(self, username: str, sharing_key: str, fsp_mount_path: Optional[str] = None, path: Optional[str] = None, new_name: Optional[str] = None) -> requests.Response:
+        """Update a proxied path with the given fsp_mount_path, path and sharing name."""
         pp_updates = {}
-        if new_path:
-            pp_updates["mount_path"] = new_path
+        if fsp_mount_path:
+            pp_updates["fsp_mount_path"] = fsp_mount_path
+        if path:
+            pp_updates["path"] = path
         if new_name:
             pp_updates["sharing_name"] = new_name
         return requests.put(

--- a/fileglancer/tests/test_proxiedpath.py
+++ b/fileglancer/tests/test_proxiedpath.py
@@ -128,15 +128,17 @@ async def test_delete_user_proxied_path_without_key(jp_fetch):
 @patch("fileglancer.handlers.ProxiedPathHandler.get_current_user", return_value=TEST_USER)
 async def test_post_user_proxied_path(test_current_user, jp_fetch, requests_mock):
     payload = {
-        "mount_path": "/test/path"
+        "fsp_mount_path": "/test",
+        "path": "path/to/data"
     }
-    requests_mock.post(f"{TEST_URL}?mount_path=/test/path",
+    requests_mock.post(f"{TEST_URL}?fsp_mount_path={payload['fsp_mount_path']}&path={payload['path']}",
                        status_code=201,
                        json={
                            "username": TEST_USER,
                            "sharing_key": "test_key",
                            "sharing_name": "test_name",
-                           "mount_path": "/test/path"
+                           "fsp_mount_path": payload["fsp_mount_path"],
+                           "path": payload["path"]
                        })
 
     response = await jp_fetch("api", "fileglancer", "proxied-path",
@@ -148,16 +150,18 @@ async def test_post_user_proxied_path(test_current_user, jp_fetch, requests_mock
     assert rj["username"] == TEST_USER
     assert rj["sharing_key"] == "test_key"
     assert rj["sharing_name"] == "test_name"
-    assert rj["mount_path"] == "/test/path"
-
+    assert rj["fsp_mount_path"] == payload["fsp_mount_path"]
+    assert rj["path"] == payload["path"]
+    
 
 @patch("fileglancer.handlers.ProxiedPathHandler.get_current_user", return_value=TEST_USER)
 async def test_post_user_proxied_path_exception(test_current_user, jp_fetch, requests_mock):
     try:
         payload = {
-            "mount_path": "/test/path"
+            "fsp_mount_path": "/test",
+            "path": "path/to/data"
         }
-        requests_mock.post(f"{TEST_URL}?mount_path=/test/path",
+        requests_mock.post(f"{TEST_URL}?fsp_mount_path={payload['fsp_mount_path']}&path={payload['path']}",
                         status_code=404,
                         json={
                             "error": "Some error"
@@ -184,27 +188,30 @@ async def test_post_user_proxied_path_without_mountpath(jp_fetch):
     except Exception as e:
         assert e.code == 400
         rj = json.loads(e.response.body)
-        assert rj["error"] == "Mount path is required to create a proxied path"
+        assert rj["error"] == "fsp_mount_path and path are required to create a proxied path"
 
 
 @patch("fileglancer.handlers.ProxiedPathHandler.get_current_user", return_value=TEST_USER)
 async def test_put_user_proxied_path(test_current_user, jp_fetch, requests_mock):
     test_key = "test_key"
-    new_mount_path = "/test/path"
+    new_fsp_mount_path = "/test"
+    new_path = "path/to/data"
     new_sharing_name = "newname"
-    requests_mock.put(f"{TEST_URL}/{test_key}?mount_path={new_mount_path}&sharing_name={new_sharing_name}",
+    requests_mock.put(f"{TEST_URL}/{test_key}?fsp_mount_path={new_fsp_mount_path}&path={new_path}&sharing_name={new_sharing_name}",
                        status_code=200,
                        json={
                             "username": TEST_USER,
                             "sharing_key": test_key,
                             "sharing_name": new_sharing_name,
-                            "mount_path": new_mount_path
+                            "fsp_mount_path": new_fsp_mount_path,
+                            "path": new_path
                        })
 
     response = await jp_fetch("api", "fileglancer", "proxied-path",
                               method="PUT",
                               body=json.dumps({
-                                  "mount_path": new_mount_path,
+                                  "fsp_mount_path": new_fsp_mount_path,
+                                  "path": new_path,
                                   "sharing_key": test_key,
                                   "sharing_name": new_sharing_name
                               }),
@@ -214,16 +221,18 @@ async def test_put_user_proxied_path(test_current_user, jp_fetch, requests_mock)
     assert rj["username"] == TEST_USER
     assert rj["sharing_key"] == test_key
     assert rj["sharing_name"] == new_sharing_name
-    assert rj["mount_path"] == new_mount_path
+    assert rj["fsp_mount_path"] == new_fsp_mount_path
+    assert rj["path"] == new_path
 
 
 @patch("fileglancer.handlers.ProxiedPathHandler.get_current_user", return_value=TEST_USER)
 async def test_put_user_proxied_path_exception(test_current_user, jp_fetch, requests_mock):
     try:
         test_key = "test_key"
-        new_mount_path = "/test/path"
+        new_fsp_mount_path = "/test"
+        new_path = "path/to/data"
         new_sharing_name = "newname"
-        requests_mock.put(f"{TEST_URL}/{test_key}?mount_path={new_mount_path}&sharing_name={new_sharing_name}",
+        requests_mock.put(f"{TEST_URL}/{test_key}?fsp_mount_path={new_fsp_mount_path}&path={new_path}&sharing_name={new_sharing_name}",
                           status_code=404,
                           json={
                             "error": "Some error"
@@ -232,7 +241,8 @@ async def test_put_user_proxied_path_exception(test_current_user, jp_fetch, requ
         await jp_fetch("api", "fileglancer", "proxied-path",
                         method="PUT",
                         body=json.dumps({
-                            "mount_path": new_mount_path,
+                            "fsp_mount_path": new_fsp_mount_path,
+                            "path": new_path,
                             "sharing_key": test_key,
                             "sharing_name": new_sharing_name
                         }),

--- a/src/components/ui/Dialogs/SharingDialog.tsx
+++ b/src/components/ui/Dialogs/SharingDialog.tsx
@@ -31,7 +31,7 @@ export default function SharingDialog({
   const [alertContent, setAlertContent] = React.useState<string>('');
   const { createProxiedPath, deleteProxiedPath } = useProxiedPathContext();
   const { currentFileSharePath } = useZoneBrowserContext();
-  const fullPath = `${currentFileSharePath?.mount_path}/${filePathWithoutFsp}`;
+  const displayPath = `${currentFileSharePath?.mount_path}/${filePathWithoutFsp}`;
 
   return (
     <Dialog open={showSharingDialog}>
@@ -55,7 +55,7 @@ export default function SharingDialog({
             <Typography className="my-8 text-large text-foreground">
               <p>
                 Are you sure you want to unshare{' '}
-                <span className="font-semibold break-all">{fullPath}</span>?
+                <span className="font-semibold break-all">{displayPath}</span>?
               </p>
               <p>
                 If you previously shared a link to these data with
@@ -67,7 +67,7 @@ export default function SharingDialog({
             <Typography className="my-8 text-large text-foreground">
               <p>
                 Are you sure you want to share{' '}
-                <span className="font-semibold break-all">{fullPath}</span>?
+                <span className="font-semibold break-all">{displayPath}</span>?
               </p>
               <p>This will allow anyone at Janelia to view this data.</p>
             </Typography>
@@ -81,17 +81,20 @@ export default function SharingDialog({
                 className="!rounded-md flex items-center gap-2"
                 onClick={async () => {
                   try {
-                    const newProxiedPath = await createProxiedPath(fullPath);
+                    const newProxiedPath = await createProxiedPath(
+                      currentFileSharePath?.mount_path || '',
+                      filePathWithoutFsp
+                    );
                     if (newProxiedPath) {
-                      setAlertContent(`Successfully shared ${fullPath}`);
+                      setAlertContent(`Successfully shared ${displayPath}`);
                     } else {
-                      setAlertContent(`Error sharing ${fullPath}`);
+                      setAlertContent(`Error sharing ${displayPath}`);
                     }
                     setIsImageShared(true);
                     setShowSharingDialog(false);
                   } catch (error) {
                     setAlertContent(
-                      `Error sharing ${fullPath}: ${
+                      `Error sharing ${displayPath}: ${
                         error instanceof Error ? error.message : 'Unknown error'
                       }`
                     );
@@ -111,11 +114,11 @@ export default function SharingDialog({
                   try {
                     await deleteProxiedPath();
                     setIsImageShared(false);
-                    setAlertContent(`Successfully unshared ${fullPath}`);
+                    setAlertContent(`Successfully unshared ${displayPath}`);
                     setShowSharingDialog(false);
                   } catch (error) {
                     setAlertContent(
-                      `Error unsharing ${fullPath}: ${
+                      `Error unsharing ${displayPath}: ${
                         error instanceof Error ? error.message : 'Unknown error'
                       }`
                     );

--- a/src/contexts/ProxiedPathContext.tsx
+++ b/src/contexts/ProxiedPathContext.tsx
@@ -7,7 +7,8 @@ import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 const proxyBaseUrl = import.meta.env.VITE_PROXY_BASE_URL;
 
 type ProxiedPath = {
-  mount_path: string;
+  fsp_mount_path: string;
+  path: string;
   sharing_key: string;
   sharing_name: string;
   username: string;
@@ -16,7 +17,7 @@ type ProxiedPath = {
 type ProxiedPathContextType = {
   proxiedPath: ProxiedPath | null;
   dataUrl: string | null;
-  createProxiedPath: (mountPath: string) => Promise<ProxiedPath | null>;
+  createProxiedPath: (fspMountPath: string, path: string) => Promise<ProxiedPath | null>;
   deleteProxiedPath: () => Promise<void>;
 };
 
@@ -62,9 +63,9 @@ export const ProxiedPathProvider = ({
     try {
       const filePath = currentNavigationPath.replace('?subpath=', '/');
       const filePathWithoutFsp = filePath.split('/').slice(1).join('/');
-      const mountPath = `${currentFileSharePath?.mount_path}/${filePathWithoutFsp}`;
+      console.log('Fetching proxied path for', currentFileSharePath?.mount_path, filePathWithoutFsp);
       const response = await sendFetchRequest(
-        `${getAPIPathRoot()}api/fileglancer/proxied-path?mount_path=${mountPath}`,
+        `${getAPIPathRoot()}api/fileglancer/proxied-path?fsp_mount_path=${currentFileSharePath?.mount_path}&path=${filePathWithoutFsp}`,
         'GET',
         cookies['_xsrf']
       );
@@ -85,13 +86,14 @@ export const ProxiedPathProvider = ({
   }
 
   async function createProxiedPath(
-    mountPath: string
+    fspMountPath: string,
+    path: string
   ): Promise<ProxiedPath | null> {
     const response = await sendFetchRequest(
       `${getAPIPathRoot()}api/fileglancer/proxied-path`,
       'POST',
       cookies['_xsrf'],
-      { mount_path: mountPath }
+      { fsp_mount_path: fspMountPath, path: path }
     );
     if (!response.ok) {
       throw new Error(


### PR DESCRIPTION
This leverages the newly extended proxy path API which is implemented in [ fileglancer-central PR#15](https://github.com/JaneliaSciComp/fileglancer-central/pull/15). 

These two PRs should be merged at the same time, and will require everyone to delete their `fileglancer.db`, because the database is changing. 

@StephanPreibisch 

