### PR TITLE
Alternative error handling

### DIFF
--- a/src/__tests__/errorHandling.test.ts
+++ b/src/__tests__/errorHandling.test.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect, afterEach, beforeEach, vi } from 'vitest';
+import { parseError, handleFailure } from '@/utils/errorHandling';
+
+// Mock loglevel
+vi.mock('loglevel', () => ({
+  default: {
+    error: vi.fn()
+  }
+}));
+
+// Mock the react-hot-toast import
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: vi.fn()
+  }
+}));
+
+// Import the mocked modules
+import toast from 'react-hot-toast';
+import log from 'loglevel';
+
+describe('parseError', () => {
+  test('parses Error objects', () => {
+    const error = new Error('Test error');
+    expect(parseError(error)).toBe('Test error');
+  });
+
+  test('parses string errors', () => {
+    const error = 'Test string error';
+    expect(parseError(error)).toBe('Test string error');
+  });
+
+  test('parses object with "error" property', () => {
+    const errorObj = { error: 'Test object error' };
+    expect(parseError(errorObj)).toBe('Test object error');
+  });
+
+  test('parses Response objects with status and statusText', () => {
+    const response = new Response(null, {
+      status: 404,
+      statusText: 'Not Found'
+    });
+    expect(parseError(response)).toBe('404: Not Found');
+  });
+
+  test('returns default message for unknown errors', () => {
+    expect(parseError({})).toBe('An unknown error occurred');
+  });
+});
+
+describe('handleFailure', () => {
+  beforeEach(() => {
+    // Clear mocks before each test
+    vi.mocked(log.error).mockClear();
+    vi.mocked(toast.error).mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('logs and displays error for Error objects', () => {
+    const error = new Error('Test error');
+    handleFailure('test action', error);
+    expect(log.error).toHaveBeenCalledWith('Error test action:', error);
+    expect(toast.error).toHaveBeenCalledWith('Error test action: Test error');
+  });
+
+  test('logs and displays error for fileglancer API response', async () => {
+    const mockJsonPromise = Promise.resolve({ error: 'Test response error' });
+    const response = {
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: vi.fn().mockReturnValue(mockJsonPromise)
+    } as unknown as Response;
+
+    handleFailure('test action', response);
+    expect(log.error).toHaveBeenCalledWith('Error test action:', response);
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Error test action: 500 - Test response error'
+      );
+    });
+  });
+
+  test('logs and displays error for typical Response format', async () => {
+    const response = {
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: vi.fn().mockRejectedValue(new Error('JSON parse error'))
+    } as unknown as Response;
+
+    handleFailure('test action', response);
+    expect(log.error).toHaveBeenCalledWith('Error test action:', response);
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Error test action: 500 Internal Server Error'
+      );
+    });
+  });
+
+  test('logs and displays error for string errors', () => {
+    const error = 'Test string error';
+    handleFailure('test action', error);
+    expect(log.error).toHaveBeenCalledWith('Error test action:', error);
+    expect(toast.error).toHaveBeenCalledWith(
+      'Error test action: Test string error'
+    );
+  });
+
+  test('logs and displays error for unknown error types', () => {
+    handleFailure('test action', {});
+    expect(log.error).toHaveBeenCalledWith(
+      'Error test action:',
+      expect.anything()
+    );
+    expect(toast.error).toHaveBeenCalledWith(
+      'Error test action: An unknown error occurred'
+    );
+  });
+});

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -1,20 +1,31 @@
 import * as React from 'react';
