### PR TITLE
Fix - missing useEffect dependencies

### DIFF
--- a/src/__tests__/pathHandling.test.ts
+++ b/src/__tests__/pathHandling.test.ts
@@ -9,7 +9,6 @@ import {
   removeLastSegmentFromPath
 } from '@/utils';
 import type { FileSharePath } from '@/shared.types';
-import type { ProxiedPath } from '@/contexts/ProxiedPathContext';
 
 describe('joinPaths', () => {
   test('joins paths in POSIX style', () => {

--- a/src/components/Browse.tsx
+++ b/src/components/Browse.tsx
@@ -15,7 +15,6 @@ import NewFolderDialog from './ui/Dialogs/NewFolderDialog';
 import Delete from './ui/Dialogs/Delete';
 import ChangePermissions from './ui/Dialogs/ChangePermissions';
 import Dashboard from './ui/FileBrowser/Dashboard';
-import Loader from './ui/Loader';
 
 type OutletContextType = {
   setShowPermissionsDialog: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/contexts/ProxiedPathContext.tsx
+++ b/src/contexts/ProxiedPathContext.tsx
@@ -163,7 +163,7 @@ export const ProxiedPathProvider = ({
       updateProxiedPath(null);
       await fetchAllProxiedPaths();
     },
-    [proxiedPath, cookies, updateProxiedPath]
+    [cookies, updateProxiedPath, fetchAllProxiedPaths]
   );
 
   React.useEffect(() => {

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -35,7 +35,7 @@ function useProfile() {
     };
 
     fetchProfile();
-  }, []);
+  }, [cookies]);
 
   return { profile, loading, error };
 }

--- a/src/hooks/useSearchFilter.ts
+++ b/src/hooks/useSearchFilter.ts
@@ -28,68 +28,74 @@ export default function useSearchFilter() {
     FolderFavorite[]
   >([]);
 
-  function filterZonesMap(query: string) {
-    const matches = Object.entries(zonesAndFileSharePathsMap)
-      .map(([key, value]) => {
-        if (key.startsWith('zone')) {
-          const zone = value as Zone;
-          const zoneNameMatches = zone.name.toLowerCase().includes(query);
+  const filterZonesMap = React.useCallback(
+    (query: string) => {
+      const matches = Object.entries(zonesAndFileSharePathsMap)
+        .map(([key, value]) => {
+          if (key.startsWith('zone')) {
+            const zone = value as Zone;
+            const zoneNameMatches = zone.name.toLowerCase().includes(query);
 
-          // Filter the file share paths inside the zone
-          const matchingFileSharePaths = zone.fileSharePaths.filter(fsp =>
-            fsp.name.toLowerCase().includes(query)
-          );
+            // Filter the file share paths inside the zone
+            const matchingFileSharePaths = zone.fileSharePaths.filter(fsp =>
+              fsp.name.toLowerCase().includes(query)
+            );
 
-          // If Zone.name matches or any FileSharePath.name inside the zone matches,
-          // return a modified Zone object with only the matching file share paths
-          if (zoneNameMatches || matchingFileSharePaths.length > 0) {
-            return [
-              key,
-              {
-                ...zone,
-                fileSharePaths: matchingFileSharePaths
-              }
-            ];
+            // If Zone.name matches or any FileSharePath.name inside the zone matches,
+            // return a modified Zone object with only the matching file share paths
+            if (zoneNameMatches || matchingFileSharePaths.length > 0) {
+              return [
+                key,
+                {
+                  ...zone,
+                  fileSharePaths: matchingFileSharePaths
+                }
+              ];
+            }
           }
-        }
-        return null; // Return null for non-matching entries
-      })
-      .filter(Boolean); // Remove null entries
+          return null; // Return null for non-matching entries
+        })
+        .filter(Boolean); // Remove null entries
 
-    setFilteredZonesMap(Object.fromEntries(matches as [string, Zone][]));
-  }
+      setFilteredZonesMap(Object.fromEntries(matches as [string, Zone][]));
+    },
+    [zonesAndFileSharePathsMap]
+  );
 
-  function filterAllFavorites(query: string) {
-    const filteredZoneFavorites = zoneFavorites.filter(
-      zone =>
-        zone.name.toLowerCase().includes(query) ||
-        // any of the file share paths inside the zone match
-        zone.fileSharePaths.some(fileSharePath =>
-          fileSharePath.name.toLowerCase().includes(query)
-        )
-    );
+  const filterAllFavorites = React.useCallback(
+    (query: string) => {
+      const filteredZoneFavorites = zoneFavorites.filter(
+        zone =>
+          zone.name.toLowerCase().includes(query) ||
+          // any of the file share paths inside the zone match
+          zone.fileSharePaths.some(fileSharePath =>
+            fileSharePath.name.toLowerCase().includes(query)
+          )
+      );
 
-    const filteredFileSharePathFavorites = fileSharePathFavorites.filter(
-      fileSharePath =>
-        fileSharePath.zone.toLowerCase().includes(query) ||
-        fileSharePath.name.toLowerCase().includes(query) ||
-        fileSharePath.group.toLowerCase().includes(query) ||
-        fileSharePath.storage.toLowerCase().includes(query)
-    );
+      const filteredFileSharePathFavorites = fileSharePathFavorites.filter(
+        fileSharePath =>
+          fileSharePath.zone.toLowerCase().includes(query) ||
+          fileSharePath.name.toLowerCase().includes(query) ||
+          fileSharePath.group.toLowerCase().includes(query) ||
+          fileSharePath.storage.toLowerCase().includes(query)
+      );
 
-    const filteredFolderFavorites = folderFavorites.filter(
-      folder =>
-        folder.folderPath.toLowerCase().includes(query) ||
-        folder.fsp.name.toLowerCase().includes(query) ||
-        folder.fsp.zone.toLowerCase().includes(query) ||
-        folder.fsp.group.toLowerCase().includes(query) ||
-        folder.fsp.storage.toLowerCase().includes(query)
-    );
+      const filteredFolderFavorites = folderFavorites.filter(
+        folder =>
+          folder.folderPath.toLowerCase().includes(query) ||
+          folder.fsp.name.toLowerCase().includes(query) ||
+          folder.fsp.zone.toLowerCase().includes(query) ||
+          folder.fsp.group.toLowerCase().includes(query) ||
+          folder.fsp.storage.toLowerCase().includes(query)
+      );
 
-    setFilteredZoneFavorites(filteredZoneFavorites);
-    setFilteredFileSharePathFavorites(filteredFileSharePathFavorites);
-    setFilteredFolderFavorites(filteredFolderFavorites);
-  }
+      setFilteredZoneFavorites(filteredZoneFavorites);
+      setFilteredFileSharePathFavorites(filteredFileSharePathFavorites);
+      setFilteredFolderFavorites(filteredFolderFavorites);
+    },
+    [zoneFavorites, fileSharePathFavorites, folderFavorites]
+  );
 
   const handleSearchChange = (
     event: React.ChangeEvent<HTMLInputElement>
@@ -114,7 +120,9 @@ export default function useSearchFilter() {
     zonesAndFileSharePathsMap,
     zoneFavorites,
     fileSharePathFavorites,
-    folderFavorites
+    folderFavorites,
+    filterAllFavorites,
+    filterZonesMap
   ]);
 
   return {

--- a/src/utils/pathHandling.ts
+++ b/src/utils/pathHandling.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import log from 'loglevel';
 import type { FileSharePath } from '@/shared.types';
-import type { ProxiedPath } from '@/contexts/ProxiedPathContext';
 
 const PATH_DELIMITER = '/';
 


### PR DESCRIPTION
ClickUp id: #86a92e9y4

This PR adds missing useEffect dependencies, as caught by the eslint plugin for React hooks. Note: I did not fix the missing dependeinces in `usePropertiesTarget`, as this hook is deleted in another PR (#96). 

I also removed unused imports in several files. I did not remove unused icon imports, as this is fixed in another PR (#94).

@krokicki @neomorphic 