### PR TITLE
feat: click on file to download

### DIFF
--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -2,6 +2,7 @@ import os
 import json
 import requests
 from abc import ABC
+from mimetypes import guess_type
 
 from jupyter_server.base.handlers import APIHandler, JupyterHandler
 from requests.exceptions import HTTPError
@@ -13,6 +14,23 @@ from fileglancer.paths import get_fsp_manager
 from fileglancer.preferences import get_preference_manager
 from fileglancer.proxiedpath import get_proxiedpath_manager
 from fileglancer.externalbucket import get_externalbucket_manager
+
+
+def _guess_content_type(filename):
+    """
+    A wrapper for guess_type which deals with unknown MIME types
+    Copied from https://github.com/JaneliaSciComp/x2s3/blob/85a743cc55b3797200e87cd9b74882a5ed39f1f0/x2s3/utils.py#L221
+    """
+    content_type, _ = guess_type(filename)
+    if content_type:
+        return content_type
+    else:
+        if filename.endswith('.yaml'):
+            # Should be application/yaml but that doesn't display in current browsers
+            # See https://httptoolkit.com/blog/yaml-media-type-rfc/
+            return 'text/plain+yaml'
+        else:
+            return 'application/octet-stream'
 
 
 def _get_mounted_filestore(fsp):
@@ -168,9 +186,15 @@ class FileContentHandler(FileShareHandler):
         
         # Stream file contents
         file_name = subpath.split('/')[-1]
+        content_type = _guess_content_type(file_name)
+        
         self.set_status(200)
-        self.set_header('Content-Type', 'application/octet-stream')
-        self.set_header('Content-Disposition', f'attachment; filename="{file_name}"')
+        self.set_header('Content-Type', content_type)
+        
+        # Only add download header for binary/unknown files
+        # See https://github.com/JaneliaSciComp/x2s3/blob/main/x2s3/client_file.py#L57
+        if content_type == 'application/octet-stream':
+            self.set_header('Content-Disposition', f'attachment; filename="{file_name}"')
 
         try:
             for chunk in filestore.stream_file_contents(subpath):

