### PR TITLE
Metadata table improvements

### DIFF
--- a/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
+++ b/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
@@ -1,14 +1,10 @@
 import * as zarr from 'zarrita';
-import { Axis, Multiscale } from 'ome-zarr.js';
+import { Axis } from 'ome-zarr.js';
 import { Metadata, translateUnitToNeuroglancer } from '../../../omezarr-helper';
 
 type ZarrMetadataTableProps = {
   metadata: Metadata;
 };
-
-function getAxesString(multiscale: Multiscale) {
-  return multiscale.axes.map((axis: Axis) => axis.name.toUpperCase()).join('');
-}
 
 function getSizeString(shapes: number[][] | undefined) {
   return shapes?.[0]?.join(', ') || 'Unknown';
@@ -16,10 +12,6 @@ function getSizeString(shapes: number[][] | undefined) {
 
 function getChunkSizeString(arr: zarr.Array<any>) {
   return arr.chunks.join(', ');
-}
-
-function getDataTypeString(arr: zarr.Array<any>) {
-  return arr.dtype;
 }
 
 /**
@@ -34,32 +26,43 @@ function getScaleTransform(coordinateTransformations: any[]) {
 }
 
 /**
- * Get the voxel size for the multiscale dataset, formatted as a comma-separated string.
- * @param multiscale - The multiscale metadata
- * @returns The voxel size string, or 'Unknown' if the voxel size cannot be determined
+ * Get axis-specific metadata for creating the second table
+ * @param metadata - The Zarr metadata
+ * @returns Array of axis data with name, shape, chunk size, scale, and unit
  */
-function getUnitSizeString(multiscale: Multiscale) {
+function getAxisData(metadata: Metadata) {
+  const { multiscale, shapes, arr } = metadata;
+  if (!multiscale?.axes || !shapes?.[0] || !arr) {
+    return [];
+  }
+
   try {
     // Get the root transform
     const rct = getScaleTransform(multiscale.coordinateTransformations as any[]);
+    const rootScales = rct?.scale || [];
+
     // Get the transform for the full scale dataset
-    const dataset = multiscale.datasets[0]
-    let ct = getScaleTransform(dataset.coordinateTransformations);
-    if (ct === undefined) {
-      return 'Unknown';
-    }
-    // Multiply the scale by the root transform scale
-    const fct = ct.scale.map((value: number, i: number) => value * (rct?.scale[i] || 1))
-    // Add the units to each scale value
-    const units = multiscale.axes.map(axis => translateUnitToNeuroglancer(axis.unit as string));
-    const quantities = fct.map((value: number, i: number) => {
-      return units[i] ? `${value} ${units[i]}` : `${value}`;
+    const dataset = multiscale.datasets[0];
+    const ct = getScaleTransform(dataset.coordinateTransformations);
+    const scales = ct?.scale || [];
+    
+    return multiscale.axes.map((axis: Axis, index: number) => {
+      const shape = shapes[0][index] || 'Unknown';
+      const chunkSize = arr.chunks[index] || 'Unknown';
+      const scale = scales[index] ? Number((scales[index] * (rootScales[index] || 1)).toFixed(4)) : 'Unknown';
+      const unit = translateUnitToNeuroglancer(axis.unit as string) || '';
+      
+      return {
+        name: axis.name.toUpperCase(),
+        shape,
+        chunkSize,
+        scale,
+        unit
+      };
     });
-    // Format the voxel size as a comma-separated string
-    return quantities.join(', ');
-  } 
-  catch (error) {
-    return 'Unknown';
+  } catch (error) {
+    console.error('Error getting axis data: ', error);
+    return [];
   }
 }
 
@@ -67,8 +70,11 @@ export default function ZarrMetadataTable({
   metadata
 }: ZarrMetadataTableProps) {
   const { zarr_version, multiscale, omero, shapes } = metadata;
+  const axisData = getAxisData(metadata);
+  
   return (
-    <div className="flex flex-col max-h-min">
+    <div className="flex flex-col gap-4 max-h-min">
+      {/* First table - General metadata */}
       <table className="bg-background/90">
         <tbody className="text-sm">
           <tr className="border-y border-surface-dark">
@@ -83,22 +89,16 @@ export default function ZarrMetadataTable({
           {metadata.arr ? (
             <tr className="border-b border-surface-dark">
               <td className="p-3 font-semibold">Data Type</td>
-              <td className="p-3">{getDataTypeString(metadata.arr)}</td>
+              <td className="p-3">{metadata.arr.dtype}</td>
             </tr>
           ) : null}
-          {multiscale?.axes ? (
-            <tr className="border-b border-surface-dark">
-              <td className="p-3 font-semibold">Axes</td>
-              <td className="p-3">{getAxesString(multiscale)}</td>
-            </tr>
-          ) : null}
-          {shapes ? (
+          {!metadata.multiscale && shapes ? (
             <tr className="border-b border-surface-dark">
               <td className="p-3 font-semibold">Shape</td>
               <td className="p-3">{getSizeString(shapes)}</td>
             </tr>
           ) : null}
-          {metadata.arr ? (
+          {!metadata.multiscale && metadata.arr ? (
             <>
               <tr className="border-b border-surface-dark">
                 <td className="p-3 font-semibold">Chunk Size</td>
@@ -106,13 +106,7 @@ export default function ZarrMetadataTable({
               </tr>
             </>
           ) : null}
-          {multiscale ? (
-            <tr className="border-b border-surface-dark">
-              <td className="p-3 font-semibold">Unit Sizes</td>
-              <td className="p-3">{getUnitSizeString(multiscale)}</td>
-            </tr>
-          ) : null}
-          {multiscale && shapes ? (
+          {metadata.multiscale && shapes ? (
             <tr className="border-b border-surface-dark">
               <td className="p-3 font-semibold">Multiscale Levels</td>
               <td className="p-3">{shapes.length}</td>
@@ -120,6 +114,32 @@ export default function ZarrMetadataTable({
           ) : null}
         </tbody>
       </table>
+
+      {/* Second table - Axis-specific metadata */}
+      {axisData.length > 0 && (
+        <table className="bg-background/90">
+          <thead className="text-sm">
+            <tr className="border-y border-surface-dark">
+              <th className="p-3 font-semibold text-left">Axes</th>
+              <th className="p-3 font-semibold text-left">Shape</th>
+              <th className="p-3 font-semibold text-left">Chunk Size</th>
+              <th className="p-3 font-semibold text-left">Scale</th>
+              <th className="p-3 font-semibold text-left">Unit</th>
+            </tr>
+          </thead>
+          <tbody className="text-sm">
+            {axisData.map((axis, index) => (
+              <tr key={axis.name} className="border-b border-surface-dark">
+                <td className="p-3 text-center">{axis.name}</td>
+                <td className="p-3 text-right">{axis.shape}</td>
+                <td className="p-3 text-right">{axis.chunkSize}</td>
+                <td className="p-3 text-right">{axis.scale}</td>
+                <td className="p-3 text-left">{axis.unit}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
+++ b/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
@@ -1,6 +1,6 @@
 import * as zarr from 'zarrita';
 import { Axis, Multiscale } from 'ome-zarr.js';
-import { Metadata } from '../../../omezarr-helper';
+import { Metadata, translateUnitToNeuroglancer } from '../../../omezarr-helper';
 
 type ZarrMetadataTableProps = {
   metadata: Metadata;
@@ -22,6 +22,47 @@ function getDataTypeString(arr: zarr.Array<any>) {
   return arr.dtype;
 }
 
+/**
+ * Find and return the first scale transform from the given coordinate transformations.
+ * @param coordinateTransformations - List of coordinate transformations
+ * @returns The first transform with type "scale", or undefined if no scale transform is found
+ */
+function getScaleTransform(coordinateTransformations: any[]) {
+  return coordinateTransformations?.find(
+    (ct: any) => ct.type === "scale"
+  ) as { scale: number[] };
+}
+
+/**
+ * Get the voxel size for the multiscale dataset, formatted as a comma-separated string.
+ * @param multiscale - The multiscale metadata
+ * @returns The voxel size string, or 'Unknown' if the voxel size cannot be determined
+ */
+function getUnitSizeString(multiscale: Multiscale) {
+  try {
+    // Get the root transform
+    const rct = getScaleTransform(multiscale.coordinateTransformations as any[]);
+    // Get the transform for the full scale dataset
+    const dataset = multiscale.datasets[0]
+    let ct = getScaleTransform(dataset.coordinateTransformations);
+    if (ct === undefined) {
+      return 'Unknown';
+    }
+    // Multiply the scale by the root transform scale
+    const fct = ct.scale.map((value: number, i: number) => value * (rct?.scale[i] || 1))
+    // Add the units to each scale value
+    const units = multiscale.axes.map(axis => translateUnitToNeuroglancer(axis.unit as string));
+    const quantities = fct.map((value: number, i: number) => {
+      return units[i] ? `${value} ${units[i]}` : `${value}`;
+    });
+    // Format the voxel size as a comma-separated string
+    return quantities.join(', ');
+  } 
+  catch (error) {
+    return 'Unknown';
+  }
+}
+
 export default function ZarrMetadataTable({
   metadata
 }: ZarrMetadataTableProps) {
@@ -39,6 +80,12 @@ export default function ZarrMetadataTable({
             <td className="p-3 font-semibold">Zarr Version</td>
             <td className="p-3">{zarr_version}</td>
           </tr>
+          {metadata.arr ? (
+            <tr className="border-b border-surface-dark">
+              <td className="p-3 font-semibold">Data Type</td>
+              <td className="p-3">{getDataTypeString(metadata.arr)}</td>
+            </tr>
+          ) : null}
           {multiscale?.axes ? (
             <tr className="border-b border-surface-dark">
               <td className="p-3 font-semibold">Axes</td>
@@ -57,15 +104,17 @@ export default function ZarrMetadataTable({
                 <td className="p-3 font-semibold">Chunk Size</td>
                 <td className="p-3">{getChunkSizeString(metadata.arr)}</td>
               </tr>
-              <tr className="border-b border-surface-dark">
-                <td className="p-3 font-semibold">Data Type</td>
-                <td className="p-3">{getDataTypeString(metadata.arr)}</td>
-              </tr>
             </>
+          ) : null}
+          {multiscale ? (
+            <tr className="border-b border-surface-dark">
+              <td className="p-3 font-semibold">Unit Sizes</td>
+              <td className="p-3">{getUnitSizeString(multiscale)}</td>
+            </tr>
           ) : null}
           {multiscale && shapes ? (
             <tr className="border-b border-surface-dark">
-              <td className="p-3 font-semibold">Mutliscale Levels</td>
+              <td className="p-3 font-semibold">Multiscale Levels</td>
               <td className="p-3">{shapes.length}</td>
             </tr>
           ) : null}

--- a/src/components/ui/BrowsePage/ZarrPreview.tsx
+++ b/src/components/ui/BrowsePage/ZarrPreview.tsx
@@ -27,11 +27,9 @@ export default function ZarrPreview({
   thumbnailError
 }: ZarrPreviewProps): React.ReactNode {
   const [isImageShared, setIsImageShared] = React.useState(false);
-  const [externalToolUrls] = React.useState<OpenWithToolUrls | null>(null);
-
   const { showDataLinkDialog, setShowDataLinkDialog } = useDataLinkDialog();
   const { proxiedPath } = useProxiedPathContext();
-  const { externalBucket } = useExternalBucketContext();
+  const { externalDataUrl } = useExternalBucketContext();
 
   React.useEffect(() => {
     setIsImageShared(proxiedPath !== null);
@@ -77,8 +75,8 @@ export default function ZarrPreview({
               onChange={() => {
                 setShowDataLinkDialog(true);
               }}
-              checked={externalBucket ? true : isImageShared}
-              disabled={externalBucket ? true : false}
+              checked={externalDataUrl ? true : isImageShared}
+              disabled={externalDataUrl ? true : false}
             />
             <label
               htmlFor="share-switch"
@@ -87,7 +85,7 @@ export default function ZarrPreview({
               <Typography
                 as="label"
                 htmlFor="share-switch"
-                className={`${externalBucket ? 'cursor-default' : 'cursor-pointer'} text-foreground font-semibold`}
+                className={`${externalDataUrl ? 'cursor-default' : 'cursor-pointer'} text-foreground font-semibold`}
               >
                 Data Link
               </Typography>
@@ -95,7 +93,7 @@ export default function ZarrPreview({
                 type="small"
                 className="text-foreground whitespace-normal max-w-[300px]"
               >
-                {externalBucket
+                {externalDataUrl
                   ? 'Public data link already exists since this data is on s3.janelia.org.'
                   : 'Creating a data link for this image allows you to open it in external viewers like Neuroglancer.'}
               </Typography>
@@ -112,10 +110,8 @@ export default function ZarrPreview({
             />
           ) : null}
 
-          {externalBucket && externalToolUrls ? (
-            <DataToolLinks title="Open with:" urls={externalToolUrls} />
-          ) : openWithToolUrls && isImageShared ? (
-            <DataToolLinks title="Open with:" urls={openWithToolUrls} />
+          {openWithToolUrls && (externalDataUrl || isImageShared) ? (
+            <DataToolLinks title="Open with:" urls={openWithToolUrls as OpenWithToolUrls} />
           ) : null}
         </div>
         {metadata && 'arr' in metadata && (

--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -442,5 +442,6 @@ export {
   getOmeZarrMetadata,
   getOmeZarrThumbnail,
   generateNeuroglancerStateForZarrArray,
-  generateNeuroglancerStateForOmeZarr
+  generateNeuroglancerStateForOmeZarr,
+  translateUnitToNeuroglancer
 };


### PR DESCRIPTION
Clickup id: 86ab01anm

Refactored axes metadata into secondary table based on feedback from @mkitti .

The metadata for an OME-Zarr now looks like this:
<img width="363" height="478" alt="Screenshot 2025-08-31 at 12 48 22 PM" src="https://github.com/user-attachments/assets/ae6fc179-877f-45e7-b72d-cefc5938b7aa" />

While a bare Zarr array looks like this:
<img width="258" height="236" alt="Screenshot 2025-08-31 at 12 48 28 PM" src="https://github.com/user-attachments/assets/7af50eaf-b266-4c35-be04-6c6da3fab586" />

This PR also fixes a bug that was preventing the "open with" links from showing up.

@StephanPreibisch @allison-truhlar @neomorphic 
