### PR TITLE
Zarr v3 support

### DIFF
--- a/src/hooks/useZarrMetadata.ts
+++ b/src/hooks/useZarrMetadata.ts
@@ -70,7 +70,7 @@ export default function useZarrMetadata() {
           fileBrowserState.currentFileOrFolder.path
         );
         const zarrayFile = fileBrowserState.files.find(
-          file => file.name === '.zarray'
+          file => file.name === 'zarr.json' || file.name === '.zarray'
         );
         if (zarrayFile) {
           try {

--- a/src/omezarr-helper.ts
+++ b/src/omezarr-helper.ts
@@ -395,9 +395,9 @@ function generateNeuroglancerStateForOmeZarr(
 
 async function getZarrArray(dataUrl: string): Promise<zarr.Array<any>> {
   log.debug('Getting Zarr array for', dataUrl);
-  const zarr_version = 2;
   const store = new zarr.FetchStore(dataUrl);
-  return await omezarr.getArray(store, '/', zarr_version);
+  // Leave zarr_version undefined to allow omezarr to detect version
+  return await omezarr.getArray(store, '/');
 }
 
 /**


### PR DESCRIPTION
Add initial Zarr v3 support

- [x] Recognize zarr.json in addition to .zarray
- [x] Allow ome-zarr.js to determine zarr_version (defaults to 2)
- [ ] Get metadata from zarr.json instead of .zattrs
