### PR TITLE
Show the NG layer panel by default with the first channel selected

### DIFF
--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -368,6 +368,11 @@ function generateNeuroglancerState(
     });
   }
 
+  state.selectedLayer = {
+    visible: true,
+    layer: channels[0].name
+  };
+
   // Convert the state to a URL-friendly format
   const stateJson = JSON.stringify(state);
   return encodeURIComponent(stateJson);


### PR DESCRIPTION
#86aa5xdg1

This PR adds to the Neuroglancer configuration so that the layer panel is opened by default with the first layer selected. 

@StephanPreibisch @allison-truhlar @neomorphic @cgoina 