### PR TITLE
Neuroglancer state generation improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Test the extension frontend
       run: |
         set -eux
-        pixi run --environment default test-frontend
+        pixi run test-frontend
 
     - name: Test the extension backend
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ dev-watch = { cmd = "NODE_ENV=development npm run watch" }
 dev-launch = { cmd = "NODE_ENV=development jupyter lab --autoreload" }
 dev-launch-remote = { cmd = "NODE_ENV=development jupyter lab --autoreload --ip=0.0.0.0 --no-browser" }
 node-install-ui-test = "npm --prefix ui-tests install"
-test-frontend = "npm run test"
 ui-test = { cmd = "npm --prefix ui-tests run test", depends-on = ["node-install-ui-test"] }
 
 [tool.pixi.dependencies]

--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -11,7 +11,9 @@ export default function Preferences() {
     hideDotFiles,
     toggleHideDotFiles,
     disableNeuroglancerStateGeneration,
-    toggleDisableNeuroglancerStateGeneration
+    toggleDisableNeuroglancerStateGeneration,
+    disableHeuristicalLayerTypeDetection,
+    toggleDisableHeuristicalLayerTypeDetection
   } = usePreferencesContext();
 
   return (
@@ -173,6 +175,35 @@ export default function Preferences() {
               className="text-foreground"
             >
               Disable Neuroglancer state generation
+            </Typography>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              className="icon-small checked:accent-secondary-light"
+              type="checkbox"
+              id="disable_heuristical_layer_type_detection"
+              checked={disableHeuristicalLayerTypeDetection ?? false}
+              onChange={async () => {
+                const result =
+                  await toggleDisableHeuristicalLayerTypeDetection();
+                if (result.success) {
+                  toast.success(
+                    disableHeuristicalLayerTypeDetection
+                      ? 'Heuristical layer type determination is now enabled'
+                      : 'Heuristical layer type determination is now disabled'
+                  );
+                } else {
+                  toast.error(result.error);
+                }
+              }}
+            />
+            <Typography
+              as="label"
+              htmlFor="disable_heuristical_layer_type_detection"
+              className="text-foreground"
+            >
+              Disable heuristical layer type determination
             </Typography>
           </div>
         </Card.Body>

--- a/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
+++ b/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
@@ -1,6 +1,11 @@
 import * as zarr from 'zarrita';
 import { Axis } from 'ome-zarr.js';
-import { Metadata, translateUnitToNeuroglancer, getScaleTransform, getResolvedScales } from '../../../omezarr-helper';
+import {
+  Metadata,
+  translateUnitToNeuroglancer,
+  getScaleTransform,
+  getResolvedScales
+} from '../../../omezarr-helper';
 
 type ZarrMetadataTableProps = {
   metadata: Metadata;
@@ -31,10 +36,12 @@ function getAxisData(metadata: Metadata) {
       const shape = shapes[0][index] || 'Unknown';
       const chunkSize = arr.chunks[index] || 'Unknown';
 
-      const scale = resolvedScales?.[index] != null ? 
-        (Number.isInteger(resolvedScales[index]) ? 
-          resolvedScales[index].toString() : 
-          resolvedScales[index].toFixed(4)) : 'Unknown';
+      const scale =
+        resolvedScales?.[index] != null
+          ? Number.isInteger(resolvedScales[index])
+            ? resolvedScales[index].toString()
+            : resolvedScales[index].toFixed(4)
+          : 'Unknown';
       const unit = translateUnitToNeuroglancer(axis.unit as string) || '';
 
       return {

--- a/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
+++ b/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
@@ -1,6 +1,6 @@
 import * as zarr from 'zarrita';
 import { Axis } from 'ome-zarr.js';
-import { Metadata, translateUnitToNeuroglancer } from '../../../omezarr-helper';
+import { Metadata, translateUnitToNeuroglancer, getScaleTransform, getResolvedScales } from '../../../omezarr-helper';
 
 type ZarrMetadataTableProps = {
   metadata: Metadata;
@@ -15,17 +15,6 @@ function getChunkSizeString(arr: zarr.Array<any>) {
 }
 
 /**
- * Find and return the first scale transform from the given coordinate transformations.
- * @param coordinateTransformations - List of coordinate transformations
- * @returns The first transform with type "scale", or undefined if no scale transform is found
- */
-function getScaleTransform(coordinateTransformations: any[]) {
-  return coordinateTransformations?.find((ct: any) => ct.type === 'scale') as {
-    scale: number[];
-  };
-}
-
-/**
  * Get axis-specific metadata for creating the second table
  * @param metadata - The Zarr metadata
  * @returns Array of axis data with name, shape, chunk size, scale, and unit
@@ -35,25 +24,17 @@ function getAxisData(metadata: Metadata) {
   if (!multiscale?.axes || !shapes?.[0] || !arr) {
     return [];
   }
-
   try {
-    // Get the root transform
-    const rct = getScaleTransform(
-      multiscale.coordinateTransformations as any[]
-    );
-    const rootScales = rct?.scale || [];
-
-    // Get the transform for the full scale dataset
-    const dataset = multiscale.datasets[0];
-    const ct = getScaleTransform(dataset.coordinateTransformations);
-    const scales = ct?.scale || [];
+    const resolvedScales = getResolvedScales(multiscale);
 
     return multiscale.axes.map((axis: Axis, index: number) => {
       const shape = shapes[0][index] || 'Unknown';
       const chunkSize = arr.chunks[index] || 'Unknown';
-      const scale = scales[index]
-        ? Number((scales[index] * (rootScales[index] || 1)).toFixed(4))
-        : 'Unknown';
+      
+      const scale = resolvedScales?.[index] != null ? 
+        (Number.isInteger(resolvedScales[index]) ? 
+          resolvedScales[index].toString() : 
+          resolvedScales[index].toFixed(4)) : 'Unknown';
       const unit = translateUnitToNeuroglancer(axis.unit as string) || '';
 
       return {
@@ -120,7 +101,7 @@ export default function ZarrMetadataTable({
       </table>
 
       {/* Second table - Axis-specific metadata */}
-      {axisData.length > 0 && (
+      {axisData?.length > 0 && (
         <table className="bg-background/90">
           <thead className="text-sm">
             <tr className="border-y border-surface-dark">

--- a/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
+++ b/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
@@ -30,7 +30,7 @@ function getAxisData(metadata: Metadata) {
     return multiscale.axes.map((axis: Axis, index: number) => {
       const shape = shapes[0][index] || 'Unknown';
       const chunkSize = arr.chunks[index] || 'Unknown';
-      
+
       const scale = resolvedScales?.[index] != null ? 
         (Number.isInteger(resolvedScales[index]) ? 
           resolvedScales[index].toString() : 
@@ -54,7 +54,7 @@ function getAxisData(metadata: Metadata) {
 export default function ZarrMetadataTable({
   metadata
 }: ZarrMetadataTableProps) {
-  const { zarr_version, multiscale, shapes } = metadata;
+  const { zarrVersion, multiscale, shapes } = metadata;
   const axisData = getAxisData(metadata);
 
   return (
@@ -69,7 +69,7 @@ export default function ZarrMetadataTable({
           </tr>
           <tr className="border-y border-surface-dark">
             <td className="p-3 font-semibold">Zarr Version</td>
-            <td className="p-3">{zarr_version}</td>
+            <td className="p-3">{zarrVersion}</td>
           </tr>
           {metadata.arr ? (
             <tr className="border-b border-surface-dark">

--- a/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
+++ b/src/components/ui/BrowsePage/ZarrMetadataTable.tsx
@@ -3,7 +3,6 @@ import { Axis } from 'ome-zarr.js';
 import {
   Metadata,
   translateUnitToNeuroglancer,
-  getScaleTransform,
   getResolvedScales
 } from '../../../omezarr-helper';
 
@@ -37,7 +36,7 @@ function getAxisData(metadata: Metadata) {
       const chunkSize = arr.chunks[index] || 'Unknown';
 
       const scale =
-        resolvedScales?.[index] != null
+        resolvedScales?.[index] !== null
           ? Number.isInteger(resolvedScales[index])
             ? resolvedScales[index].toString()
             : resolvedScales[index].toFixed(4)

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -33,6 +33,8 @@ type PreferencesContextType = {
   toggleHideDotFiles: () => Promise<Result<void>>;
   disableNeuroglancerStateGeneration: boolean;
   toggleDisableNeuroglancerStateGeneration: () => Promise<Result<void>>;
+  disableHeuristicalLayerTypeDetection: boolean;
+  toggleDisableHeuristicalLayerTypeDetection: () => Promise<Result<void>>;
   zonePreferenceMap: Record<string, ZonePreference>;
   zoneFavorites: Zone[];
   fileSharePathPreferenceMap: Record<string, FileSharePathPreference>;
@@ -78,6 +80,10 @@ export const PreferencesProvider = ({
   const [
     disableNeuroglancerStateGeneration,
     setDisableNeuroglancerStateGeneration
+  ] = React.useState<boolean>(false);
+  const [
+    disableHeuristicalLayerTypeDetection,
+    setDisableHeuristicalLayerTypeDetection
   ] = React.useState<boolean>(false);
   const [zonePreferenceMap, setZonePreferenceMap] = React.useState<
     Record<string, ZonePreference>
@@ -250,6 +256,25 @@ export const PreferencesProvider = ({
             const newValue = !prevDisableNeuroglancerStateGeneration;
             savePreferencesToBackend(
               'disableNeuroglancerStateGeneration',
+              newValue
+            );
+            return newValue;
+          }
+        );
+      } catch (error) {
+        return handleError(error);
+      }
+      return createSuccess(undefined);
+    }, [savePreferencesToBackend]);
+
+  const toggleDisableHeuristicalLayerTypeDetection =
+    React.useCallback(async (): Promise<Result<void>> => {
+      try {
+        setDisableHeuristicalLayerTypeDetection(
+          prevDisableHeuristicalLayerTypeDetection => {
+            const newValue = !prevDisableHeuristicalLayerTypeDetection;
+            savePreferencesToBackend(
+              'disableHeuristicalLayerTypeDetection',
               newValue
             );
             return newValue;
@@ -514,6 +539,23 @@ export const PreferencesProvider = ({
   }, [fetchPreferences]);
 
   React.useEffect(() => {
+    (async function () {
+      const rawDisableHeuristicalLayerTypeDetection = await fetchPreferences(
+        'disableHeuristicalLayerTypeDetection'
+      );
+      if (rawDisableHeuristicalLayerTypeDetection !== null) {
+        log.debug(
+          'setting initial disableHeuristicalLayerTypeDetection preference:',
+          rawDisableHeuristicalLayerTypeDetection
+        );
+        setDisableHeuristicalLayerTypeDetection(
+          rawDisableHeuristicalLayerTypeDetection
+        );
+      }
+    })();
+  }, [fetchPreferences]);
+
+  React.useEffect(() => {
     if (!isZonesMapReady) {
       return;
     }
@@ -662,6 +704,8 @@ export const PreferencesProvider = ({
         toggleHideDotFiles,
         disableNeuroglancerStateGeneration,
         toggleDisableNeuroglancerStateGeneration,
+        disableHeuristicalLayerTypeDetection,
+        toggleDisableHeuristicalLayerTypeDetection,
         zonePreferenceMap,
         zoneFavorites,
         fileSharePathPreferenceMap,

--- a/src/hooks/useZarrMetadata.ts
+++ b/src/hooks/useZarrMetadata.ts
@@ -207,10 +207,7 @@ export default function useZarrMetadata() {
     );
     const url = externalDataUrl || dataUrl;
 
-
-
     if (metadata && url) {
-
       (async () => {
         const uniqueValueCount = await getPercentUniqueValues(metadata, url);
         console.log('Percentage unique values:', uniqueValueCount);
@@ -257,12 +254,12 @@ export default function useZarrMetadata() {
               neuroglancerBaseUrl + generateNeuroglancerStateForDataURL(url);
           } else {
             openWithToolUrls.neuroglancer =
-              neuroglancerBaseUrl + generateNeuroglancerStateForZarrArray(url, 2, layerType);
+              neuroglancerBaseUrl +
+              generateNeuroglancerStateForZarrArray(url, 2, layerType);
           }
         }
         setOpenWithToolUrls(openWithToolUrls);
       })();
-      
     }
   }, [metadata, dataUrl, externalDataUrl, disableNeuroglancerStateGeneration]);
 

--- a/src/hooks/useZarrMetadata.ts
+++ b/src/hooks/useZarrMetadata.ts
@@ -209,7 +209,7 @@ export default function useZarrMetadata() {
 
     if (metadata && url) {
       (async () => {
-        const uniqueValueCount = await getPercentUniqueValues(metadata, url);
+        const uniqueValueCount = await getPercentUniqueValues(metadata);
         console.log('Percentage unique values:', uniqueValueCount);
         const layerType = uniqueValueCount < 0.001 ? 'segmentation' : 'image';
         console.log('Assuming layer type:', layerType);

--- a/src/hooks/useZarrMetadata.ts
+++ b/src/hooks/useZarrMetadata.ts
@@ -9,7 +9,7 @@ import {
   generateNeuroglancerStateForDataURL,
   generateNeuroglancerStateForZarrArray,
   generateNeuroglancerStateForOmeZarr,
-  getPercentUniqueValues
+  getLayerType
 } from '@/omezarr-helper';
 import type { Metadata } from '@/omezarr-helper';
 import { fetchFileAsJson, getFileURL } from '@/utils';
@@ -209,10 +209,9 @@ export default function useZarrMetadata() {
 
     if (metadata && url) {
       (async () => {
-        const uniqueValueCount = await getPercentUniqueValues(metadata);
-        console.log('Percentage unique values:', uniqueValueCount);
-        const layerType = uniqueValueCount < 0.001 ? 'segmentation' : 'image';
-        console.log('Assuming layer type:', layerType);
+        const determinedLayerType = await getLayerType(metadata);
+        console.log('Determined layer type:', determinedLayerType);
+        
 
         const openWithToolUrls = {
           copy: url
@@ -231,7 +230,7 @@ export default function useZarrMetadata() {
                 generateNeuroglancerStateForOmeZarr(
                   url,
                   metadata.zarrVersion,
-                  layerType,
+                  determinedLayerType,
                   metadata.multiscale,
                   metadata.arr,
                   metadata.omero
@@ -255,7 +254,11 @@ export default function useZarrMetadata() {
           } else {
             openWithToolUrls.neuroglancer =
               neuroglancerBaseUrl +
-              generateNeuroglancerStateForZarrArray(url, 2, layerType);
+              generateNeuroglancerStateForZarrArray(
+                url,
+                2,
+                determinedLayerType
+              );
           }
         }
         setOpenWithToolUrls(openWithToolUrls);

--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -608,17 +608,17 @@ async function getLayerType(
     if (metadata.multiscale && metadata.multiscale.axes) {
       const axesMap = getAxesMap(metadata.multiscale);
 
-      // // Check for multiple timepoints
-      // if (axesMap.t && metadata.arr.shape[axesMap.t.index] > 1) {
-      //   log.debug('Multiple timepoints detected, assuming image');
-      //   return 'image';
-      // }
+      // Check for multiple timepoints
+      if (axesMap.t && metadata.arr.shape[axesMap.t.index] > 1) {
+        log.debug('Multiple timepoints detected, assuming image');
+        return 'image';
+      }
 
-      // // Check for multiple channels
-      // if (axesMap.c && metadata.arr.shape[axesMap.c.index] > 1) {
-      //   log.debug('Multiple channels detected, assuming image');
-      //   return 'image';
-      // }
+      // Check for multiple channels
+      if (axesMap.c && metadata.arr.shape[axesMap.c.index] > 1) {
+        log.debug('Multiple channels detected, assuming image');
+        return 'image';
+      }
     }
 
     // If no multiple timepoints or channels, analyze unique values

--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -154,22 +154,32 @@ function getNeuroglancerSource(dataUrl: string, zarr_version: 2 | 3): string {
   return dataUrl + '|zarr' + zarr_version + ':';
 }
 
+/**
+ * Get the layer name for a given URL, the same way that Neuroglancer does it.
+ */
 function getLayerName(dataUrl: string): string {
+  // Get the last component of the URL after the final slash (filter(Boolean) discards empty strings)
   return dataUrl.split('/').filter(Boolean).pop() || 'Default';
 }
 
 function generateNeuroglancerStateForDataURL(dataUrl: string): string | null {
   log.debug('Generating Neuroglancer state for Zarr array:', dataUrl);
-
+  const layerName = getLayerName(dataUrl);
   const layer: Record<string, any> = {
-    // Get the last component of the URL after the final slash (filter(Boolean) discards empty strings)
-    name: getLayerName(dataUrl),
-    source: dataUrl
+    name: layerName,
+    source: dataUrl,
+    type: 'new'
   };
 
-  // Create the scaffold for theNeuroglancer viewer state
+  // The intent of this state is to reproduce the behavior of the Neuroglancer viewer 
+  // when a URL is pasted into source input.
   const state: any = {
-    layers: [layer]
+    layers: [layer],
+    selectedLayer: {
+      visible: true,
+      layer: layerName
+    },
+    layout: '4panel-alt'
   };
 
   // Convert the state to a URL-friendly format

--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -514,12 +514,12 @@ async function getPercentUniqueValues(
     const arr = metadata.arr;
     const arrayShape = arr.shape;
     const chunks = arr.chunks;
-
-    log.debug('Array shape:', arrayShape);
-    log.debug('Chunk sizes:', chunks);
+    log.trace('Array shape:', arrayShape);
+    log.trace('Chunk sizes:', chunks);
 
     // Calculate the center point of the array
     const centerPoint = arrayShape.map(dimSize => Math.floor(dimSize / 2));
+    log.trace('Center point:', centerPoint);
 
     // Align crop to chunk boundaries
     const startIndices: number[] = [];
@@ -527,14 +527,19 @@ async function getPercentUniqueValues(
 
     for (let i = 0; i < arrayShape.length; i++) {
       const chunkSize = chunks[i];
+      log.trace('Chunk size:', chunkSize);
       const center = centerPoint[i];
+      log.trace('Center:', center);
 
       // Find which chunk contains the center point
       const centerChunkIndex = Math.floor(center / chunkSize);
+      log.trace('Center chunk index:', centerChunkIndex);
 
       // Calculate the start and end indices
-      startIndices[i] = centerChunkIndex * cropSize;
-      endIndices[i] = startIndices[i] + cropSize;
+      startIndices[i] = centerChunkIndex * chunkSize;
+      log.trace('Start index:', startIndices[i]);
+      endIndices[i] = Math.min(startIndices[i] + cropSize, arrayShape[i]);
+      log.trace('End index:', endIndices[i]);
     }
 
     // Create selection slice for the crop

--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -502,7 +502,10 @@ async function getOmeZarrThumbnail(
  * @param dataUrl - The URL of the zarr array
  * @returns Promise<number> - The percentage of unique values in the sampled data
  */
-async function getPercentUniqueValues(metadata: Metadata, dataUrl: string): Promise<number> {
+async function getPercentUniqueValues(
+  metadata: Metadata,
+  dataUrl: string
+): Promise<number> {
   log.debug(
     'Fetching centermost chunk for percentage unique values analysis from',
     dataUrl

--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -611,27 +611,8 @@ async function getLayerType(
   try {
     // If heuristical detection is disabled, return "auto"
     if (!useHeuristicalDetection) {
-      log.debug(
-        'Heuristical layer type detection is disabled, assuming image'
-      );
+      log.debug('Heuristical layer type detection is disabled, assuming image');
       return 'image';
-    }
-
-    // Check if we have multiscale metadata with axes information
-    if (metadata.multiscale && metadata.multiscale.axes) {
-      const axesMap = getAxesMap(metadata.multiscale);
-
-      // Check for multiple timepoints
-      if (axesMap.t && metadata.arr.shape[axesMap.t.index] > 1) {
-        log.debug('Multiple timepoints detected, assuming image');
-        return 'image';
-      }
-
-      // Check for multiple channels
-      if (axesMap.c && metadata.arr.shape[axesMap.c.index] > 1) {
-        log.debug('Multiple channels detected, assuming image');
-        return 'image';
-      }
     }
 
     // If no multiple timepoints or channels, analyze unique values


### PR DESCRIPTION
Clickup ids: 86abk3vnm and 86abn3x6p

When Neuroglancer state generation is disabled, this now generates the same state that you would get if you pasted the URL directly into Neuroglancer.

In addition, we now implement a sampling step to classify the image type automatically. It randomly samples a subset of voxels from the volume and compute the ratio of unique intensity values to the total number of samples. If this ratio exceeds a predefined threshold (currently 0.1%), infer that the dataset represents a segmentation volume rather than a natural image. In such cases, we automatically configure Neuroglancer with the "segmentation" layer setting. 

@StephanPreibisch @vaxenburg @allison-truhlar @neomorphic 
