### PR TITLE
Fix: ensure content is scrollable

### DIFF
--- a/src/components/Browse.tsx
+++ b/src/components/Browse.tsx
@@ -31,7 +31,7 @@ export default function Browse() {
   const [showRenameDialog, setShowRenameDialog] = React.useState(false);
 
   return (
-    <div className="flex flex-col h-full max-h-full">
+    <div className="flex flex-col h-full min-w-fit max-h-full">
       <Toolbar
         showPropertiesDrawer={showPropertiesDrawer}
         togglePropertiesDrawer={togglePropertiesDrawer}

--- a/src/components/Browse.tsx
+++ b/src/components/Browse.tsx
@@ -39,7 +39,7 @@ export default function Browse() {
         toggleSidebar={toggleSidebar}
       />
       <div
-        className={`relative grow max-h-full flex flex-col overflow-y-auto ${!currentFileSharePath ? 'grid grid-cols-2 grid-rows-[60px_1fr] bg-surface-light gap-6 p-6' : ''}`}
+        className={`relative grow shrink-0 max-h-[calc(100%-55px)] flex flex-col overflow-y-auto px-2 ${!currentFileSharePath ? 'grid grid-cols-2 grid-rows-[60px_1fr] bg-surface-light gap-6 p-6' : ''}`}
       >
         {!currentFileSharePath ? (
           <>

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -43,7 +43,7 @@ export default function Help() {
           {`Fileglancer Version ${versionNo}`}
         </Typography>
       </div>
-      <Card>
+      <Card className="min-h-max shrink-0">
         <List className="w-fit gap-2 p-4">
           {helpLinks.map(({ icon: Icon, title, url }) => (
             <List.Item className="hover:bg-transparent focus:bg-transparent">

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -20,7 +20,7 @@ export default function Preferences() {
         Preferences
       </Typography>
 
-      <Card>
+      <Card className="min-h-max shrink-0">
         <Card.Header>
           <Typography className="font-semibold">
             Format to use for file paths:
@@ -115,7 +115,7 @@ export default function Preferences() {
         </Card.Body>
       </Card>
 
-      <Card className="mt-6">
+      <Card className="mt-6 min-h-max shrink-0">
         <Card.Header>
           <Typography className="font-semibold">Options:</Typography>
         </Card.Header>

--- a/src/components/ui/BrowsePage/Dashboard/FgDashboardCard.tsx
+++ b/src/components/ui/BrowsePage/Dashboard/FgDashboardCard.tsx
@@ -8,7 +8,7 @@ export default function DashboardCard({
   children: React.ReactNode;
 }) {
   return (
-    <Card className="w-full rounded-lg border shadow-sm overflow-hidden bg-background border-surface shadow-black/5 overflow-y-auto max-h-full">
+    <Card className="w-full border bg-background border-surface overflow-y-auto min-h-32 max-h-full">
       <Card.Header className="pt-4 pl-4">
         <Typography className="font-semibold text-surface-foreground">
           {title}

--- a/src/components/ui/BrowsePage/FileBrowser.tsx
+++ b/src/components/ui/BrowsePage/FileBrowser.tsx
@@ -48,51 +48,45 @@ export default function FileBrowser({
   } = useZarrMetadata();
 
   return (
-    <div className="px-2 transition-all duration-300 flex flex-col h-full overflow-hidden">
+    <>
       <Crumbs />
-      <div className="overflow-y-auto">
-        {metadata ? (
-          <ZarrPreview
-            metadata={metadata}
-            thumbnailSrc={thumbnailSrc}
-            loadingThumbnail={loadingThumbnail}
-            openWithToolUrls={openWithToolUrls}
-            thumbnailError={thumbnailError}
-          />
-        ) : null}
+      {metadata ? (
+        <ZarrPreview
+          metadata={metadata}
+          thumbnailSrc={thumbnailSrc}
+          loadingThumbnail={loadingThumbnail}
+          openWithToolUrls={openWithToolUrls}
+          thumbnailError={thumbnailError}
+        />
+      ) : null}
 
-        {/* Loading state */}
-        {areFileDataLoading ? (
-          <div className="min-w-full bg-background select-none">
-            {Array.from({ length: 10 }, (_, index) => (
-              <FileRowSkeleton key={index} />
-            ))}
-          </div>
-        ) : !areFileDataLoading && displayFiles.length > 0 ? (
-          <Table
-            data={displayFiles}
-            showPropertiesDrawer={showPropertiesDrawer}
-            handleContextMenuClick={handleContextMenuClick}
-          />
-        ) : !areFileDataLoading &&
-          displayFiles.length === 0 &&
-          !fileBrowserState.uiErrorMsg ? (
-          <div className="flex items-center pl-3 py-1">
-            <Typography className="text-primary-default">
-              No files available for display.
-            </Typography>
-          </div>
-        ) : !areFileDataLoading &&
-          displayFiles.length === 0 &&
-          fileBrowserState.uiErrorMsg ? (
-          /* Error state */
-          <div className="flex items-center pl-3 py-1">
-            <Typography className="text-primary-default">
-              {fileBrowserState.uiErrorMsg}
-            </Typography>
-          </div>
-        ) : null}
-      </div>
+      {/* Loading state */}
+      {areFileDataLoading ? (
+        <div className="min-w-full bg-background select-none">
+          {Array.from({ length: 10 }, (_, index) => (
+            <FileRowSkeleton key={index} />
+          ))}
+        </div>
+      ) : !areFileDataLoading && displayFiles.length > 0 ? (
+        <Table
+          data={displayFiles}
+          showPropertiesDrawer={showPropertiesDrawer}
+          handleContextMenuClick={handleContextMenuClick}
+        />
+      ) : !areFileDataLoading &&
+        displayFiles.length === 0 &&
+        !fileBrowserState.uiErrorMsg ? (
+        <div className="flex items-center pl-3 py-1">
+          <Typography>No files available for display.</Typography>
+        </div>
+      ) : !areFileDataLoading &&
+        displayFiles.length === 0 &&
+        fileBrowserState.uiErrorMsg ? (
+        /* Error state */
+        <div className="flex items-center pl-3 py-1">
+          <Typography>{fileBrowserState.uiErrorMsg}</Typography>
+        </div>
+      ) : null}
       {showContextMenu ? (
         <ContextMenu
           x={contextMenuCoords.x}
@@ -107,6 +101,6 @@ export default function FileBrowser({
           setShowConvertFileDialog={setShowConvertFileDialog}
         />
       ) : null}
-    </div>
+    </>
   );
 }

--- a/src/components/ui/widgets/TableCard.tsx
+++ b/src/components/ui/widgets/TableCard.tsx
@@ -39,7 +39,7 @@ function TableCard({
   emptyText
 }: TableCardProps) {
   return (
-    <Card>
+    <Card className="min-h-32 overflow-y-auto">
       <div
         className={`grid ${gridColsClass} gap-4 px-4 py-2 border-b border-surface dark:border-foreground`}
       >

--- a/src/hooks/useLayoutPrefs.ts
+++ b/src/hooks/useLayoutPrefs.ts
@@ -17,6 +17,8 @@ const LAYOUT_NAME = 'react-resizable-panels:layout';
 // in the respective Panel components
 const DEFAULT_LAYOUT =
   '{"main,properties,sidebar":{"expandToSizes":{},"layout":[24,50,24]}}';
+const DEFAULT_LAYOUT_SMALL_SCREENS =
+  '{"main":{"expandToSizes":{},"layout":[100]}}';
 
 // Layout keys for the two possible panel combinations
 const WITH_PROPERTIES_AND_SIDEBAR = 'main,properties,sidebar';
@@ -61,8 +63,15 @@ export default function useLayoutPrefs() {
     if (!isLayoutLoadedFromDB) {
       return;
     } else if (layout === '') {
-      // default layout includes properties drawer
-      setShowPropertiesDrawer(true);
+      // If screen is small, default to no sidebar or properties drawer
+      if (window.innerWidth < 640) {
+        setShowPropertiesDrawer(false);
+        setShowSidebar(false);
+        return;
+      } else {
+        // default layout for larger screens includes properties drawer
+        setShowPropertiesDrawer(true);
+      }
     } else {
       try {
         const parsedLayout = JSON.parse(layout);
@@ -97,13 +106,21 @@ export default function useLayoutPrefs() {
           logger.debug('Layout not loaded from DB yet, returning empty string');
           return '';
         }
-        // If layout is empty, return default layout
+        // If layout is empty, return default layout based on screen size
         if (layout === '') {
-          logger.debug(
-            'Layout is empty, returning default layout',
-            DEFAULT_LAYOUT
-          );
-          return DEFAULT_LAYOUT;
+          if (window.innerWidth < 640) {
+            logger.debug(
+              'Layout is empty and screen is small, returning default layout',
+              DEFAULT_LAYOUT_SMALL_SCREENS
+            );
+            return DEFAULT_LAYOUT_SMALL_SCREENS;
+          } else {
+            logger.debug(
+              'Layout is empty, returning default layout',
+              DEFAULT_LAYOUT
+            );
+            return DEFAULT_LAYOUT;
+          }
         }
 
         try {

--- a/src/layouts/BrowseLayout.tsx
+++ b/src/layouts/BrowseLayout.tsx
@@ -78,7 +78,7 @@ export const BrowsePageLayout = () => {
               </PanelResizeHandle>
             </>
           ) : null}
-          <Panel id="main" order={2}>
+          <Panel id="main" order={2} style={{ overflowX: 'auto' }}>
             <Outlet context={outletContextValue} />
           </Panel>
           {showPropertiesDrawer ? (


### PR DESCRIPTION
Clickup id: 86abc2f23

@krokicki @neomorphic 

This PR fixes the following scrolling issues I identified:

`/browse`, small height screens:
- In the dashboard, there was a point at which you could still see the navigation widget, but you couldn't scroll down to see the dashboard cards. This was because the dashboard cards were shrinking down to essentially a line. Now, the entire dashboard area is scroll-able in the y-direction because the dashboard cards have a minimum height set.
- In the file browser, there was a point at which you could only see the breadcrumbs and the very top of the file browser. This was because the flex item containing the file browser was shrinking.

`/browse`, small width screens:
- The toolbar couldn't scroll horizontally. Now, the entire main panel can scroll in the x direction
- I also changed the useLayout hook so that if a layout preference isn't set and the screen width is less than 640px, the sidebar and properties panel are not shown.

`/links`, `/jobs`, `/help`, `/preferences`, small height screens:
- There was a point at which the cards completely collapsed down to lines so you couldn't see anything inside them. Fixed this with minimum heights. 