### PR TITLE
Use external URL from ProxiedPath

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-# Environment variables for Fileglancer
-# Copy this file to .env.local and set your actual values
-
-# Base URL for the file proxy service
-VITE_PROXY_BASE_URL=https://your-proxy-server.example.com:7878/files

--- a/fileglancer/proxiedpath.py
+++ b/fileglancer/proxiedpath.py
@@ -4,8 +4,6 @@ import logging
 from typing import Optional
 from functools import cache
 
-from fileglancer.uimodels import ProxiedPath, ProxiedPathResponse
-
 log = logging.getLogger(__name__)
 
 class ProxiedPathManager:

--- a/fileglancer/uimodels.py
+++ b/fileglancer/uimodels.py
@@ -37,25 +37,3 @@ class FileSharePath(BaseModel):
         description="The path used to mount the file share on Linux (e.g. /unix/style/path)",
         default=None
     )
-
-
-class ProxiedPath(BaseModel):
-    """A proxied path which is used to share a file system path via a URL"""
-    username: str = Field(
-        description="The username of the user who owns this proxied path"
-    )
-    sharing_key: str = Field(
-        description="The sharing key is part of the URL proxy path. It is used to uniquely identify the proxied path."
-    )
-    sharing_name: str = Field(
-        description="The sharing path is part of the URL proxy path. It is mainly used to provide file extension information to the client."
-    )
-    mount_path: str = Field(
-        description="The root path on the file system to be proxied"
-    )
-
-
-class ProxiedPathResponse(BaseModel):
-    paths: list[ProxiedPath] = Field(
-        description="A list of proxied paths"
-    )

--- a/src/__tests__/pathHandling.test.ts
+++ b/src/__tests__/pathHandling.test.ts
@@ -6,7 +6,6 @@ import {
   getLastSegmentFromPath,
   getPreferredPathForDisplay,
   makePathSegmentArray,
-  makeProxiedPathUrl,
   removeLastSegmentFromPath
 } from '@/utils';
 import type { FileSharePath } from '@/shared.types';