-import { Alert, Button, Card, Typography } from '@material-tailwind/react';
-import { XMarkIcon } from '@heroicons/react/24/outline';
+import { Button, Card, Typography } from '@material-tailwind/react';
+import toast from 'react-hot-toast';
+
+import { handleFailure } from '@/utils/errorHandling';
 import { usePreferencesContext } from '@/contexts/PreferencesContext';
 import useLocalPathPreference from '@/hooks/useLocalPathPreference';
 
 export default function Preferences() {
-  const {
-    showPathPrefAlert,
-    setShowPathPrefAlert,
-    handlePathPreferenceSubmit
-  } = usePreferencesContext();
+  const { handlePathPreferenceSubmit } = usePreferencesContext();
   const { localPathPreference, handleLocalChange } = useLocalPathPreference();
 
-  React.useEffect(() => {
-    setShowPathPrefAlert(false);
-  }, [setShowPathPrefAlert]);
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    try {
+      const response = await handlePathPreferenceSubmit(
+        event,
+        localPathPreference
+      );
+      if (response.ok) {
+        toast.success('Path preference updated successfully!');
+      } else if (!response.ok) {
+        handleFailure('updating path preference', response);
+      }
+    } catch (error) {
+      handleFailure('updating path preference', error);
+    }
+  }
 
   return (
     <div className="pt-12 w-4/5">
@@ -24,7 +35,7 @@ export default function Preferences() {
 
       <form
         onSubmit={(event: React.FormEvent<HTMLFormElement>) =>
-          handlePathPreferenceSubmit(event, localPathPreference)
+          handleSubmit(event)
         }
       >
         <Card className="p-6">
@@ -43,7 +54,6 @@ export default function Preferences() {
                 checked={localPathPreference[0] === 'linux_path'}
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   handleLocalChange(event);
-                  setShowPathPrefAlert(false);
                 }}
               />
 
@@ -65,7 +75,6 @@ export default function Preferences() {
                 checked={localPathPreference[0] === 'windows_path'}
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   handleLocalChange(event);
-                  setShowPathPrefAlert(false);
                 }}
               />
               <Typography
@@ -86,7 +95,6 @@ export default function Preferences() {
                 checked={localPathPreference[0] === 'mac_path'}
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   handleLocalChange(event);
-                  setShowPathPrefAlert(false);
                 }}
               />
               <Typography
