### PR TITLE
Correct properties target state management

### DIFF
--- a/src/components/Jobs.tsx
+++ b/src/components/Jobs.tsx
@@ -10,12 +10,12 @@ export default function Jobs() {
       <Typography type="h5" className="mb-6 text-foreground font-bold">
         Jobs
       </Typography>
-        <Typography variant="small" className="mb-6 text-foreground">
-          A job is created when you request a file to be converted to a
-          different format. To start a file conversion job, select a file in the
-          file browser, open the <strong>Properties</strong> panel, and click
-          the <strong>Convert</strong> button.
-        </Typography>
+      <Typography variant="small" className="mb-6 text-foreground">
+        A job is created when you request a file to be converted to a different
+        format. To start a file conversion job, select a file in the file
+        browser, open the <strong>Properties</strong> panel, and click the{' '}
+        <strong>Convert</strong> button.
+      </Typography>
       <div className="rounded-lg shadow bg-background">
         <div className="grid grid-cols-[2fr_3fr_1fr_1fr] gap-4 px-4 py-2 border-b border-surface">
           <Typography className="font-bold">File Path</Typography>

--- a/src/components/Links.tsx
+++ b/src/components/Links.tsx
@@ -10,27 +10,27 @@ export default function Links() {
       <Typography type="h5" className="mb-6 text-foreground font-bold">
         Data Links
       </Typography>
-       <Typography className="mb-6 text-foreground">
-          Data links can be created for any Zarr folder in the file browser.
-          They are used to open files in external viewers like Neuroglancer. You
-          can share data links with internal collaborators.
-        </Typography>
+      <Typography className="mb-6 text-foreground">
+        Data links can be created for any Zarr folder in the file browser. They
+        are used to open files in external viewers like Neuroglancer. You can
+        share data links with internal collaborators.
+      </Typography>
       <div className="rounded-lg shadow bg-background">
         <div className="grid grid-cols-[1.5fr_2.5fr_1.5fr_1fr] gap-4 px-4 py-2 border-b border-surface">
           <Typography className="font-bold">Name</Typography>
           <Typography className="font-bold">File Path</Typography>
           <Typography className="font-bold">Date Created</Typography>
-          <Typography className="font-bold">Actions</Typography>       
-          </div>
-          {allProxiedPaths?.map(item => (
-            <ProxiedPathRow key={item.sharing_key} item={item} />
-          ))}
-           {!allProxiedPaths || allProxiedPaths?.length === 0 ? (
+          <Typography className="font-bold">Actions</Typography>
+        </div>
+        {allProxiedPaths?.map(item => (
+          <ProxiedPathRow key={item.sharing_key} item={item} />
+        ))}
+        {!allProxiedPaths || allProxiedPaths?.length === 0 ? (
           <div className="px-4 py-8 text-center text-gray-500">
             No shared paths.
           </div>
         ) : null}
-        </div>
+      </div>
     </>
   );
 }

--- a/src/contexts/TicketsContext.tsx
+++ b/src/contexts/TicketsContext.tsx
@@ -84,7 +84,9 @@ export const TicketProvider = ({ children }: { children: React.ReactNode }) => {
 
   const fetchTicket = React.useCallback(async () => {
     if (!currentFileSharePath || !propertiesTarget) {
-      log.warn('Cannot fetch ticket; no current file share path or file/folder selected');
+      log.warn(
+        'Cannot fetch ticket; no current file share path or file/folder selected'
+      );
       return null;
     }
     try {
@@ -194,7 +196,7 @@ export const TicketProvider = ({ children }: { children: React.ReactNode }) => {
   React.useEffect(() => {
     (async function () {
       if (!currentFileSharePath || !propertiesTarget) {
-        return 
+        return;
       }
       try {
         const ticket = await fetchTicket();


### PR DESCRIPTION
ClickUp id: 86aaaybtb

This PR adds the propertiesTarget to the unified fileBrowserState in FileBrowserContext.tsx. Thiis fixes the problem of the properties target not being cleared if you navigate from a URL with FSP and/or file path params (e.g., `/browse/fsp_name/file_path`) to one without, (e.g. `/browse`). 

@krokicki I think this works - let me know if I should merge it or wait since we didn't plan to include it in the upcoming release.
@neomorphic 
