### PR TITLE
Fix: y-scrolling on all pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,8 @@ import { CookiesProvider } from 'react-cookie';
 import { ErrorBoundary } from 'react-error-boundary';
 
 import { MainLayout } from './layouts/MainLayout';
-import { BrowseLayout } from './layouts/BrowseLayout';
+import { BrowsePageLayout } from './layouts/BrowseLayout';
+import { OtherPagesLayout } from './layouts/OtherPagesLayout';
 import Home from '@/components/Home';
 import Browse from '@/components/Browse';
 import Help from '@/components/Help';
@@ -56,12 +57,14 @@ const AppComponent = () => {
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/*" element={<MainLayout />}>
-          <Route path="shared" element={<Shared />} />
-          <Route path="jobs" element={<Jobs />} />
-          <Route path="help" element={<Help />} />
-          <Route path="profile" element={<Profile />} />
-          <Route path="preferences" element={<Preferences />} />
-          <Route element={<BrowseLayout />}>
+          <Route element={<OtherPagesLayout />}>
+            <Route path="shared" element={<Shared />} />
+            <Route path="jobs" element={<Jobs />} />
+            <Route path="help" element={<Help />} />
+            <Route path="profile" element={<Profile />} />
+            <Route path="preferences" element={<Preferences />} />
+          </Route>
+          <Route element={<BrowsePageLayout />}>
             <Route path="browse" element={<Browse />} />
             <Route path="browse/:fspName" element={<Browse />} />
             <Route path="browse/:fspName/*" element={<Browse />} />

--- a/src/components/Browse.tsx
+++ b/src/components/Browse.tsx
@@ -56,7 +56,7 @@ export default function Browse() {
   const [showRenameDialog, setShowRenameDialog] = React.useState(false);
 
   return (
-    <div className="flex-1 overflow-auto flex flex-col h-full">
+    <div className="flex-1 flex flex-col h-full">
       <Toolbar
         hideDotFiles={hideDotFiles}
         setHideDotFiles={setHideDotFiles}
@@ -66,7 +66,7 @@ export default function Browse() {
         setShowSidebar={setShowSidebar}
         setShowNewFolderDialog={setShowNewFolderDialog}
       />
-      <div className="relative grow h-full flex flex-col overflow-hidden mb-3">
+      <div className="relative grow h-full flex flex-col overflow-y-auto mb-3">
         {!currentFileSharePath ? (
           <Dashboard />
         ) : (

--- a/src/layouts/BrowseLayout.tsx
+++ b/src/layouts/BrowseLayout.tsx
@@ -9,7 +9,7 @@ import Sidebar from '@/components/ui/Sidebar/Sidebar';
 import PropertiesDrawer from '@/components/ui/PropertiesDrawer/PropertiesDrawer';
 import ErrorFallback from '@/components/ErrorFallback';
 
-export const BrowseLayout = () => {
+export const BrowsePageLayout = () => {
   const [showPermissionsDialog, setShowPermissionsDialog] =
     React.useState(false);
   const [showConvertFileDialog, setShowConvertFileDialog] =

--- a/src/layouts/BrowseLayout.tsx
+++ b/src/layouts/BrowseLayout.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { Outlet } from 'react-router';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { PiDotsSixVerticalBold } from 'react-icons/pi';
-import { ErrorBoundary } from 'react-error-boundary';
 
 import useShowPropertiesDrawer from '@/hooks/useShowPropertiesDrawer';
 import Sidebar from '@/components/ui/Sidebar/Sidebar';
 import PropertiesDrawer from '@/components/ui/PropertiesDrawer/PropertiesDrawer';
-import ErrorFallback from '@/components/ErrorFallback';
 
 export const BrowsePageLayout = () => {
   const [showPermissionsDialog, setShowPermissionsDialog] =
@@ -31,50 +29,48 @@ export const BrowsePageLayout = () => {
   };
 
   return (
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
-      <div className="flex h-full w-full overflow-y-hidden">
-        <PanelGroup autoSaveId="conditional" direction="horizontal">
-          {showSidebar ? (
-            <>
-              <Panel
-                id="sidebar"
-                order={1}
-                defaultSize={18}
-                minSize={10}
-                maxSize={50}
-              >
-                <Sidebar />
-              </Panel>
-              <PanelResizeHandle className="group relative border-r border-surface hover:border-secondary/60">
-                <PiDotsSixVerticalBold className="icon-default stroke-2 absolute -right-1 top-1/2 stroke-black dark:stroke-white" />
-              </PanelResizeHandle>
-            </>
-          ) : null}
-          <Panel id="main" order={2}>
-            <Outlet context={outletContextValue} />
-          </Panel>
-          {showPropertiesDrawer ? (
-            <>
-              <PanelResizeHandle className="group relative w-3 bg-surface border-l border-surface hover:border-secondary/60">
-                <PiDotsSixVerticalBold className="icon-default stroke-2 absolute -left-1 top-1/2 stroke-black dark:stroke-white" />
-              </PanelResizeHandle>
-              <Panel
-                id="properties"
-                order={3}
-                defaultSize={18}
-                minSize={15}
-                maxSize={50}
-              >
-                <PropertiesDrawer
-                  setShowPropertiesDrawer={setShowPropertiesDrawer}
-                  setShowPermissionsDialog={setShowPermissionsDialog}
-                  setShowConvertFileDialog={setShowConvertFileDialog}
-                />
-              </Panel>
-            </>
-          ) : null}
-        </PanelGroup>
-      </div>
-    </ErrorBoundary>
+    <div className="flex h-full w-full overflow-y-hidden">
+      <PanelGroup autoSaveId="conditional" direction="horizontal">
+        {showSidebar ? (
+          <>
+            <Panel
+              id="sidebar"
+              order={1}
+              defaultSize={18}
+              minSize={10}
+              maxSize={50}
+            >
+              <Sidebar />
+            </Panel>
+            <PanelResizeHandle className="group relative border-r border-surface hover:border-secondary/60">
+              <PiDotsSixVerticalBold className="icon-default stroke-2 absolute -right-1 top-1/2 stroke-black dark:stroke-white" />
+            </PanelResizeHandle>
+          </>
+        ) : null}
+        <Panel id="main" order={2}>
+          <Outlet context={outletContextValue} />
+        </Panel>
+        {showPropertiesDrawer ? (
+          <>
+            <PanelResizeHandle className="group relative w-3 bg-surface border-l border-surface hover:border-secondary/60">
+              <PiDotsSixVerticalBold className="icon-default stroke-2 absolute -left-1 top-1/2 stroke-black dark:stroke-white" />
+            </PanelResizeHandle>
+            <Panel
+              id="properties"
+              order={3}
+              defaultSize={18}
+              minSize={15}
+              maxSize={50}
+            >
+              <PropertiesDrawer
+                setShowPropertiesDrawer={setShowPropertiesDrawer}
+                setShowPermissionsDialog={setShowPermissionsDialog}
+                setShowConvertFileDialog={setShowConvertFileDialog}
+              />
+            </Panel>
+          </>
+        ) : null}
+      </PanelGroup>
+    </div>
   );
 };

--- a/src/layouts/OtherPagesLayout.tsx
+++ b/src/layouts/OtherPagesLayout.tsx
@@ -1,14 +1,9 @@
 import { Outlet } from 'react-router';
-import { ErrorBoundary } from 'react-error-boundary';
-
-import ErrorFallback from '@/components/ErrorFallback';
 
 export const OtherPagesLayout = () => {
   return (
-    <ErrorBoundary FallbackComponent={ErrorFallback}>
-      <div className="w-full overflow-y-auto">
-        <Outlet />
-      </div>
-    </ErrorBoundary>
+    <div className="w-full overflow-y-auto">
+      <Outlet />
+    </div>
   );
 };

--- a/src/layouts/OtherPagesLayout.tsx
+++ b/src/layouts/OtherPagesLayout.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import ErrorFallback from '@/components/ErrorFallback';
+
+export const OtherPagesLayout = () => {
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback}>
+      <div className="w-full overflow-y-auto">
+        <Outlet />
+      </div>
+    </ErrorBoundary>
+  );
+};


### PR DESCRIPTION
Click up id: 86aaau0x6

This PR:
- Adds a layout for all pages other than Browse that allows y-scrolling when there is overflow. 
- Fixes y-scrolling the Browse page for the case of short screens and no file list (which already can scroll vertically), only the dashboard

@krokicki @neomorphic 