### PR TITLE
Link from Shared to Browse

### DIFF
--- a/src/components/ui/Shared/ProxiedPathRow.tsx
+++ b/src/components/ui/Shared/ProxiedPathRow.tsx
@@ -5,6 +5,7 @@ import {
   Typography
 } from '@material-tailwind/react';
 import { HiOutlineEllipsisHorizontalCircle } from 'react-icons/hi2';
+import { useNavigate } from 'react-router';
 import log from 'loglevel';
 import toast from 'react-hot-toast';
 
@@ -12,7 +13,8 @@ import SharingDialog from '@/components/ui/Dialogs/SharingDialog';
 import type { FileSharePath } from '@/shared.types';
 import {
   getPreferredPathForDisplay,
-  makeMapKey
+  makeMapKey,
+  makeBrowseLink
 } from '@/utils';
 import useSharingDialog from '@/hooks/useSharingDialog';
 import useCopyPath from '@/hooks/useCopyPath';
@@ -47,6 +49,7 @@ export default function ProxiedPathRow({
   const { pathPreference } = usePreferencesContext();
   const { zonesAndFileSharePathsMap } = useZoneAndFspMapContext();
   const { setCurrentFileSharePath } = useFileBrowserContext();
+  const navigate = useNavigate();
 
   const pathFsp = zonesAndFileSharePathsMap[
     makeMapKey('fsp', item.fsp_name)
@@ -57,6 +60,8 @@ export default function ProxiedPathRow({
     item.path
   );
 
+  // Create navigation link for the file browser
+  const browseLink = makeBrowseLink(item.fsp_name, item.path);
 
   const handleCopyPath = async () => {
     try {
@@ -78,18 +83,29 @@ export default function ProxiedPathRow({
     }
   };
 
+  const handleRowClick = () => {
+    navigate(browseLink);
+  };
+
+  const handleNameClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigate(browseLink);
+  };
+
   return (
     <>
       <div
         key={item.sharing_key}
-        className="grid grid-cols-[1.5fr_2.5fr_1.5fr_1fr] gap-4 items-center px-4 py-3 border-b last:border-b-0 border-surface hover:bg-primary-light/20 relative"
+        className="grid grid-cols-[1.5fr_2.5fr_1.5fr_1fr] gap-4 items-center px-4 py-3 border-b last:border-b-0 border-surface hover:bg-primary-light/20 relative cursor-pointer"
+        onClick={handleRowClick}
       >
         {/* Sharing name */}
         <Tooltip>
           <Tooltip.Trigger className="max-w-full truncate">
             <Typography
               variant="small"
-              className="text-left text-foreground truncate"
+              className="text-left text-foreground truncate hover:text-primary-light hover:underline"
+              onClick={handleNameClick}
             >
               {item.sharing_name}
             </Typography>
@@ -126,6 +142,7 @@ export default function ProxiedPathRow({
             as={IconButton}
             variant="ghost"
             className="p-1 max-w-fit"
+            onClick={(e: React.MouseEvent) => e.stopPropagation()}
           >
             <HiOutlineEllipsisHorizontalCircle className="icon-default text-foreground" />
           </Menu.Trigger>
@@ -150,7 +167,7 @@ export default function ProxiedPathRow({
               <Typography
                 className="text-sm p-1 cursor-pointer text-red-600"
                 onClick={() => {
-                  setCurrentFileSharePath(pathFsp);
+                  setCurrentFileSharePath(item.fsp_name);
                   setShowSharingDialog(true);
                 }}
               >

--- a/src/components/ui/Shared/ProxiedPathRow.tsx
+++ b/src/components/ui/Shared/ProxiedPathRow.tsx
@@ -104,7 +104,7 @@ export default function ProxiedPathRow({
           <Tooltip.Trigger className="max-w-full truncate">
             <Typography
               variant="small"
-              className="text-left text-foreground truncate hover:text-primary-light hover:underline"
+              className="text-left text-primary-light truncate hover:underline"
               onClick={handleNameClick}
             >
               {item.sharing_name}

--- a/src/contexts/FileBrowserContext.tsx
+++ b/src/contexts/FileBrowserContext.tsx
@@ -27,6 +27,7 @@ type FileBrowserContextType = {
   currentFolder: FileOrFolder | null;
   currentFileSharePath: FileSharePath | null;
   fetchAndSetFiles: (fspName: string, path?: string) => Promise<void>;
+  setCurrentFileSharePath: (fspName: string) => void;
 };
 
 const FileBrowserContext = React.createContext<FileBrowserContextType | null>(


### PR DESCRIPTION
This PR adds a way to navigate from each shared link (proxied path) to the file browser. 

@neomorphic @allison-truhlar @StephanPreibisch 