### PR TITLE
fix: use URL constructor to ensure // after protocol

### DIFF
--- a/src/utils/pathHandling.ts
+++ b/src/utils/pathHandling.ts
@@ -72,10 +72,7 @@ function getFileURL(fspName: string, filePath?: string): string {
   const fspPath = joinPaths('/api/fileglancer/content/', fspName);
   const apiPath = getFullPath(fspPath);
   const apiFilePath = filePath ? joinPaths(apiPath, filePath) : apiPath;
-  return joinPaths(
-    window.location.origin,
-    apiFilePath
-  );
+  return new URL(apiFilePath, window.location.origin).href;
 }
 
 /**
@@ -147,7 +144,7 @@ function getPreferredPathForDisplay(
  * // Returns 'http://localhost:8888/proxy/key123/shared-folder'
  */
 function makeProxiedPathUrl(item: ProxiedPath): string {
-  return joinPaths(PROXY_BASE_URL, item.sharing_key, item.sharing_name);
+  return new URL(joinPaths(item.sharing_key, item.sharing_name), PROXY_BASE_URL).href;
 }
 
 export {


### PR DESCRIPTION
@krokicki @neomorphic 
The `joinPaths` method was replacing the `//` with `/'. The `path.join` method in NodeJS first joins the path segments and then normalizes them - any double slashes are replaced with a single slash. Using the URL constructor maintains the double slash, plus these are URLs we're forming so it's probably better practice.