### PR TITLE
Fix shared context menu

### DIFF
--- a/src/components/ui/FileBrowser/ContextMenu.tsx
+++ b/src/components/ui/FileBrowser/ContextMenu.tsx
@@ -41,8 +41,8 @@ export default function ContextMenu({
         top: `${y}px`
       }}
     >
-        <Menu.Item>
-          {/* Show/hide properties drawer */}
+      <Menu.Item>
+        {/* Show/hide properties drawer */}
         <Typography
           className="text-sm p-1 cursor-pointer text-secondary-light"
           onClick={() => {
@@ -52,10 +52,10 @@ export default function ContextMenu({
         >
           View file properties
         </Typography>
-        </Menu.Item>
-        {/* Set/unset folders as favorites */}
-        {selectedFiles.length === 1 && selectedFiles[0].is_dir ? (
-          <Menu.Item>
+      </Menu.Item>
+      {/* Set/unset folders as favorites */}
+      {selectedFiles.length === 1 && selectedFiles[0].is_dir ? (
+        <Menu.Item>
           <Typography
             className="text-sm p-1 cursor-pointer text-secondary-light"
             onClick={() => {
@@ -74,11 +74,11 @@ export default function ContextMenu({
           >
             Set/unset as favorite
           </Typography>
-          </Menu.Item>
-        ) : null}
-        {/* Rename file or folder */}
-        {selectedFiles.length === 1 ? (
-          <Menu.Item>
+        </Menu.Item>
+      ) : null}
+      {/* Rename file or folder */}
+      {selectedFiles.length === 1 ? (
+        <Menu.Item>
           <Typography
             onClick={() => {
               setShowRenameDialog(true);
@@ -88,11 +88,11 @@ export default function ContextMenu({
           >
             Rename
           </Typography>
-          </Menu.Item>
-        ) : null}
-        {/* Change permissions on file(s) */}
-        {selectedFiles.length === 1 && !selectedFiles[0].is_dir ? (
-          <Menu.Item>
+        </Menu.Item>
+      ) : null}
+      {/* Change permissions on file(s) */}
+      {selectedFiles.length === 1 && !selectedFiles[0].is_dir ? (
+        <Menu.Item>
           <Typography
             className="text-sm p-1 cursor-pointer text-secondary-light"
             onClick={() => {
@@ -102,10 +102,10 @@ export default function ContextMenu({
           >
             Change permissions
           </Typography>
-          </Menu.Item>
-        ) : null}
-        {/* Delete file(s) or folder(s) */}
-        <Menu.Item>
+        </Menu.Item>
+      ) : null}
+      {/* Delete file(s) or folder(s) */}
+      <Menu.Item>
         <Typography
           className="text-sm p-1 cursor-pointer text-red-600"
           onClick={() => {
@@ -115,7 +115,7 @@ export default function ContextMenu({
         >
           Delete
         </Typography>
-        </Menu.Item>
+      </Menu.Item>
     </div>,
 
     document.body // Render context menu directly to body

--- a/src/components/ui/FileBrowser/ContextMenu.tsx
+++ b/src/components/ui/FileBrowser/ContextMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Typography } from '@material-tailwind/react';
+import { Menu, Typography } from '@material-tailwind/react';
 
 import type { FileOrFolder } from '@/shared.types';
 import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
@@ -35,16 +35,16 @@ export default function ContextMenu({
   return ReactDOM.createPortal(
     <div
       ref={menuRef}
-      className="fixed z-[9999] bg-background shadow-lg shadow-surface rounded-md p-2"
+      className="fixed z-[9999] min-w-40 rounded-lg space-y-0.5 border border-surface bg-background p-1"
       style={{
         left: `${x}px`,
         top: `${y}px`
       }}
     >
-      <div className="flex flex-col gap-2">
-        {/* Show/hide properties drawer */}
+        <Menu.Item>
+          {/* Show/hide properties drawer */}
         <Typography
-          className="text-sm p-1 cursor-pointer text-secondary-light hover:bg-secondary-light/30 transition-colors whitespace-nowrap"
+          className="text-sm p-1 cursor-pointer text-secondary-light"
           onClick={() => {
             setShowPropertiesDrawer(true);
             setShowContextMenu(false);
@@ -52,10 +52,12 @@ export default function ContextMenu({
         >
           View file properties
         </Typography>
+        </Menu.Item>
         {/* Set/unset folders as favorites */}
         {selectedFiles.length === 1 && selectedFiles[0].is_dir ? (
+          <Menu.Item>
           <Typography
-            className="text-sm p-1 cursor-pointer text-secondary-light hover:bg-secondary-light/30 transition-colors whitespace-nowrap"
+            className="text-sm p-1 cursor-pointer text-secondary-light"
             onClick={() => {
               if (currentFileSharePath) {
                 handleFavoriteChange(
@@ -72,23 +74,27 @@ export default function ContextMenu({
           >
             Set/unset as favorite
           </Typography>
+          </Menu.Item>
         ) : null}
         {/* Rename file or folder */}
         {selectedFiles.length === 1 ? (
+          <Menu.Item>
           <Typography
             onClick={() => {
               setShowRenameDialog(true);
               setShowContextMenu(false);
             }}
-            className="text-left text-sm p-1 cursor-pointer text-secondary-light hover:bg-secondary-light/30 transition-colors whitespace-nowrap"
+            className="text-left text-sm p-1 cursor-pointer text-secondary-light"
           >
             Rename
           </Typography>
+          </Menu.Item>
         ) : null}
         {/* Change permissions on file(s) */}
         {selectedFiles.length === 1 && !selectedFiles[0].is_dir ? (
+          <Menu.Item>
           <Typography
-            className="text-sm p-1 cursor-pointer text-secondary-light hover:bg-secondary-light/30 transition-colors whitespace-nowrap"
+            className="text-sm p-1 cursor-pointer text-secondary-light"
             onClick={() => {
               setShowPermissionsDialog(true);
               setShowContextMenu(false);
@@ -96,10 +102,12 @@ export default function ContextMenu({
           >
             Change permissions
           </Typography>
+          </Menu.Item>
         ) : null}
         {/* Delete file(s) or folder(s) */}
+        <Menu.Item>
         <Typography
-          className="text-sm p-1 cursor-pointer text-secondary-light hover:bg-secondary-light/30 transition-colors whitespace-nowrap"
+          className="text-sm p-1 cursor-pointer text-red-600"
           onClick={() => {
             setShowDeleteDialog(true);
             setShowContextMenu(false);
@@ -107,7 +115,7 @@ export default function ContextMenu({
         >
           Delete
         </Typography>
-      </div>
+        </Menu.Item>
     </div>,
 
     document.body // Render context menu directly to body

--- a/src/components/ui/FileBrowser/FileRow.tsx
+++ b/src/components/ui/FileBrowser/FileRow.tsx
@@ -2,9 +2,9 @@ import React, { ReactNode } from 'react';
 import { IconButton, Tooltip, Typography } from '@material-tailwind/react';
 import {
   DocumentIcon,
-  EllipsisHorizontalCircleIcon,
   FolderIcon
 } from '@heroicons/react/24/outline';
+import { HiOutlineEllipsisHorizontalCircle } from "react-icons/hi2";
 import toast from 'react-hot-toast';
 
 import type { FileOrFolder } from '@/shared.types';
@@ -190,7 +190,7 @@ export default function FileRow({
         }}
       >
         <IconButton variant="ghost">
-          <EllipsisHorizontalCircleIcon className="icon-default text-foreground" />
+          <HiOutlineEllipsisHorizontalCircle className="icon-default text-foreground" />
         </IconButton>
       </div>
     </div>

--- a/src/components/ui/FileBrowser/FileRow.tsx
+++ b/src/components/ui/FileBrowser/FileRow.tsx
@@ -1,10 +1,7 @@
 import React, { ReactNode } from 'react';
 import { IconButton, Tooltip, Typography } from '@material-tailwind/react';
-import {
-  DocumentIcon,
-  FolderIcon
-} from '@heroicons/react/24/outline';
-import { HiOutlineEllipsisHorizontalCircle } from "react-icons/hi2";
+import { DocumentIcon, FolderIcon } from '@heroicons/react/24/outline';
+import { HiOutlineEllipsisHorizontalCircle } from 'react-icons/hi2';
 import toast from 'react-hot-toast';
 
 import type { FileOrFolder } from '@/shared.types';

--- a/src/components/ui/Shared/ProxiedPathRow.tsx
+++ b/src/components/ui/Shared/ProxiedPathRow.tsx
@@ -1,12 +1,10 @@
 import {
-  ButtonGroup,
   IconButton,
   Menu,
   Tooltip,
   Typography
 } from '@material-tailwind/react';
-import { HiEllipsisHorizontal } from 'react-icons/hi2';
-import { TbShareOff } from 'react-icons/tb';
+import { HiOutlineEllipsisHorizontalCircle } from "react-icons/hi2";
 import log from 'loglevel';
 import toast from 'react-hot-toast';
 
@@ -115,13 +113,13 @@ export default function ProxiedPathRow({
         </Tooltip>
         {/* Actions */}
         <Menu>
-          <Menu.Trigger as={IconButton}>
-            <HiEllipsisHorizontal className="icon-default" />
+          <Menu.Trigger as={IconButton} variant="ghost" className="p-1 max-w-fit">
+            <HiOutlineEllipsisHorizontalCircle className="icon-default text-foreground" />
           </Menu.Trigger>
-          <Menu.Content>
-            <Menu.Item>
+          <Menu.Content className="menu-content">
+            <Menu.Item className="menu-item">
               <Typography
-                className="flex items-center gap-2 text-sm p-1 cursor-pointer text-secondary-light hover:bg-secondary-light/30 transition-colors whitespace-nowrap"
+                className="text-sm p-1 cursor-pointer text-secondary-light"
                 onClick={handleCopyUrl}
               >
                 Copy sharing URL
@@ -129,7 +127,7 @@ export default function ProxiedPathRow({
             </Menu.Item>
             <Menu.Item>
               <Typography
-                className="flex items-center gap-2 text-sm p-1 cursor-pointer text-red-600 hover:bg-red-50 transition-colors whitespace-nowrap"
+                className="text-sm p-1 cursor-pointer text-red-600"
                 onClick={() => {
                   setCurrentFileSharePath(pathFsp);
                   setShowSharingDialog(true);
@@ -140,51 +138,6 @@ export default function ProxiedPathRow({
             </Menu.Item>
           </Menu.Content>
         </Menu>
-        {/* Context menu
-
-          <div className="flex justify-center relative">
-            <Tooltip>
-              <Tooltip.Trigger
-                as={IconButton}
-                variant="outline"
-                onClick={() =>
-                  setMenuOpenId(
-                    menuOpenId === item.sharing_key ? null : item.sharing_key
-                  )
-                }
-              >
-                <Tooltip.Content className="px-2.5 py-1.5 text-primary-foreground">
-                  <Typography type="small" className="opacity-90">
-                    More actions
-                  </Typography>
-                  <Tooltip.Arrow />
-                </Tooltip.Content>
-              </Tooltip.Trigger>
-            </Tooltip>
-            {menuOpenId === item.sharing_key ? (
-              <div className="absolute z-10 right-0 top-8 bg-background shadow-lg shadow-surface rounded-md p-2 min-w-[180px] border border-surface">
-                <div className="flex flex-col gap-2">
-                  <Typography
-                    className="flex items-center gap-2 text-sm p-1 cursor-pointer text-secondary-light hover:bg-secondary-light/30 transition-colors whitespace-nowrap"
-                    onClick={handleCopyUrl}
-                  >
-                    Copy sharing URL
-                  </Typography>
-                  <Typography
-                    className="flex items-center gap-2 text-sm p-1 cursor-pointer text-red-600 hover:bg-red-50 transition-colors whitespace-nowrap"
-                    onClick={() => {
-                      setCurrentFileSharePath(pathFsp);
-                      setShowSharingDialog(true);
-                    }}
-                  >
-                    Unshare
-                  </Typography>
-                </div>
-              </div>
-            ) : null}
-          </div>
-        </ButtonGroup>
-      */}
       </div>
       {/* Sharing dialog */}
       {showSharingDialog ? (

--- a/src/components/ui/Shared/ProxiedPathRow.tsx
+++ b/src/components/ui/Shared/ProxiedPathRow.tsx
@@ -4,7 +4,7 @@ import {
   Tooltip,
   Typography
 } from '@material-tailwind/react';
-import { HiOutlineEllipsisHorizontalCircle } from "react-icons/hi2";
+import { HiOutlineEllipsisHorizontalCircle } from 'react-icons/hi2';
 import log from 'loglevel';
 import toast from 'react-hot-toast';
 
@@ -113,7 +113,11 @@ export default function ProxiedPathRow({
         </Tooltip>
         {/* Actions */}
         <Menu>
-          <Menu.Trigger as={IconButton} variant="ghost" className="p-1 max-w-fit">
+          <Menu.Trigger
+            as={IconButton}
+            variant="ghost"
+            className="p-1 max-w-fit"
+          >
             <HiOutlineEllipsisHorizontalCircle className="icon-default text-foreground" />
           </Menu.Trigger>
           <Menu.Content className="menu-content">

--- a/src/components/ui/Shared/ProxiedPathRow.tsx
+++ b/src/components/ui/Shared/ProxiedPathRow.tsx
@@ -1,10 +1,11 @@
 import {
   ButtonGroup,
   IconButton,
+  Menu,
   Tooltip,
   Typography
 } from '@material-tailwind/react';
-import { HiEllipsisHorizontal } from "react-icons/hi2";
+import { HiEllipsisHorizontal } from 'react-icons/hi2';
 import { TbShareOff } from 'react-icons/tb';
 import log from 'loglevel';
 import toast from 'react-hot-toast';
@@ -113,40 +114,45 @@ export default function ProxiedPathRow({
           <Tooltip.Content>{formatDateString(item.created_at)}</Tooltip.Content>
         </Tooltip>
         {/* Actions */}
-        <ButtonGroup className="gap-1">
-          {/* Unshare button */}
-          <Tooltip>
-            <Tooltip.Trigger
-            as={IconButton}
-            variant="outline"
-            className='!rounded-md'
-            onClick={() => {
-              setCurrentFileSharePath(pathFsp);
-              setShowSharingDialog(true);
-            }}
-            >
-            <TbShareOff className='icon-default'/>
-            <Tooltip.Content className="px-2.5 py-1.5 text-primary-foreground">
-              <Typography type="small" className="opacity-90">
+        <Menu>
+          <Menu.Trigger as={IconButton}>
+            <HiEllipsisHorizontal className="icon-default" />
+          </Menu.Trigger>
+          <Menu.Content>
+            <Menu.Item>
+              <Typography
+                className="flex items-center gap-2 text-sm p-1 cursor-pointer text-secondary-light hover:bg-secondary-light/30 transition-colors whitespace-nowrap"
+                onClick={handleCopyUrl}
+              >
+                Copy sharing URL
+              </Typography>
+            </Menu.Item>
+            <Menu.Item>
+              <Typography
+                className="flex items-center gap-2 text-sm p-1 cursor-pointer text-red-600 hover:bg-red-50 transition-colors whitespace-nowrap"
+                onClick={() => {
+                  setCurrentFileSharePath(pathFsp);
+                  setShowSharingDialog(true);
+                }}
+              >
                 Unshare
               </Typography>
-              <Tooltip.Arrow />
-            </Tooltip.Content>
-            </Tooltip.Trigger>
-          </Tooltip>
-            {/* Context menu */}
+            </Menu.Item>
+          </Menu.Content>
+        </Menu>
+        {/* Context menu
 
           <div className="flex justify-center relative">
             <Tooltip>
               <Tooltip.Trigger
-              as={IconButton}
-              variant="outline"
-              onClick={() =>
-                setMenuOpenId(
-                  menuOpenId === item.sharing_key ? null : item.sharing_key
-                )
-              }>
-                <HiEllipsisHorizontal className="icon-default" />
+                as={IconButton}
+                variant="outline"
+                onClick={() =>
+                  setMenuOpenId(
+                    menuOpenId === item.sharing_key ? null : item.sharing_key
+                  )
+                }
+              >
                 <Tooltip.Content className="px-2.5 py-1.5 text-primary-foreground">
                   <Typography type="small" className="opacity-90">
                     More actions
@@ -178,6 +184,7 @@ export default function ProxiedPathRow({
             ) : null}
           </div>
         </ButtonGroup>
+      */}
       </div>
       {/* Sharing dialog */}
       {showSharingDialog ? (


### PR DESCRIPTION
- Removes the "unshare" button on the Shared page
- Changes the "actions" icon on the Shared page to match the Browse page
- Switches to using the Material Tailwind `Menu` component on the Shared page
- Uses the Material Tailwind `Menu.Item` component, instead of styling that mimics it, for the items inside the context menu on the Browse page
- Adjusts the styling of the div that holds the context menu on the Browse page to use styles copied from the Material Tailwind `Menu` component