### PR TITLE
Propagate channel units

### DIFF
--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -372,7 +372,7 @@ function generateNeuroglancerStateForOmeZarr(
 
       const layer: Record<string, any> = {
         type: 'image',
-        source: { 
+        source: {
           url: getNeuroglancerSource(dataUrl, zarr_version),
           transform
         },


### PR DESCRIPTION
Clickup id: 86aan40bt

This propagates channel units to the Neuroglancer configuration. I also added a source transform for `c` to `c'`, since that seems necessary in some cases (CZYX) and doesn't affect the ones that already worked (TCZYX). 

@StephanPreibisch @allison-truhlar @neomorphic 