### PR TITLE
Unified file browser state

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,7 +61,7 @@ export default defineConfig([
     files: ['**/*.{js,jsx,ts,tsx}'],
     plugins: { react },
     rules: {
-      '@typescript-eslint/naming-convention': [
+      /* '@typescript-eslint/naming-convention': [
         'error',
         {
           selector: 'interface',
@@ -71,7 +71,7 @@ export default defineConfig([
             match: true
           }
         }
-      ],
+      ], */
       '@typescript-eslint/no-unused-vars': [
         'warn',
         {

--- a/src/components/ui/FileBrowser/Toolbar.tsx
+++ b/src/components/ui/FileBrowser/Toolbar.tsx
@@ -41,7 +41,7 @@ export default function Toolbar({
   setShowSidebar,
   setShowNewFolderDialog
 }: ToolbarProps): JSX.Element {
-  const { currentFolder, currentFileSharePath, fetchAndSetFiles } =
+  const { currentFolder, currentFileSharePath, refreshFiles } =
     useFileBrowserContext();
 
   const {
@@ -140,10 +140,7 @@ export default function Toolbar({
                 if (!currentFileSharePath) {
                   return;
                 }
-                await fetchAndSetFiles(
-                  currentFileSharePath.name,
-                  currentFolder?.path
-                );
+                await refreshFiles();
               }}
             >
               <HiRefresh className="icon-default" />

--- a/src/contexts/FileBrowserContext.tsx
+++ b/src/contexts/FileBrowserContext.tsx
@@ -47,22 +47,59 @@ export const useFileBrowserContext = () => {
   return context;
 };
 
+export interface FileState {
+  isFileBrowserReady: boolean;
+  currentFileSharePath: FileSharePath | null;
+  currentFolder: FileOrFolder | null;
+  files: FileOrFolder[];
+  fetchErrorMsg: string | null;
+}
+
 // fspName and filePath come from URL parameters, accessed in MainLayout
 export const FileBrowserContextProvider = ({
   children,
   fspName,
   filePath
 }: FileBrowserContextProviderProps) => {
-  const [isFileBrowserReady, setIsFileBrowserReady] = React.useState(true);
-  const [files, setFiles] = React.useState<FileOrFolder[]>([]);
-  const [currentFolder, setCurrentFolder] = React.useState<FileOrFolder | null>(
-    null
-  );
-  const [currentFileSharePath, setCurrentFileSharePath] =
-    React.useState<FileSharePath | null>(null);
+  const [fileState, setFileState] = React.useState<FileState>({
+    isFileBrowserReady: false,
+    currentFileSharePath: null,
+    currentFolder: null,
+    files: [],
+    fetchErrorMsg: null
+  });
+
   const [propertiesTarget, setPropertiesTarget] =
     React.useState<FileOrFolder | null>(null);
-  const [fetchErrorMsg, setFetchErrorMsg] = React.useState<string | null>(null);
+
+  // Destructure state values and setters
+  const {
+    isFileBrowserReady,
+    currentFileSharePath,
+    currentFolder,
+    files,
+    fetchErrorMsg
+  } = fileState;
+
+  const setIsFileBrowserReady = React.useCallback((ready: boolean) => {
+    setFileState(prev => ({ ...prev, isFileBrowserReady: ready }));
+  }, []);
+
+  const setCurrentFileSharePath = React.useCallback((path: FileSharePath | null) => {
+    setFileState(prev => ({ ...prev, currentFileSharePath: path }));
+  }, []);
+
+  const setCurrentFolder = React.useCallback((folder: FileOrFolder | null) => {
+    setFileState(prev => ({ ...prev, currentFolder: folder }));
+  }, []);
+
+  const setFiles = React.useCallback((newFiles: FileOrFolder[]) => {
+    setFileState(prev => ({ ...prev, files: newFiles }));
+  }, []);
+
+  const setFetchErrorMsg = React.useCallback((errorMsg: string | null) => {
+    setFileState(prev => ({ ...prev, fetchErrorMsg: errorMsg }));
+  }, []);
 
   const { showBoundary } = useErrorBoundary();
   const { cookies } = useCookiesContext();
@@ -80,13 +117,9 @@ export const FileBrowserContextProvider = ({
         if (!response.ok) {
           if (response.status === 403) {
             if (data.info && data.info.owner) {
-              setFetchErrorMsg(
-                `You do not have permission to view this folder. Contact the owner (${data.info.owner}) for access.`
-              );
+              setFetchErrorMsg(`You do not have permission to view this folder. Contact the owner (${data.info.owner}) for access.`);
             } else {
-              setFetchErrorMsg(
-                'You do not have permission to view this folder. Contact the owner for access.'
-              );
+              setFetchErrorMsg('You do not have permission to view this folder. Contact the owner for access.');
             }
           } else if (response.status === 404) {
             showBoundary(new Error('Folder not found'));
@@ -122,13 +155,9 @@ export const FileBrowserContextProvider = ({
         if (!response.ok) {
           if (response.status === 403) {
             if (data.info && data.info.owner) {
-              setFetchErrorMsg(
-                `You do not have permission to view this folder. Contact the owner (${data.info.owner}) for access.`
-              );
+              setFetchErrorMsg(`You do not have permission to list this folder. Contact the owner (${data.info.owner}) for access.`);
             } else {
-              setFetchErrorMsg(
-                'You do not have permission to view this folder. Contact the owner for access.'
-              );
+              setFetchErrorMsg('You do not have permission to list this folder. Contact the owner for access.');
             }
           } else if (response.status === 404) {
             showBoundary(new Error('Folder not found'));

--- a/src/contexts/FileBrowserContext.tsx
+++ b/src/contexts/FileBrowserContext.tsx
@@ -18,7 +18,18 @@ type FileBrowserContextProviderProps = {
   filePath: string | undefined;
 };
 
+// TODO: In the future we could use this unified state in the clients of this context, instead of the 
+// individual local states. This would ensure future consistency and would be easier to reason about. 
+export interface FileState {
+  isFileBrowserReady: boolean;
+  currentFileSharePath: FileSharePath | null;
+  currentFolder: FileOrFolder | null;
+  files: FileOrFolder[];
+  fetchErrorMsg: string | null;
+}
+
 type FileBrowserContextType = {
+  fileState: FileState;
   isFileBrowserReady: boolean;
   fspName: string | undefined;
   filePath: string | undefined;
@@ -47,13 +58,6 @@ export const useFileBrowserContext = () => {
   return context;
 };
 
-export interface FileState {
-  isFileBrowserReady: boolean;
-  currentFileSharePath: FileSharePath | null;
-  currentFolder: FileOrFolder | null;
-  files: FileOrFolder[];
-  fetchErrorMsg: string | null;
-}
 
 // fspName and filePath come from URL parameters, accessed in MainLayout
 export const FileBrowserContextProvider = ({
@@ -68,7 +72,7 @@ export const FileBrowserContextProvider = ({
   const [files, setFiles] = React.useState<FileOrFolder[]>([]);
   const [fetchErrorMsg, setFetchErrorMsg] = React.useState<string | null>(null);
 
-  // Main fileState that gets updated when everything is ready
+  // Unified state that keeps a consistent view of the file browser
   const [fileState, setFileState] = React.useState<FileState>({
     isFileBrowserReady: false,
     currentFileSharePath: null,
@@ -272,6 +276,7 @@ export const FileBrowserContextProvider = ({
   return (
     <FileBrowserContext.Provider
       value={{
+        fileState,
         isFileBrowserReady,
         fspName,
         filePath,

--- a/src/contexts/FileBrowserContext.tsx
+++ b/src/contexts/FileBrowserContext.tsx
@@ -23,9 +23,7 @@ type FileBrowserContextProviderProps = {
   filePath: string | undefined;
 };
 
-// TODO: In the future we could use this unified state in the clients of this context, instead of the 
-// individual local states. This would ensure future consistency and would be easier to reason about. 
-export interface FileState {
+export interface FileBrowserState {
   isFileBrowserReady: boolean;
   currentFileSharePath: FileSharePath | null;
   currentFolder: FileOrFolder | null;
@@ -34,7 +32,7 @@ export interface FileState {
 }
 
 type FileBrowserContextType = {
-  fileState: FileState;
+  fileBrowserState: FileBrowserState;
   isFileBrowserReady: boolean;
   fspName: string | undefined;
   filePath: string | undefined;
@@ -78,7 +76,7 @@ export const FileBrowserContextProvider = ({
   const [fetchErrorMsg, setFetchErrorMsg] = React.useState<string | null>(null);
 
   // Unified state that keeps a consistent view of the file browser
-  const [fileState, setFileState] = React.useState<FileState>({
+  const [fileBrowserState, setFileBrowserState] = React.useState<FileBrowserState>({
     isFileBrowserReady: false,
     currentFileSharePath: null,
     currentFolder: null,
@@ -89,10 +87,10 @@ export const FileBrowserContextProvider = ({
   const [propertiesTarget, setPropertiesTarget] =
     React.useState<FileOrFolder | null>(null);
 
-  // Function to update fileState with complete, consistent data
-  const updateFileState = React.useCallback((newState: Partial<FileState>) => {
-    log.debug('Updating fileState:', newState);
-    setFileState(prev => ({
+  // Function to update fileBrowserState with complete, consistent data
+  const updateFileBrowserState = React.useCallback((newState: Partial<FileBrowserState>) => {
+    log.debug('Updating fileBrowserState:', newState);
+    setFileBrowserState(prev => ({
       ...prev,
       ...newState
     }));
@@ -107,8 +105,8 @@ export const FileBrowserContextProvider = ({
     errorMsg: string | null
   ) => {
 
-    // Update fileState with complete, consistent data
-    updateFileState({
+    // Update fileBrowserState with complete, consistent data
+    updateFileBrowserState({
       isFileBrowserReady: ready,
       currentFileSharePath: sharePath,
       currentFolder: folder,
@@ -134,7 +132,7 @@ export const FileBrowserContextProvider = ({
       setFetchErrorMsg(errorMsg);
     }
 
-  }, [updateFileState]);
+  }, [updateFileBrowserState]);
 
   const { showBoundary } = useErrorBoundary();
   const { cookies } = useCookiesContext();
@@ -166,8 +164,8 @@ export const FileBrowserContextProvider = ({
     [cookies]
   );
 
-  // Fetch files for the given FSP and folder, and update the fileState
-  const fetchAndUpdateFileState = React.useCallback(
+  // Fetch files for the given FSP and folder, and update the fileBrowserState
+  const fetchAndUpdateFileBrowserState = React.useCallback(
     async (fsp: FileSharePath, folder: FileOrFolder): Promise<void> => {
 
       try {
@@ -201,13 +199,13 @@ export const FileBrowserContextProvider = ({
   // Function to refresh files for the current FSP and current folder
   const refreshFiles = React.useCallback(
     async (): Promise<void> => {
-      if (!fileState.currentFileSharePath || !fileState.currentFolder) {
+      if (!fileBrowserState.currentFileSharePath || !fileBrowserState.currentFolder) {
         return;
       }
       log.debug('Refreshing file list');
-      await fetchAndUpdateFileState(fileState.currentFileSharePath, fileState.currentFolder);
+      await fetchAndUpdateFileBrowserState(fileBrowserState.currentFileSharePath, fileBrowserState.currentFolder);
     },
-    [fileState.currentFileSharePath, fileState.currentFolder, fetchAndUpdateFileState]
+    [fileBrowserState.currentFileSharePath, fileBrowserState.currentFolder, fetchAndUpdateFileBrowserState]
   );
 
   // Effect to update currentFolder and propertiesTarget when URL params change
@@ -248,7 +246,7 @@ export const FileBrowserContextProvider = ({
         log.debug('Updated urlParamFolder:', urlParamFolder);
       }
 
-      await fetchAndUpdateFileState(urlFsp, urlParamFolder);
+      await fetchAndUpdateFileBrowserState(urlFsp, urlParamFolder);
       if (cancelled) return;
       setPropertiesTarget(urlParamFolder);
     
@@ -266,13 +264,13 @@ export const FileBrowserContextProvider = ({
     fspName,
     filePath,
     updateAllStates,
-    fetchAndUpdateFileState
+    fetchAndUpdateFileBrowserState
   ]);
 
   return (
     <FileBrowserContext.Provider
       value={{
-        fileState,
+        fileBrowserState,
         isFileBrowserReady,
         fspName,
         filePath,

--- a/src/contexts/ProxiedPathContext.tsx
+++ b/src/contexts/ProxiedPathContext.tsx
@@ -64,6 +64,7 @@ export const ProxiedPathProvider = ({
 
   const updateProxiedPath = React.useCallback(
     (proxiedPath: ProxiedPath | null) => {
+      log.debug('updateProxiedPath', proxiedPath);
       setProxiedPath(proxiedPath);
       if (proxiedPath) {
         setDataUrl(proxiedPath.url);

--- a/src/hooks/useDeleteDialog.ts
+++ b/src/hooks/useDeleteDialog.ts
@@ -10,7 +10,7 @@ import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 
 export default function useDeleteDialog() {
   const { cookies } = useCookiesContext();
-  const { currentFileSharePath, fetchAndSetFiles } = useFileBrowserContext();
+  const { currentFileSharePath, refreshFiles } = useFileBrowserContext();
 
   async function handleDelete(targetItem: FileOrFolder) {
     if (!currentFileSharePath) {
@@ -25,10 +25,7 @@ export default function useDeleteDialog() {
 
     try {
       await sendFetchRequest(fetchPath, 'DELETE', cookies['_xsrf']);
-      await fetchAndSetFiles(
-        currentFileSharePath.name,
-        removeLastSegmentFromPath(targetItem.path)
-      );
+      await refreshFiles();
       toast.success(`Successfully deleted ${targetItem.path}`);
       return true;
     } catch (error) {

--- a/src/hooks/useNewFolderDialog.ts
+++ b/src/hooks/useNewFolderDialog.ts
@@ -16,7 +16,7 @@ export default function useNewFolderDialog() {
   const [showAlert, setShowAlert] = useState<boolean>(false);
   const [alertContent, setAlertContent] = useState<string>('');
 
-  const { filePath, currentFolder, fetchAndSetFiles } = useFileBrowserContext();
+  const { currentFolder, refreshFiles } = useFileBrowserContext();
   const { currentFileSharePath } = useFileBrowserContext();
   const { pathPreference } = usePreferencesContext();
   const { cookies } = useCookiesContext();
@@ -57,7 +57,7 @@ export default function useNewFolderDialog() {
       );
       try {
         await addNewFolder();
-        await fetchAndSetFiles(currentFileSharePath.name, filePath);
+        await refreshFiles();
         const alertContent = `Created new folder at path: ${displayPath}`;
         toast.success(alertContent);
         return true;

--- a/src/hooks/usePermissionsDialog.ts
+++ b/src/hooks/usePermissionsDialog.ts
@@ -13,7 +13,7 @@ import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 export default function usePermissionsDialog() {
   const [showAlert, setShowAlert] = React.useState<boolean>(false);
   const { cookies } = useCookiesContext();
-  const { currentFileSharePath, fetchAndSetFiles } = useFileBrowserContext();
+  const { currentFileSharePath, refreshFiles } = useFileBrowserContext();
 
   async function handleChangePermissions(
     targetItem: FileOrFolder,
@@ -33,10 +33,7 @@ export default function usePermissionsDialog() {
       await sendFetchRequest(fetchPath, 'PATCH', cookies['_xsrf'], {
         permissions: localPermissions
       });
-      await fetchAndSetFiles(
-        currentFileSharePath.name,
-        removeLastSegmentFromPath(targetItem.path)
-      );
+      await refreshFiles();
       toast.success(`Successfully updated permissions for ${fetchPath}`);
     } catch (error) {
       toast.error(

--- a/src/hooks/useRenameDialog.ts
+++ b/src/hooks/useRenameDialog.ts
@@ -17,8 +17,7 @@ export default function useRenameDialog() {
   const [showAlert, setShowAlert] = useState<boolean>(false);
   const [alertContent, setAlertContent] = useState<string>('');
 
-  const { currentFileSharePath, refreshFiles } =
-    useFileBrowserContext();
+  const { currentFileSharePath, refreshFiles } = useFileBrowserContext();
   const { pathPreference } = usePreferencesContext();
   const { cookies } = useCookiesContext();
 

--- a/src/hooks/useRenameDialog.ts
+++ b/src/hooks/useRenameDialog.ts
@@ -17,7 +17,7 @@ export default function useRenameDialog() {
   const [showAlert, setShowAlert] = useState<boolean>(false);
   const [alertContent, setAlertContent] = useState<string>('');
 
-  const { currentFileSharePath, currentFolder, fetchAndSetFiles } =
+  const { currentFileSharePath, refreshFiles } =
     useFileBrowserContext();
   const { pathPreference } = usePreferencesContext();
   const { cookies } = useCookiesContext();
@@ -31,7 +31,7 @@ export default function useRenameDialog() {
     await sendFetchRequest(fetchPath, 'PATCH', cookies['_xsrf'], {
       path: newPath
     });
-    await fetchAndSetFiles(currentFileSharePath.name, currentFolder?.path);
+    await refreshFiles();
   }
 
   async function handleRenameSubmit(path: string) {


### PR DESCRIPTION
This PR refactors the file browser hooks such that all state is grouped into one object. This makes downstream updates atomic, and fixes stale data issues. For the time being, I have preserved the individual states which are shared with many downstream clients. I didn't update all those locations to minimize merge conflicts. They can be easily updated at any time in the future to use the new unified state. 

During the course of refactoring I also addressed some other minor issues in the same code:
* Optimized number of fetches - since every fetch includes both info and files, each update only requires a single fetch (except when a file is provided in the URL and we have to navigate upwards, but this should be very rare). 
* Consolidated refreshes - I created a refreshFiles method which can be used by any action that modifies the current file structure. This consolidates how refreshing is done through-out the application.

@StephanPreibisch @cgoina 