### PR TITLE
fix: sets /fg/ as the vite base.

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '',
+  base: '/fg/',
   plugins: [react(), nodePolyfills({ include: ['path'] })],
   resolve: {
     alias: {


### PR DESCRIPTION
The default setting for a vite build is to use the '' base. This
produces relative links to the assets folder in the index.html, at build
time. This causes an issue when using urls that are more than one level
deep and the backend always serves up the index.html file for any
request. Setting the value to /fg/ means that we will always send asset
requests to the top level /fg/ directory, no mater what url is
requested.
