### PR TITLE
content: change "job" to "task" in UI text

### DIFF
--- a/src/components/Jobs.tsx
+++ b/src/components/Jobs.tsx
@@ -9,12 +9,12 @@ export default function Jobs() {
   return (
     <>
       <Typography type="h5" className="mb-6 text-foreground font-bold">
-        Jobs
+        Tasks
       </Typography>
       <Typography className="mb-6 text-foreground">
-        A job is created when you request a file to be converted to a different
-        format. To start a file conversion job, select a file in the file
-        browser, open the <strong>Properties</strong> panel, and click the{' '}
+        A task is created in Jira when you request a file to be converted to a
+        different format. To start a file conversion task, select a file in the
+        file browser, open the <strong>Properties</strong> panel, and click the{' '}
         <strong>Convert</strong> button.
       </Typography>
       <TableCard
@@ -22,7 +22,7 @@ export default function Jobs() {
         rowTitles={['File Path', 'Job Description', 'Status', 'Last Updated']}
         rowContent={TicketRow}
         items={allTickets}
-        emptyMessage="You have not started any jobs."
+        emptyMessage="You have not opened any Jira tasks."
       />
     </>
   );

--- a/src/components/ui/Navbar/Navbar.tsx
+++ b/src/components/ui/Navbar/Navbar.tsx
@@ -35,7 +35,7 @@ const LINKS = [
   },
   {
     icon: HiOutlineBriefcase,
-    title: 'Jobs',
+    title: 'Tasks',
     href: '/jobs'
   },
   {

--- a/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
+++ b/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
@@ -154,7 +154,8 @@ export default function PropertiesDrawer({
             ) : (
               <>
                 <Typography variant="small" className="font-medium">
-                  Create a job in JIRA to convert this file to OME-Zarr format
+                  Open a task to request the conversion of this file to OME-Zarr
+                  format.
                 </Typography>
                 <Button
                   variant="outline"


### PR DESCRIPTION
Clickup id: 86aatawrk

For clarity, this PR changes instances of "job" to "task" in the UI text. It does not change the `/jobs` route or the names of components.
@krokicki 
@neomorphic 