@@ -75,27 +74,6 @@ describe('getLastSegmentFromPath', () => {
 describe('makePathSegmentArray', () => {
   test('splits POSIX-style path into segments', () => {
     expect(makePathSegmentArray('/a/b/c')).toEqual(['', 'a', 'b', 'c']);
-  });
-});
-
-describe('makeProxiedPathUrl', () => {
-  test('returns correctly formatted URL', () => {
-    const mockProxiedPath = {
-      fsp_name: 'file-share-path',
-      path: 'file.zarr',
-      sharing_key: '12345',
-      sharing_name: 'shared-file',
-      created_at: '2025-06-01T12:00:00Z',
-      updated_at: '2025-06-02T12:00:00Z',
-      username: 'test_user'
-    } as ProxiedPath;
-
-    expect(
-      makeProxiedPathUrl(
-        mockProxiedPath,
-        'https://fileglancer-int.janelia.org/files'
-      )
-    ).toBe('https://fileglancer-int.janelia.org/files/12345/shared-file');
   });
 });
 

--- a/src/components/ui/Shared/ProxiedPathRow.tsx
+++ b/src/components/ui/Shared/ProxiedPathRow.tsx
@@ -12,8 +12,7 @@ import SharingDialog from '@/components/ui/Dialogs/SharingDialog';
 import type { FileSharePath } from '@/shared.types';
 import {
   getPreferredPathForDisplay,
-  makeMapKey,
-  makeProxiedPathUrl
+  makeMapKey
 } from '@/utils';
 import useSharingDialog from '@/hooks/useSharingDialog';
 import useCopyPath from '@/hooks/useCopyPath';
@@ -57,7 +56,7 @@ export default function ProxiedPathRow({
     pathFsp,
     item.path
   );
-  const proxiedPathUrl = makeProxiedPathUrl(item);
+
 
   const handleCopyPath = async () => {
     try {
@@ -71,7 +70,7 @@ export default function ProxiedPathRow({
 
   const handleCopyUrl = async () => {
     try {
-      await copyToClipboard(proxiedPathUrl);
+      await copyToClipboard(item.url);
       toast.success('URL copied to clipboard');
     } catch (error) {
       log.error('Failed to copy sharing URL:', error);

--- a/src/contexts/ProxiedPathContext.tsx
+++ b/src/contexts/ProxiedPathContext.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { default as log } from '@/logger';
 import { useCookiesContext } from '@/contexts/CookiesContext';
-import { sendFetchRequest, makeProxiedPathUrl } from '@/utils';
+import { sendFetchRequest } from '@/utils';
 import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 
 export type ProxiedPath = {
-  fsp_name: string;
-  path: string;
+  username: string;
   sharing_key: string;
   sharing_name: string;
+  path: string;
+  fsp_name: string;
   created_at: string;
   updated_at: string;
-  username: string;
+  url: string;
 };
 
 type ProxiedPathContextType = {
@@ -65,7 +66,7 @@ export const ProxiedPathProvider = ({
     (proxiedPath: ProxiedPath | null) => {
       setProxiedPath(proxiedPath);
       if (proxiedPath) {
-        setDataUrl(makeProxiedPathUrl(proxiedPath));
+        setDataUrl(proxiedPath.url);
       } else {
         setDataUrl(null);
       }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,7 +8,6 @@ import {
   joinPaths,
   makeBrowseLink,
   makePathSegmentArray,
-  makeProxiedPathUrl,
   removeLastSegmentFromPath
 } from './pathHandling';
 
@@ -144,7 +143,6 @@ export {
   makeBrowseLink,
   makeMapKey,
   makePathSegmentArray,
-  makeProxiedPathUrl,
   parsePermissions,
   removeLastSegmentFromPath,
   sendFetchRequest

--- a/src/utils/pathHandling.ts
+++ b/src/utils/pathHandling.ts
@@ -4,10 +4,6 @@ import type { FileSharePath } from '@/shared.types';
 import type { ProxiedPath } from '@/contexts/ProxiedPathContext';
 
 const PATH_DELIMITER = '/';
-const PROXY_BASE_URL = import.meta.env.VITE_PROXY_BASE_URL;
-if (!PROXY_BASE_URL) {
-  log.warn('VITE_PROXY_BASE_URL is not defined in the environment.');
-}
 
 /**
  * Joins multiple path segments into a single POSIX-style path, trimming any whitespace first.
@@ -174,25 +170,6 @@ function getPreferredPathForDisplay(
 }
 
 /**
- * Constructs a shareable URL for a proxied path item.
- * Optional override for the proxy base URL; defaults to VITE_PROXY_BASE_URL env variable.
- * Example:
- * makeProxiedPathUrl({ sharing_key: 'key123', sharing_name: 'shared-folder' });
- * // Returns 'http://localhost:8888/proxy/key123/shared-folder'
- */
-function makeProxiedPathUrl(
-  item: ProxiedPath,
-  proxyBaseUrl: string = PROXY_BASE_URL
-): string {
-  // Ensure the base URL ends with a slash for proper path joining
-  const baseWithSlash = proxyBaseUrl.endsWith('/')
-    ? proxyBaseUrl
-    : `${proxyBaseUrl}/`;
-  return new URL(joinPaths(item.sharing_key, item.sharing_name), baseWithSlash)
-    .href;
-}
-
-/**
  * Constructs a browse link for a file share path.
  * If filePath is provided, appends it to the base path.
  * Example:
@@ -221,6 +198,5 @@ export {
   joinPaths,
   makeBrowseLink,
   makePathSegmentArray,
-  makeProxiedPathUrl,
   removeLastSegmentFromPath
 };


### PR DESCRIPTION
Since [fileglancer-central#17](https://github.com/JaneliaSciComp/fileglancer-central/pull/17) is now returning a URL with each proxied path, we can use that and don't need to construct it in the client. 

@StephanPreibisch @neomorphic 