### PR TITLE
feat: add time to "last modified" column in file browser

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,7 +25,9 @@ const formatFileSize = (sizeInBytes: number): string => {
 
 const formatUnixTimestamp = (timestamp: number): string => {
   const date = new Date(timestamp * 1000);
-  return date.toLocaleDateString('en-US', {
+  return date.toLocaleString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
     month: 'short',
     day: 'numeric',
     year: 'numeric'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,7 +41,13 @@ const formatDateString = (dateStr: string) => {
     normalized = dateStr + 'Z';
   }
   const date = new Date(normalized);
-  return date.toLocaleString();
+  return date.toLocaleString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    month: 'numeric',
+    day: 'numeric',
+    year: 'numeric'
+  });
 };
 
 class HTTPError extends Error {


### PR DESCRIPTION
ClickUp id: 86aaw7kfe

Uses `date.toLocaleString` instead of `date.toDateString` to return both date and time from `formatUnixTimestamp`, which is used to format the file info for the file browser.

I also added options to the `date.toLocaleString` call used in `formatDateString`, which is used to format the Jobs and Data Link data, so that seconds aren't shown - I figure this level of granularity isn't necessary.

@krokicki @neomorphic 