### PR TITLE
fix: toast configuration

### DIFF
--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -15,7 +15,13 @@ export const MainLayout = () => {
         <PreferencesProvider>
           <FileBrowserContextProvider>
             <ProxiedPathProvider>
-              <Toaster />
+              <Toaster
+                position="bottom-center"
+                toastOptions={{
+                  className: 'min-w-fit',
+                  success: { duration: 4000 }
+                }}
+              />
               <div className="flex flex-col items-center h-full w-full overflow-y-hidden bg-background text-foreground box-border">
                 <FileglancerNavbar />
                 <Outlet />


### PR DESCRIPTION
This is a quick PR that modifies the app-wide toast configuration to: 

- fit the message content width
- display longer for success messages (previously 0.2 s; now equal to error messages at 0.4 s)
- display at the bottom of the page (when testing the sharing, the toasts were blocking my access to the navbar briefly)

@krokicki @neomorphic @cgoina 