### PR TITLE
Clicking folder favorite doesn't open zones

### DIFF
--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -142,7 +142,7 @@ class FileContentHandler(FileShareHandler):
                 self.write(chunk)
             self.finish()
         except FileNotFoundError:
-            self.log.error(f"File or directory not found: {subpath}")
+            self.log.error(f"File not found in {filestore_name}: {subpath}")
             self.set_status(404)
             self.finish(json.dumps({"error": "File or directory not found"}))
         except PermissionError:

--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -97,7 +97,6 @@ export default function FavoritesBrowser({
               <Folder
                 key={folderFavorite.fsp.name + '-' + folderFavorite.folderPath}
                 folderFavorite={folderFavorite}
-                setOpenZones={setOpenZones}
               />
             );
           })}

--- a/src/components/ui/Sidebar/Folder.tsx
+++ b/src/components/ui/Sidebar/Folder.tsx
@@ -28,10 +28,9 @@ import {
 
 type FolderProps = {
   folderFavorite: FolderFavorite;
-  setOpenZones: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
 };
 
-export default function Folder({ folderFavorite, setOpenZones }: FolderProps) {
+export default function Folder({ folderFavorite }: FolderProps) {
   const [showMissingFolderFavoriteDialog, setShowMissingFolderFavoriteDialog] =
     React.useState(false);
   const { handleFileBrowserNavigation, setCurrentFileSharePath } =
@@ -85,10 +84,6 @@ export default function Folder({ folderFavorite, setOpenZones }: FolderProps) {
             log.error('Error checking folder existence:', error);
           }
           if (folderExists) {
-            setOpenZones({
-              all: true,
-              [folderFavorite.fsp.zone]: true
-            });
             setCurrentFileSharePath(folderFavorite.fsp);
             await handleFileBrowserNavigation({
               fspName: folderFavorite.fsp.name,


### PR DESCRIPTION
When clicking on a folder favorite, the zones area would open if it was closed. I removed the code to stop this from happening, which I _think_ is vestigial code, but @allison-truhlar please let me know if there's any concerns.

@StephanPreibisch @neomorphic 