### PR TITLE
style: delay file browser loader appearance to avoid flash

### DIFF
--- a/src/components/ui/widgets/Loaders.tsx
+++ b/src/components/ui/widgets/Loaders.tsx
@@ -20,7 +20,8 @@ function Spinner({
 
 function FileRowSkeleton(): JSX.Element {
   return (
-    <div className="grid grid-cols-[minmax(170px,2fr)_minmax(80px,1fr)_minmax(95px,1fr)_minmax(75px,1fr)_minmax(40px,1fr)] gap-6 animate-pulse">
+    <div className="grid grid-cols-[minmax(170px,2fr)_minmax(80px,1fr)_minmax(95px,1fr)_minmax(75px,1fr)_minmax(40px,1fr)] gap-6 animate-appear animate-pulse animate-delay-150 opacity-0">
+      {/* For div above, after specified delay, executes animate-appear to convert opacity to 1 and then let animate-pulse take over */}
       {/* Name column */}
       <div className="flex items-center pl-3 py-2">
         <div className="w-40 h-4 bg-surface rounded "></div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,4 @@
+import plugin from 'tailwindcss';
 import { mtConfig } from '@material-tailwind/react';
 
 /** @type {import('tailwindcss').Config} */
@@ -16,10 +17,41 @@ const config = {
       },
       screens: {
         short: { raw: '(min-height: 0px) and (max-height: 420px)' }
+      },
+      // Animation to make elements immediately appear (used for file browser skeleton loader)
+      //https://stackoverflow.com/questions/73802482/tailwind-css-transition-on-load
+      keyframes: {
+        appear: {
+          '0%': {
+            opacity: '0'
+          },
+          '100%': {
+            opacity: '1'
+          }
+        }
+      },
+      animation: {
+        appear: 'appear 0.01s ease-in-out backwards'
       }
     }
   },
   plugins: [
+    // Custom plugin to add animation delay utility
+    // https://github.com/tailwindlabs/tailwindcss/discussions/3378#discussioncomment-4177286
+    plugin(({ matchUtilities, theme }) => {
+      matchUtilities(
+        {
+          'animation-delay': value => {
+            return {
+              'animation-delay': value
+            };
+          }
+        },
+        {
+          values: theme('transitionDelay')
+        }
+      );
+    }),
     mtConfig({
       colors: {
         background: '#FFFFFF',


### PR DESCRIPTION
Clickup id: 86abm3ur5

@krokicki @neomorphic 
This PR addresses the issue of the skeleton loader flashing briefly in the file browser. It adds another animation that makes elements transition almost immediately from 0 to 1 opacity and a utility that sets a delay to animations. Then in the outermost div of the FileRowSkeleton component, two animations are applied: animate-appear and animate-pulse. Both are delayed by 150ms (currently, this can be adjusted) so that after 150ms, the opacity changes from 0 to 1 almost immediately and then animation-pulse takes over.

https://github.com/user-attachments/assets/d7469bcf-37cf-4a7e-b104-83e5400071e8

