### PR TITLE
Refactor file API

### DIFF
--- a/fileglancer/app.py
+++ b/fileglancer/app.py
@@ -1,7 +1,8 @@
 from jupyter_server.extension.application import ExtensionApp
 from fileglancer.handlers import (
     FileSharePathsHandler,
-    FileShareHandler,
+    FileMetadataHandler,
+    FileContentHandler,
     VersionHandler,
     StaticHandler,
     PreferencesHandler,
@@ -77,8 +78,9 @@ class Fileglancer(ExtensionApp):
         self.handlers.extend([
             (r"/api/fileglancer/file-share-paths", FileSharePathsHandler),
             (r"/api/fileglancer/proxied-path", ProxiedPathHandler),
-            (r"/api/fileglancer/files/(.*)", FileShareHandler),
-            (r"/api/fileglancer/files", FileShareHandler),
+            (r"/api/fileglancer/files/(.*)", FileMetadataHandler),
+            (r"/api/fileglancer/files", FileMetadataHandler),
+            (r"/api/fileglancer/content/(.*)", FileContentHandler),
             (r"/api/fileglancer/version", VersionHandler),
             (r"/api/fileglancer/preference", PreferencesHandler),
             (r"/api/fileglancer/profile", ProfileHandler),

--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -363,16 +363,16 @@ class ProxiedPathHandler(BaseHandler):
         """
         username = self.get_current_user()
         key = self.get_argument("sharing_key", None)
-        fsp_mount_path = self.get_argument("fsp_mount_path", None)
+        fsp_name = self.get_argument("fsp_name", None)
         path = self.get_argument("path", None)
         try:
             proxied_path_manager = get_proxiedpath_manager(self.settings)
             if key:
                 self.log.info(f"GET /api/fileglancer/proxied-path username={username} key={key}")
                 response = proxied_path_manager.get_proxied_path_by_key(username, key)
-            elif fsp_mount_path and path:
-                self.log.info(f"GET /api/fileglancer/proxied-path username={username} fsp_mount_path={fsp_mount_path} path={path}")
-                response = proxied_path_manager.get_proxied_paths(username, fsp_mount_path, path)
+            elif fsp_name and path:
+                self.log.info(f"GET /api/fileglancer/proxied-path username={username} fsp_name={fsp_name} path={path}")
+                response = proxied_path_manager.get_proxied_paths(username, fsp_name, path)
             else:
                 self.log.info(f"GET /api/fileglancer/proxied-path username={username}")
                 response = proxied_path_manager.get_proxied_paths(username)
@@ -403,20 +403,19 @@ class ProxiedPathHandler(BaseHandler):
         data = self.get_json_body()
         if data is None:
             self.set_status(400)
-            self.finish(json.dumps({"error": "JSON body with fsp_mount_path and path is required to create a proxied path"}))
+            self.finish(json.dumps({"error": "JSON body with fsp_name and path is required to create a proxied path"}))
             return
-        fsp_mount_path = data.get("fsp_mount_path", None)
+        fsp_name = data.get("fsp_name", None)
         path = data.get("path", None)
-        self.log.info(f"POST /api/fileglancer/proxied-path username={username} fsp_mount_path={fsp_mount_path} path={path}")
+        self.log.info(f"POST /api/fileglancer/proxied-path username={username} fsp_name={fsp_name} path={path}")
         try:
-            if fsp_mount_path is None or path is None:
-                self.log.warning("fsp_mount_path and path are required to create a proxied path")
+            if fsp_name is None or path is None:
+                self.log.warning("fsp and path are required to create a proxied path")
                 self.set_status(400)
-                self.finish(json.dumps({"error": "fsp_mount_path and path are required to create a proxied path"}))
+                self.finish(json.dumps({"error": "fsp_name and path are required to create a proxied path"}))
                 return
-
             proxied_path_manager = get_proxiedpath_manager(self.settings)
-            response = proxied_path_manager.create_proxied_path(username, fsp_mount_path, path)
+            response = proxied_path_manager.create_proxied_path(username, fsp_name, path)
             response.raise_for_status()
             rjson = response.json()
             self.set_status(201)
@@ -437,7 +436,7 @@ class ProxiedPathHandler(BaseHandler):
 
 
     @web.authenticated
-    def put(self):
+    def patch(self):
         """
         Update a shared path for the current user.
         """
@@ -448,23 +447,21 @@ class ProxiedPathHandler(BaseHandler):
             self.finish(json.dumps({"error": "JSON body is required to update a proxied path"}))
             return
         key = data.get("sharing_key", None)
-        fsp_mount_path = data.get("fsp_mount_path", None)
+        fsp_name = data.get("fsp_name", None)
         path = data.get("path", None)
         sharing_name = data.get("sharing_name", None)
         self.log.info((
-            "PUT /api/fileglancer/proxied-path "
-            f"username={username} key={key} "
-            f"fsp_mount_path={fsp_mount_path} path={path} sharing_name={sharing_name}"
+            "PATCH /api/fileglancer/proxied-path"
+            f"username={username} fsp_name={fsp_name} path={path} sharing_name={sharing_name}"
         ))
         try:
             if key is None:
-                self.log.warning("Key is required to update a proxied path")
+                self.log.warning("sharing_key is required to update a proxied path")
                 self.set_status(400)
-                self.finish(json.dumps({"error": "Key is required to update a proxied path"}))
+                self.finish(json.dumps({"error": "sharing_key is required to update a proxied path"}))
                 return
-
             proxied_path_manager = get_proxiedpath_manager(self.settings)
-            response = proxied_path_manager.update_proxied_path(username, key, fsp_mount_path, path, sharing_name)
+            response = proxied_path_manager.update_proxied_path(username, key, fsp_name, path, sharing_name)
             response.raise_for_status()
             self.set_status(200)
             self.finish(response.json())

--- a/fileglancer/proxiedpath.py
+++ b/fileglancer/proxiedpath.py
@@ -15,12 +15,12 @@ class ProxiedPathManager:
         self.central_url = central_url
         self._cached_proxied_paths = {}
 
-    def get_proxied_path_by_key(self, username: str, sharing_key: str) -> ProxiedPath:
+    def get_proxied_path_by_key(self, username: str, sharing_key: str) -> requests.Response:
         """Retrieve a proxied path by sharing key."""
         log.info(f"Retrieve proxied path {sharing_key} for user {username} from {self.central_url}")
         return requests.get(f"{self.central_url}/proxied-path/{username}/{sharing_key}")
 
-    def get_proxied_paths(self, username: str, fsp_mount_path: Optional[str] = None, path: Optional[str] = None) -> ProxiedPathResponse:
+    def get_proxied_paths(self, username: str, fsp_mount_path: Optional[str] = None, path: Optional[str] = None) -> requests.Response:
         """Retrieve user proxied paths, optionally filtered by fsp_mount_path and path."""
         log.info(f"Retrieve all proxied paths for user {username} from {self.central_url}")
         return requests.get(

--- a/fileglancer/proxiedpath.py
+++ b/fileglancer/proxiedpath.py
@@ -20,38 +20,32 @@ class ProxiedPathManager:
         log.info(f"Retrieve proxied path {sharing_key} for user {username} from {self.central_url}")
         return requests.get(f"{self.central_url}/proxied-path/{username}/{sharing_key}")
 
-    def get_proxied_paths(self, username: str, fsp_mount_path: Optional[str] = None, path: Optional[str] = None) -> requests.Response:
-        """Retrieve user proxied paths, optionally filtered by fsp_mount_path and path."""
+    def get_proxied_paths(self, username: str, fsp_name: Optional[str] = None, path: Optional[str] = None) -> requests.Response:
+        """Retrieve user proxied paths, optionally filtered by fsp_name and path."""
         log.info(f"Retrieve all proxied paths for user {username} from {self.central_url}")
         return requests.get(
             f"{self.central_url}/proxied-path/{username}", 
             params = {
-                "fsp_mount_path": fsp_mount_path,
+                "fsp_name": fsp_name,
                 "path": path
             }
         )
 
-    def create_proxied_path(self, username: str, fsp_mount_path: str, path: str) -> requests.Response:
-        """Create a proxied path for the given fsp_mount_path and path."""
+    def create_proxied_path(self, username: str, fsp_name: str, path: str) -> requests.Response:
+        """Create a proxied path for the given fsp_name and path."""
         return requests.post(
             f"{self.central_url}/proxied-path/{username}",
             params = {
-                "fsp_mount_path": fsp_mount_path,
+                "fsp_name": fsp_name,
                 "path": path
             }
         )
 
-    def delete_proxied_path(self, username: str, sharing_key: str) -> requests.Response:
-        """Delete a proxied path by sharing key."""
-        return requests.delete(
-            f"{self.central_url}/proxied-path/{username}/{sharing_key}"
-        )
-
-    def update_proxied_path(self, username: str, sharing_key: str, fsp_mount_path: Optional[str] = None, path: Optional[str] = None, new_name: Optional[str] = None) -> requests.Response:
-        """Update a proxied path with the given fsp_mount_path, path and sharing name."""
+    def update_proxied_path(self, username: str, sharing_key: str, fsp_name: Optional[str] = None, path: Optional[str] = None, new_name: Optional[str] = None) -> requests.Response:
+        """Update a proxied path with the given fsp_name, path and sharing name."""
         pp_updates = {}
-        if fsp_mount_path:
-            pp_updates["fsp_mount_path"] = fsp_mount_path
+        if fsp_name:
+            pp_updates["fsp_name"] = fsp_name
         if path:
             pp_updates["path"] = path
         if new_name:
@@ -59,6 +53,12 @@ class ProxiedPathManager:
         return requests.put(
             f"{self.central_url}/proxied-path/{username}/{sharing_key}",
             params = pp_updates
+        )
+
+    def delete_proxied_path(self, username: str, sharing_key: str) -> requests.Response:
+        """Delete a proxied path by sharing key."""
+        return requests.delete(
+            f"{self.central_url}/proxied-path/{username}/{sharing_key}"
         )
 
 

--- a/fileglancer/tests/test_localfilesharepaths.py
+++ b/fileglancer/tests/test_localfilesharepaths.py
@@ -3,9 +3,6 @@ import pytest
 
 from . import server_config_without_central_server
 
-"""
-"""
-
 @pytest.fixture
 def jp_server_config(server_config_without_central_server):
     return server_config_without_central_server

--- a/fileglancer/tests/test_proxiedpath.py
+++ b/fileglancer/tests/test_proxiedpath.py
@@ -128,16 +128,16 @@ async def test_delete_user_proxied_path_without_key(jp_fetch):
 @patch("fileglancer.handlers.ProxiedPathHandler.get_current_user", return_value=TEST_USER)
 async def test_post_user_proxied_path(test_current_user, jp_fetch, requests_mock):
     payload = {
-        "fsp_mount_path": "/test",
+        "fsp_name": "/test",
         "path": "path/to/data"
     }
-    requests_mock.post(f"{TEST_URL}?fsp_mount_path={payload['fsp_mount_path']}&path={payload['path']}",
+    requests_mock.post(f"{TEST_URL}?fsp_name={payload['fsp_name']}&path={payload['path']}",
                        status_code=201,
                        json={
                            "username": TEST_USER,
                            "sharing_key": "test_key",
                            "sharing_name": "test_name",
-                           "fsp_mount_path": payload["fsp_mount_path"],
+                           "fsp_name": payload["fsp_name"],
                            "path": payload["path"]
                        })
 
@@ -150,7 +150,7 @@ async def test_post_user_proxied_path(test_current_user, jp_fetch, requests_mock
     assert rj["username"] == TEST_USER
     assert rj["sharing_key"] == "test_key"
     assert rj["sharing_name"] == "test_name"
-    assert rj["fsp_mount_path"] == payload["fsp_mount_path"]
+    assert rj["fsp_name"] == payload["fsp_name"]
     assert rj["path"] == payload["path"]
     
 
@@ -158,10 +158,10 @@ async def test_post_user_proxied_path(test_current_user, jp_fetch, requests_mock
 async def test_post_user_proxied_path_exception(test_current_user, jp_fetch, requests_mock):
     try:
         payload = {
-            "fsp_mount_path": "/test",
+            "fsp_name": "/test",
             "path": "path/to/data"
         }
-        requests_mock.post(f"{TEST_URL}?fsp_mount_path={payload['fsp_mount_path']}&path={payload['path']}",
+        requests_mock.post(f"{TEST_URL}?fsp_name={payload['fsp_name']}&path={payload['path']}",
                         status_code=404,
                         json={
                             "error": "Some error"
@@ -188,29 +188,29 @@ async def test_post_user_proxied_path_without_mountpath(jp_fetch):
     except Exception as e:
         assert e.code == 400
         rj = json.loads(e.response.body)
-        assert rj["error"] == "fsp_mount_path and path are required to create a proxied path"
+        assert rj["error"] == "fsp_name and path are required to create a proxied path"
 
 
 @patch("fileglancer.handlers.ProxiedPathHandler.get_current_user", return_value=TEST_USER)
-async def test_put_user_proxied_path(test_current_user, jp_fetch, requests_mock):
+async def test_patch_user_proxied_path(test_current_user, jp_fetch, requests_mock):
     test_key = "test_key"
-    new_fsp_mount_path = "/test"
+    new_fsp_name = "test"
     new_path = "path/to/data"
     new_sharing_name = "newname"
-    requests_mock.put(f"{TEST_URL}/{test_key}?fsp_mount_path={new_fsp_mount_path}&path={new_path}&sharing_name={new_sharing_name}",
+    requests_mock.put(f"{TEST_URL}/{test_key}?fsp_name={new_fsp_name}&path={new_path}&sharing_name={new_sharing_name}",
                        status_code=200,
                        json={
                             "username": TEST_USER,
                             "sharing_key": test_key,
                             "sharing_name": new_sharing_name,
-                            "fsp_mount_path": new_fsp_mount_path,
+                            "fsp_name": new_fsp_name,
                             "path": new_path
                        })
 
     response = await jp_fetch("api", "fileglancer", "proxied-path",
-                              method="PUT",
+                              method="PATCH",
                               body=json.dumps({
-                                  "fsp_mount_path": new_fsp_mount_path,
+                                  "fsp_name": new_fsp_name,
                                   "path": new_path,
                                   "sharing_key": test_key,
                                   "sharing_name": new_sharing_name
@@ -221,27 +221,27 @@ async def test_put_user_proxied_path(test_current_user, jp_fetch, requests_mock)
     assert rj["username"] == TEST_USER
     assert rj["sharing_key"] == test_key
     assert rj["sharing_name"] == new_sharing_name
-    assert rj["fsp_mount_path"] == new_fsp_mount_path
+    assert rj["fsp_name"] == new_fsp_name
     assert rj["path"] == new_path
 
 
 @patch("fileglancer.handlers.ProxiedPathHandler.get_current_user", return_value=TEST_USER)
-async def test_put_user_proxied_path_exception(test_current_user, jp_fetch, requests_mock):
+async def test_patch_user_proxied_path_exception(test_current_user, jp_fetch, requests_mock):
     try:
         test_key = "test_key"
-        new_fsp_mount_path = "/test"
+        new_fsp_name = "test"
         new_path = "path/to/data"
         new_sharing_name = "newname"
-        requests_mock.put(f"{TEST_URL}/{test_key}?fsp_mount_path={new_fsp_mount_path}&path={new_path}&sharing_name={new_sharing_name}",
+        requests_mock.put(f"{TEST_URL}/{test_key}?fsp_name={new_fsp_name}&path={new_path}&sharing_name={new_sharing_name}",
                           status_code=404,
                           json={
                             "error": "Some error"
                           })
 
         await jp_fetch("api", "fileglancer", "proxied-path",
-                        method="PUT",
+                        method="PATCH",
                         body=json.dumps({
-                            "fsp_mount_path": new_fsp_mount_path,
+                            "fsp_name": new_fsp_name,
                             "path": new_path,
                             "sharing_key": test_key,
                             "sharing_name": new_sharing_name
@@ -254,14 +254,14 @@ async def test_put_user_proxied_path_exception(test_current_user, jp_fetch, requ
         assert rj["error"] == "Proxied path not found"
 
 
-async def test_post_user_proxied_path_without_sharingkey(jp_fetch):
+async def test_patch_user_proxied_path_without_sharingkey(jp_fetch):
     try:
         await jp_fetch("api", "fileglancer", "proxied-path",
-                       method="PUT",
+                       method="PATCH",
                        body=json.dumps({}), # empty payload
                        headers={"Content-Type": "application/json"})
         assert False, "Expected 400 error"
     except Exception as e:
         assert e.code == 400
         rj = json.loads(e.response.body)
-        assert rj["error"] == "Key is required to update a proxied path"
+        assert rj["error"] == "sharing_key is required to update a proxied path"

--- a/fileglancer/tests/test_proxiedpath.py
+++ b/fileglancer/tests/test_proxiedpath.py
@@ -74,7 +74,7 @@ async def test_get_user_proxied_path_when_key_not_present(test_current_user, jp_
     except Exception as e:
         assert e.code == 404
         rj = json.loads(e.response.body)
-        assert rj["error"] == "{\"error\": \"Proxied path not found\"}"
+        assert rj["error"] == "Proxied path not found"
 
 
 @patch("fileglancer.handlers.ProxiedPathHandler.get_current_user", return_value=TEST_INVALID_USER)
@@ -89,7 +89,7 @@ async def test_get_user_proxied_path_when_central_responds_with_404(test_current
     except Exception as e:
         assert e.code == 404
         rj = json.loads(e.response.body)
-        assert rj["error"] == "{\"error\": \"Returned an error\"}"
+        assert rj["error"] == "Proxied path not found"
 
 
 @patch("fileglancer.handlers.ProxiedPathHandler.get_current_user", return_value=TEST_USER)
@@ -112,7 +112,7 @@ async def test_delete_user_proxied_path_exception(test_current_user, jp_fetch, r
     except Exception as e:
         assert e.code == 404
         rj = json.loads(e.response.body)
-        assert rj["error"] == f"404 Client Error: None for url: {test_delete_url}"
+        assert rj["error"] == "Proxied path not found"
 
 
 async def test_delete_user_proxied_path_without_key(jp_fetch):
@@ -175,7 +175,7 @@ async def test_post_user_proxied_path_exception(test_current_user, jp_fetch, req
     except Exception as e:
         assert e.code == 404
         rj = json.loads(e.response.body)
-        assert rj["error"] == "{\"error\": \"Some error\"}"
+        assert rj["error"] == "Proxied path not found"
 
 
 async def test_post_user_proxied_path_without_mountpath(jp_fetch):
@@ -251,7 +251,7 @@ async def test_put_user_proxied_path_exception(test_current_user, jp_fetch, requ
     except Exception as e:
         assert e.code == 404
         rj = json.loads(e.response.body)
-        assert rj["error"] == "{\"error\": \"Some error\"}"
+        assert rj["error"] == "Proxied path not found"
 
 
 async def test_post_user_proxied_path_without_sharingkey(jp_fetch):

--- a/src/__tests__/pathHandling.test.ts
+++ b/src/__tests__/pathHandling.test.ts
@@ -30,7 +30,7 @@ describe('getFileFetchPath', () => {
   });
   test('handles parentOnly param', () => {
     expect(getFileFetchPath('fsp', 'file', true)).toBe(
-      '/api/fileglancer/files/fsp?subpath=file&cwd_only=true'
+      '/api/fileglancer/files/fsp?subpath=file'
     );
   });
   test('encodes filePath', () => {

--- a/src/__tests__/pathHandling.test.ts
+++ b/src/__tests__/pathHandling.test.ts
@@ -28,11 +28,6 @@ describe('getFileFetchPath', () => {
   test('handles empty string', () => {
     expect(getFileFetchPath('')).toBe('/api/fileglancer/files/');
   });
-  test('handles parentOnly param', () => {
-    expect(getFileFetchPath('fsp', 'file', true)).toBe(
-      '/api/fileglancer/files/fsp?subpath=file'
-    );
-  });
   test('encodes filePath', () => {
     expect(getFileFetchPath('fsp', 'a/b c')).toBe(
       '/api/fileglancer/files/fsp?subpath=a%2Fb%20c'

--- a/src/__tests__/pathHandling.test.ts
+++ b/src/__tests__/pathHandling.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import {
   joinPaths,
-  getFileFetchPath,
+  getFileBrowsePath,
   getLastSegmentFromPath,
   getPreferredPathForDisplay,
   makePathSegmentArray,
@@ -19,17 +19,17 @@ describe('joinPaths', () => {
   });
 });
 
-describe('getFileFetchPath', () => {
+describe('getFileBrowsePath', () => {
   test('returns correct API path for normal path', () => {
-    expect(getFileFetchPath('fsp_name', 'file.zarr')).toBe(
+    expect(getFileBrowsePath('fsp_name', 'file.zarr')).toBe(
       '/api/fileglancer/files/fsp_name?subpath=file.zarr'
     );
   });
   test('handles empty string', () => {
-    expect(getFileFetchPath('')).toBe('/api/fileglancer/files/');
+    expect(getFileBrowsePath('')).toBe('/api/fileglancer/files/');
   });
   test('encodes filePath', () => {
-    expect(getFileFetchPath('fsp', 'a/b c')).toBe(
+    expect(getFileBrowsePath('fsp', 'a/b c')).toBe(
       '/api/fileglancer/files/fsp?subpath=a%2Fb%20c'
     );
   });

--- a/src/components/ui/Dialogs/SharingDialog.tsx
+++ b/src/components/ui/Dialogs/SharingDialog.tsx
@@ -89,7 +89,7 @@ export default function SharingDialog({
                 onClick={async () => {
                   try {
                     const newProxiedPath = await createProxiedPath(
-                      currentFileSharePath?.mount_path || '',
+                      currentFileSharePath.name,
                       filePathWithoutFsp
                     );
                     if (newProxiedPath) {

--- a/src/components/ui/FileBrowser/Crumbs.tsx
+++ b/src/components/ui/FileBrowser/Crumbs.tsx
@@ -49,7 +49,7 @@ export default function Crumbs(): ReactNode {
                     }
                     await handleFileBrowserNavigation({
                       fspName: currentFileSharePath.name,
-                      path: joinPaths(...dirArray.slice(1, index))
+                      path: joinPaths(...dirArray.slice(1, index+1))
                     });
                   }}
                 >

--- a/src/components/ui/Sidebar/Folder.tsx
+++ b/src/components/ui/Sidebar/Folder.tsx
@@ -11,7 +11,7 @@ import { StarIcon as StarFilled } from '@heroicons/react/24/solid';
 
 import {
   makeMapKey,
-  getFileFetchPath,
+  getFileBrowsePath,
   sendFetchRequest,
   getLastSegmentFromPath,
   getPreferredPathForDisplay
@@ -55,7 +55,7 @@ export default function Folder({ folderFavorite, setOpenZones }: FolderProps) {
 
   async function checkFolderExists(folderFavorite: FolderFavorite) {
     try {
-      const fetchPath = getFileFetchPath(
+      const fetchPath = getFileBrowsePath(
         folderFavorite.fsp.name,
         folderFavorite.folderPath
       );

--- a/src/contexts/FileBrowserContext.tsx
+++ b/src/contexts/FileBrowserContext.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Zone, FileOrFolder, FileSharePath } from '@/shared.types';
-import { getFileFetchPath, sendFetchRequest } from '@/utils';
+import { getFileBrowsePath, sendFetchRequest } from '@/utils';
 import { useCookiesContext } from './CookiesContext';
 import { useZoneAndFspMapContext } from './ZonesAndFspMapContext';
 import { usePreferencesContext } from './PreferencesContext';
@@ -58,7 +58,7 @@ export const FileBrowserContextProvider = ({
 
   const updateCurrentFileOrFolder = React.useCallback(
     async ({ fspName, path }: { fspName: string; path?: string }) => {
-      const url = getFileFetchPath(fspName, path);
+      const url = getFileBrowsePath(fspName, path);
       try {
         const response = await sendFetchRequest(url, 'GET', cookies['_xsrf']);
         const data = await response.json();
@@ -79,8 +79,8 @@ export const FileBrowserContextProvider = ({
   const fetchAndFormatFilesForDisplay = React.useCallback(
     async ({ fspName, path }: { fspName: string; path?: string }) => {
       const url = path
-        ? getFileFetchPath(fspName, path)
-        : getFileFetchPath(fspName);
+        ? getFileBrowsePath(fspName, path)
+        : getFileBrowsePath(fspName);
 
       let data = [];
       try {

--- a/src/contexts/FileBrowserContext.tsx
+++ b/src/contexts/FileBrowserContext.tsx
@@ -58,12 +58,12 @@ export const FileBrowserContextProvider = ({
 
   const updateCurrentFileOrFolder = React.useCallback(
     async ({ fspName, path }: { fspName: string; path?: string }) => {
-      const url = getFileFetchPath(fspName, path, true);
+      const url = getFileFetchPath(fspName, path);
       try {
         const response = await sendFetchRequest(url, 'GET', cookies['_xsrf']);
         const data = await response.json();
         if (data) {
-          setCurrentFileOrFolder(data as FileOrFolder);
+          setCurrentFileOrFolder(data['info'] as FileOrFolder);
         }
       } catch (error: unknown) {
         if (error instanceof Error) {

--- a/src/contexts/ProxiedPathContext.tsx
+++ b/src/contexts/ProxiedPathContext.tsx
@@ -6,7 +6,7 @@ import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 const proxyBaseUrl = import.meta.env.VITE_PROXY_BASE_URL;
 
 type ProxiedPath = {
-  fsp_mount_path: string;
+  fsp_name: string;
   path: string;
   sharing_key: string;
   sharing_name: string;
@@ -17,7 +17,7 @@ type ProxiedPathContextType = {
   proxiedPath: ProxiedPath | null;
   dataUrl: string | null;
   createProxiedPath: (
-    fspMountPath: string,
+    fspName: string,
     path: string
   ) => Promise<ProxiedPath | null>;
   deleteProxiedPath: () => Promise<void>;
@@ -70,7 +70,7 @@ export const ProxiedPathProvider = ({
     }
     try {
       const response = await sendFetchRequest(
-        `/api/fileglancer/proxied-path?fsp_mount_path=${currentFileSharePath.mount_path}&path=${currentFileOrFolder.path}`,
+        `/api/fileglancer/proxied-path?fsp_name=${currentFileSharePath.name}&path=${currentFileOrFolder.path}`,
         'GET',
         cookies['_xsrf']
       );
@@ -91,12 +91,12 @@ export const ProxiedPathProvider = ({
   }, [cookies, currentFileSharePath, currentFileOrFolder]);
 
   const createProxiedPath = React.useCallback(
-    async (fspMountPath: string, path: string) => {
+    async (fspName: string, path: string) => {
       const response = await sendFetchRequest(
         '/api/fileglancer/proxied-path',
         'POST',
         cookies['_xsrf'],
-        { fsp_mount_path: fspMountPath, path: path }
+        { fsp_name: fspName, path: path }
       );
       if (!response.ok) {
         throw new Error(

--- a/src/hooks/useDeleteDialog.ts
+++ b/src/hooks/useDeleteDialog.ts
@@ -2,7 +2,7 @@ import toast from 'react-hot-toast';
 
 import type { FileOrFolder } from '@/shared.types';
 import {
-  getFileFetchPath,
+  getFileBrowsePath,
   sendFetchRequest,
   removeLastSegmentFromPath
 } from '@/utils';
@@ -20,7 +20,7 @@ export default function useDeleteDialog() {
       return false;
     }
 
-    const fetchPath = getFileFetchPath(
+    const fetchPath = getFileBrowsePath(
       currentFileSharePath.name,
       targetItem.path
     );

--- a/src/hooks/useNewFolderDialog.ts
+++ b/src/hooks/useNewFolderDialog.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 
 import {
-  getFileFetchPath,
+  getFileBrowsePath,
   sendFetchRequest,
   joinPaths,
   getPreferredPathForDisplay
@@ -30,7 +30,7 @@ export default function useNewFolderDialog() {
       throw new Error('No current file or folder selected.');
     }
     await sendFetchRequest(
-      getFileFetchPath(
+      getFileBrowsePath(
         currentFileSharePath.name,
         joinPaths(currentFileOrFolder.path, newName)
       ),

--- a/src/hooks/usePermissionsDialog.ts
+++ b/src/hooks/usePermissionsDialog.ts
@@ -4,7 +4,7 @@ import toast from 'react-hot-toast';
 import {
   sendFetchRequest,
   removeLastSegmentFromPath,
-  getFileFetchPath
+  getFileBrowsePath
 } from '@/utils';
 import { useCookiesContext } from '@/contexts/CookiesContext';
 import type { FileOrFolder } from '@/shared.types';
@@ -25,7 +25,7 @@ export default function usePermissionsDialog() {
       return;
     }
 
-    const fetchPath = getFileFetchPath(
+    const fetchPath = getFileBrowsePath(
       currentFileSharePath.name,
       targetItem.path
     );

--- a/src/hooks/useRenameDialog.ts
+++ b/src/hooks/useRenameDialog.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 
 import {
-  getFileFetchPath,
+  getFileBrowsePath,
   joinPaths,
   sendFetchRequest,
   removeLastSegmentFromPath,
@@ -30,7 +30,7 @@ export default function useRenameDialog() {
       throw new Error('No file share path selected.');
     }
     const newPath = joinPaths(removeLastSegmentFromPath(path), newName);
-    const fetchPath = getFileFetchPath(currentFileSharePath?.name, path);
+    const fetchPath = getFileBrowsePath(currentFileSharePath?.name, path);
     await sendFetchRequest(fetchPath, 'PATCH', cookies['_xsrf'], {
       path: newPath
     });

--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -411,6 +411,7 @@ async function getOmeZarrMetadata(
   maxThumbnailSize: number = 1024,
   autoBoost: boolean = true
 ): Promise<Metadata> {
+  console.log('Getting OME-Zarr metadata for', dataUrl);
   const store = new zarr.FetchStore(dataUrl);
   const { arr, shapes, multiscale, omero, scales, zarr_version } =
     await omezarr.getMultiscaleWithArray(store, 0);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 import {
   convertPathToWindowsStyle,
-  getFileFetchPath,
+  getFileContentPath,
+  getFileBrowsePath,
   getFileURL,
   getLastSegmentFromPath,
   getPreferredPathForDisplay,
@@ -114,7 +115,7 @@ async function fetchFileContent(
   path: string,
   cookies: Record<string, string>
 ): Promise<Uint8Array> {
-  const url = getFileFetchPath(fspName, path);
+  const url = getFileContentPath(fspName, path);
   const response = await sendFetchRequest(url, 'GET', cookies._xsrf);
   if (!response.ok) {
     throw new Error(`Failed to fetch file: ${response.statusText}`);
@@ -149,7 +150,7 @@ export {
   fetchFileContent,
   formatDate,
   formatFileSize,
-  getFileFetchPath,
+  getFileBrowsePath,
   getFileURL,
   getLastSegmentFromPath,
   getPreferredPathForDisplay,

--- a/src/utils/pathHandling.ts
+++ b/src/utils/pathHandling.ts
@@ -5,7 +5,7 @@ function joinPaths(...paths: string[]): string {
   return path.posix.join(...paths.map(path => path.trim()));
 }
 
-function getFileFetchPath(
+function getFileBrowsePath(
   fspName: string,
   filePath?: string
 ): string {
@@ -22,17 +22,32 @@ function getFileFetchPath(
   return fetchPath;
 }
 
+function getFileContentPath(
+  fspName: string,
+  filePath: string
+): string {
+  let fetchPath = joinPaths('/api/fileglancer/content/', fspName);
+
+  const params: string[] = [];
+  if (filePath) {
+    params.push(`subpath=${encodeURIComponent(filePath)}`);
+  }
+  if (params.length > 0) {
+    fetchPath += `?${params.join('&')}`;
+  }
+
+  return fetchPath;
+}
+
 function getFileURL(fspName: string, filePath?: string): string {
   let url = joinPaths(
     window.location.origin,
-    '/api/fileglancer/files/',
+    '/api/fileglancer/content/',
     fspName
   );
   if (!filePath) {
     return url;
   } else if (filePath) {
-    // Ensure the filePath is URL-encoded
-    filePath = encodeURIComponent(filePath);
     url = joinPaths(url, filePath);
   }
   return url;
@@ -74,7 +89,8 @@ function getPreferredPathForDisplay(
 
 export {
   convertPathToWindowsStyle,
-  getFileFetchPath,
+  getFileBrowsePath,
+  getFileContentPath,
   getFileURL,
   getLastSegmentFromPath,
   getPreferredPathForDisplay,

--- a/src/utils/pathHandling.ts
+++ b/src/utils/pathHandling.ts
@@ -18,7 +18,7 @@ function getFileFetchPath(
   }
   if (parentOnly) {
     // TODO: cwd_only is no longer supported, file info is always returned
-    params.push(`cwd_only=${parentOnly}`);
+    //params.push(`cwd_only=${parentOnly}`);
   }
   if (params.length > 0) {
     fetchPath += `?${params.join('&')}`;

--- a/src/utils/pathHandling.ts
+++ b/src/utils/pathHandling.ts
@@ -7,18 +7,13 @@ function joinPaths(...paths: string[]): string {
 
 function getFileFetchPath(
   fspName: string,
-  filePath?: string,
-  parentOnly?: boolean
+  filePath?: string
 ): string {
   let fetchPath = joinPaths('/api/fileglancer/files/', fspName);
 
   const params: string[] = [];
   if (filePath) {
     params.push(`subpath=${encodeURIComponent(filePath)}`);
-  }
-  if (parentOnly) {
-    // TODO: cwd_only is no longer supported, file info is always returned
-    //params.push(`cwd_only=${parentOnly}`);
   }
   if (params.length > 0) {
     fetchPath += `?${params.join('&')}`;

--- a/src/utils/pathHandling.ts
+++ b/src/utils/pathHandling.ts
@@ -17,6 +17,7 @@ function getFileFetchPath(
     params.push(`subpath=${encodeURIComponent(filePath)}`);
   }
   if (parentOnly) {
+    // TODO: cwd_only is no longer supported, file info is always returned
     params.push(`cwd_only=${parentOnly}`);
   }
   if (params.length > 0) {


### PR DESCRIPTION
As discussed, I moved the file content retrieval to a new endpoint at `/api/fileglancer/content/`, and changed `/api/fileglancer/files/` to always return metadata about the requested path. 

When the requested subpath is a directory you get:
```
{
    info:{...}, 
    files:[]
}
```
When it's a file, you just get the `info`. 

I also deleted some unused code (CORS, etc.) and moved some things around to clean up the ordering of methods (this unfortunately results in a messy diff). 

@StephanPreibisch @neomorphic 