--- a/src/components/ui/BrowsePage/FileRow.tsx
+++ b/src/components/ui/BrowsePage/FileRow.tsx
@@ -9,6 +9,7 @@ import {
 import type { FileOrFolder } from '@/shared.types';
 import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 import useHandleLeftClick from '@/hooks/useHandleLeftClick';
+import { useHandleDownload } from '@/hooks/useHandleDownload';
 import {
   formatUnixTimestamp,
   formatFileSize,
@@ -37,12 +38,12 @@ export default function FileRow({
   index,
   selectedFiles,
   setSelectedFiles,
-  // displayFiles,
   showPropertiesDrawer,
   handleContextMenuClick
 }: FileRowProps): ReactNode {
   const { currentFileSharePath } = useFileBrowserContext();
   const { handleLeftClick } = useHandleLeftClick();
+  const { handleDownload } = useHandleDownload(file);
 
   const isSelected = selectedFiles.some(
     selectedFile => selectedFile.name === file.name
@@ -70,13 +71,22 @@ export default function FileRow({
     >
       {/* Name column */}
       <div className="flex items-center pl-3 py-1">
-        <FgTooltip label={file.name} triggerClasses="max-w-full truncate">
+        <FgTooltip
+          label={file.is_dir ? file.name : 'Click to download'}
+          triggerClasses="max-w-full truncate"
+        >
           {file.is_dir ? (
             <Typography as={FgStyledLink} to={link}>
               {file.name}
             </Typography>
           ) : (
-            <Typography className="font-medium text-primary-default truncate">
+            <Typography
+              className="text-primary-default truncate cursor-pointer hover:underline"
+              onClick={(e: React.MouseEvent) => {
+                handleDownload();
+                e.stopPropagation();
+              }}
+            >
               {file.name}
             </Typography>
           )}

--- a/src/components/ui/BrowsePage/FileRow.tsx
+++ b/src/components/ui/BrowsePage/FileRow.tsx
@@ -56,8 +56,8 @@ export default function FileRow({
 
   return (
     <div
-      className={`cursor-pointer grid grid-cols-[minmax(170px,2fr)_minmax(80px,1fr)_minmax(95px,1fr)_minmax(75px,1fr)_minmax(40px,1fr)] gap-4 hover:bg-primary-light/30 focus:bg-primary-light/30 ${isSelected && 'bg-primary-light/30'} ${index % 2 === 0 && !isSelected && 'bg-surface/50'}  `}
-      onClick={(e: React.MouseEvent<HTMLDivElement>) =>
+      className={`grid grid-cols-[minmax(170px,2fr)_minmax(80px,1fr)_minmax(95px,1fr)_minmax(75px,1fr)_minmax(40px,1fr)] gap-4 hover:bg-primary-light/30 focus:bg-primary-light/30 select-none ${isSelected && 'bg-primary-light/30'} ${index % 2 === 0 && !isSelected && 'bg-surface/50'}  `}
+      onClick={() =>
         handleLeftClick(
           file,
           selectedFiles,
@@ -70,18 +70,22 @@ export default function FileRow({
       }
     >
       {/* Name column */}
-      <div className="flex items-center pl-3 py-1">
+      <div className="flex items-center pl-3">
         <FgTooltip
-          label={file.is_dir ? file.name : 'Click to download'}
-          triggerClasses="max-w-full truncate"
+          label={file.name}
+          triggerClasses="max-w-full truncate w-full h-full text-left"
         >
           {file.is_dir ? (
-            <Typography as={FgStyledLink} to={link}>
+            <Typography
+              as={FgStyledLink}
+              to={link}
+              className="block py-2 cursor-pointer"
+            >
               {file.name}
             </Typography>
           ) : (
             <Typography
-              className="text-primary-default truncate cursor-pointer hover:underline"
+              className="text-primary-default truncate cursor-pointer hover:underline focus:underline block py-2"
               onClick={(e: React.MouseEvent) => {
                 handleDownload();
                 e.stopPropagation();

--- a/src/components/ui/Menus/ContextMenu.tsx
+++ b/src/components/ui/Menus/ContextMenu.tsx
@@ -7,6 +7,7 @@ import type { FileOrFolder, Result } from '@/shared.types';
 import { makeMapKey } from '@/utils';
 import { usePreferencesContext } from '@/contexts/PreferencesContext';
 import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
+import { useHandleDownload } from '@/hooks/useHandleDownload';
 
 type ContextMenuProps = {
   x: number;
@@ -29,6 +30,7 @@ type ContextMenuActionProps = {
   handleContextMenuFavorite: (
     selectedFiles: FileOrFolder[]
   ) => Promise<Result<boolean>>;
+  handleDownload: (file: FileOrFolder) => void;
   setShowPropertiesDrawer: React.Dispatch<React.SetStateAction<boolean>>;
   setShowContextMenu: React.Dispatch<React.SetStateAction<boolean>>;
   setShowRenameDialog: React.Dispatch<React.SetStateAction<boolean>>;
@@ -52,6 +54,7 @@ export default function ContextMenu({
 }: ContextMenuProps): React.ReactNode {
   const { fileBrowserState } = useFileBrowserContext();
   const { folderPreferenceMap } = usePreferencesContext();
+  const { handleDownload } = useHandleDownload(selectedFiles[0]);
 
   const isFavorite: boolean = Boolean(
     folderPreferenceMap[
@@ -70,6 +73,14 @@ export default function ContextMenu({
         props.setShowContextMenu(false);
       },
       shouldShow: true
+    },
+    {
+      name: 'Download',
+      action: (props: ContextMenuActionProps) => {
+        handleDownload();
+        props.setShowContextMenu(false);
+      },
+      shouldShow: !selectedFiles[0].is_dir
     },
     {
       name: isFavorite ? 'Unset favorite' : 'Set favorite',
@@ -120,6 +131,7 @@ export default function ContextMenu({
 
   const actionProps = {
     selectedFiles,
+    handleDownload,
     handleContextMenuFavorite,
     setShowPropertiesDrawer,
     setShowContextMenu,

--- a/src/hooks/useHandleDownload.ts
+++ b/src/hooks/useHandleDownload.ts
@@ -1,0 +1,25 @@
+import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
+import { getFileURL } from '@/utils/index';
+import { FileOrFolder } from '@/shared.types';
+
+export function useHandleDownload(file: FileOrFolder) {
+  const { fileBrowserState } = useFileBrowserContext();
+
+  const handleDownload = () => {
+    if (!fileBrowserState.currentFileSharePath) {
+      return;
+    }
+    const downloadUrl = getFileURL(
+      fileBrowserState.currentFileSharePath.name,
+      file.path
+    );
+    const link = document.createElement('a');
+    link.href = downloadUrl;
+    link.download = file.name;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return { handleDownload };
+}


### PR DESCRIPTION
Clickup id: 86aaydz39

This PR adds logic to the frontend to initiate a file download (/src/hooks/useHandleDownload.tsx). This is triggered in FileRow.tsx when the user clicks on a file name. It is also added to the context menu for files. On the backend, a function was added to guess the content type when not known (pulled from the [x2s3 repo](https://github.com/JaneliaSciComp/x2s3/blob/85a743cc55b3797200e87cd9b74882a5ed39f1f0/x2s3/utils.py#L221)). This is used in the FileContentHandler to set the content type header. 

This PR also changes the styling of file names in FileRow.tsx, to indicate they are clickable by adding an underline on hover and focus.

Finally, this PR increases the target size of the links for folders and files to the full size of the name column in the file browser. It also adds back the `none-select` styling to the file browser rows, so you can't select the text.