### PR TITLE
fix: class changes to ensure scrollbar in chrome

### DIFF
--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -48,7 +48,7 @@ export default function FavoritesBrowser({
       : folderFavorites;
 
   return (
-    <div className="w-[calc(100%-1.5rem)] min-h-fit flex flex-col overflow-hidden h-full mt-3 x-short:mt-1 mx-3 pb-1">
+    <div className="w-[calc(100%-1.5rem)] min-h-fit flex flex-col h-full x-short:mt-1 mt-3 mx-3 pb-1">
       <List className="bg-background !min-w-40">
         <List.Item
           onClick={() => toggleOpenFavorites('all')}
@@ -67,7 +67,7 @@ export default function FavoritesBrowser({
           </List.ItemEnd>
         </List.Item>
       </List>
-      <div className="overflow-y-auto">
+      <div className="overflow-y-auto max-h-[calc(100%-3.5rem)]">
         <Collapse open={openFavorites['all'] ? true : false}>
           <List className="bg-surface-light !py-0 !gap-0 !min-w-20 overflow-hidden">
             {/* Zone favorites */}


### PR DESCRIPTION
Removes `overflow-hidden` from the outer container and adds a max height to the inner container with the `overflow-y-auto` class. It seems Firefox will still allow scrolling on the inner child while the outer container has `overflow-hidden`, but Chrome will not.
@krokicki @neomorphic @cgoina 