@@ -102,15 +110,6 @@ export default function Preferences() {
             <Button className="!rounded-md" type="submit">
               Submit
             </Button>
-            {showPathPrefAlert === true ? (
-              <Alert className="flex items-center gap-6 mt-6 bg-secondary-light/70 border-none">
-                <Alert.Content>Preference updated!</Alert.Content>
-                <XMarkIcon
-                  className="icon-default cursor-pointer"
-                  onClick={() => setShowPathPrefAlert(false)}
-                />
-              </Alert>
-            ) : null}
           </Card.Footer>
         </Card>
       </form>

--- a/src/components/ui/Sidebar/Folder.tsx
+++ b/src/components/ui/Sidebar/Folder.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { default as log } from '@/logger';
 import { Link } from 'react-router-dom';
 import {
   IconButton,
@@ -18,6 +17,7 @@ import {
   getPreferredPathForDisplay,
   makeBrowseLink
 } from '@/utils';
+import { handleFailure } from '@/utils/errorHandling';
 import { useCookiesContext } from '@/contexts/CookiesContext';
 import MissingFolderFavoriteDialog from './MissingFolderFavoriteDialog';
 
@@ -64,14 +64,11 @@ export default function Folder({ folderFavorite }: FolderProps) {
         cookies['_xsrf']
       );
 
-      if (response.status === 200) {
-        return true;
-      } else {
-        return false;
+      if (response.status === 404) {
+        setShowMissingFolderFavoriteDialog(true);
       }
     } catch (error) {
-      log.error('Error checking folder existence:', error);
-      return false;
+      handleFailure('checking folder exists', error);
     }
   }
 
@@ -79,17 +76,7 @@ export default function Folder({ folderFavorite }: FolderProps) {
     <>
       <List.Item
         key={mapKey}
-        onClick={async () => {
-          let folderExists;
-          try {
-            folderExists = await checkFolderExists(folderFavorite);
-          } catch (error) {
-            log.error('Error checking folder existence:', error);
-          }
-          if (folderExists === false) {
-            setShowMissingFolderFavoriteDialog(true);
-          }
-        }}
+        onClick={() => checkFolderExists(folderFavorite)}
         className="pl-6 w-full flex gap-2 items-center justify-between rounded-md cursor-pointer text-foreground hover:bg-primary-light/30 focus:bg-primary-light/30 "
       >
         <Link
@@ -121,9 +108,9 @@ export default function Folder({ folderFavorite }: FolderProps) {
             className="min-w-0 min-h-0"
             variant="ghost"
             isCircular
-            onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();
-              await handleFavoriteChange(folderFavorite, 'folder');
+              handleFavoriteChange(folderFavorite, 'folder');
             }}
           >
             <StarFilled className="icon-small short:icon-xsmall mb-[2px]" />

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -1,0 +1,66 @@
+import toast from 'react-hot-toast';
+import log from 'loglevel';
+
+/**
+ * Parses an error object or string to extract a meaningful error message.
+ * It handles Error objects, string messages, and responses from the fileglancer API.
+ *
+ * @param error - The error object or string to parse.
+ * @returns A string containing the parsed error message.
+ */
+const parseError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  } else if (typeof error === 'string') {
+    return error;
+  } else if (error && typeof error === 'object') {
+    const errorObj = error as Record<string, unknown>;
+    // "error" property is used in fileglancer API responses
+    if (errorObj.error && typeof errorObj.error === 'string') {
+      return errorObj.error;
+    } else if (errorObj.status && errorObj.statusText) {
+      // Fallback for typical Response objects
+      return `${errorObj.status}: ${errorObj.statusText}`;
+    }
+  }
+  return 'An unknown error occurred';
+};
+
+/**
+ * Handles errors by logging them and displaying a toast notification.
+ * It can handle both Error objects and Response objects.
+ *
+ * @param action - The action being performed when the error occurred.
+ * @param errorOrResponse - The error or response object containing error details.
+ */
+const handleFailure = (action: string, errorOrResponse: unknown) => {
+  log.error(`Error ${action}:`, errorOrResponse);
+
+  // Handle Response objects
+  if (
+    errorOrResponse &&
+    typeof errorOrResponse === 'object' &&
+    'ok' in errorOrResponse &&
+    !errorOrResponse.ok
+  ) {
+    const response = errorOrResponse as Response;
+
+    response
+      .json()
+      .then(errorData => {
+        const errorMessage = parseError(errorData);
+        toast.error(`Error ${action}: ${response.status} - ${errorMessage}`);
+      })
+      .catch(() => {
+        toast.error(
+          `Error ${action}: ${response.status} ${response.statusText}`
+        );
+      });
+  } else {
+    // Handle string error msgs and Error objects
+    const description = parseError(errorOrResponse);
+    toast.error(`Error ${action}: ${description}`);
+  }
+};
+
+export { handleFailure, parseError };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -60,12 +60,6 @@ async function sendFetchRequest(
       body && { body: JSON.stringify(body) })
   };
   const response = await fetch(getFullPath(apiPath), options);
-  if (!response.ok) {
-    throw new HTTPError(
-      `Request failed: ${response.status} - ${response.statusText}`,
-      response.status
-    );
-  }
   return response;
 }
 


### PR DESCRIPTION
@krokicki Again, no rush to look at this, but I would appreciate your thoughts before I continue refactoring the code base to follow this implementation of the error handling.

**Note:** This PR is a draft/work-in-progress. I haven't refactored every function to follow this new pattern yet.
This PR adds what I think is a more straightforward implementation of error handling than that proposed in #83. Informed by this [blog post](https://www.haydenbleasel.com/blog/on-javascript-errors).

### Main changes:

- Adds `handleFailure` and `parseError` utility functions. `handleFailure` receives either response objects or errors, logs them, and then uses `parseError` to return a string description of the error, which is used to show a toast notification. 
- - Adds tests of `handleFailure` and `parseError`
- Following the **Just use try/catch** section of the blog post, removes try/catch blocks from lower level functions, allowing errors to bubble up to the UI level. This is where `handleFailure` is called.
- Refactors lower level functions making API calls to return a response, which can be handled at the UI level code, like the errors, by `handleFailure` if `!response.ok`.