### PR TITLE
feat: add preference to enable automatic data link creation

### DIFF
--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -3,6 +3,7 @@ import { Card, Typography } from '@material-tailwind/react';
 import toast from 'react-hot-toast';
 
 import { usePreferencesContext } from '@/contexts/PreferencesContext';
+import AutomaticLinksToggle from '@/components/ui/PreferencesPage/AutomaticLinksToggle';
 
 export default function Preferences() {
   const {
@@ -146,6 +147,10 @@ export default function Preferences() {
             >
               Hide dot files (files and folders starting with ".")
             </Typography>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <AutomaticLinksToggle />
           </div>
 
           <div className="flex items-center gap-2">

--- a/src/components/ui/BrowsePage/DataToolLinks.tsx
+++ b/src/components/ui/BrowsePage/DataToolLinks.tsx
@@ -56,7 +56,7 @@ export default function DataToolLinks({
         {title}
       </Typography>
       <ButtonGroup className="relative">
-        {urls?.neuroglancer ? (
+        {urls?.neuroglancer !== undefined ? (
           <FgTooltip
             as={Button}
             variant="ghost"
@@ -79,7 +79,7 @@ export default function DataToolLinks({
           </FgTooltip>
         ) : null}
 
-        {urls?.vole ? (
+        {urls?.vole !== undefined ? (
           <FgTooltip
             as={Button}
             variant="ghost"
@@ -102,7 +102,7 @@ export default function DataToolLinks({
           </FgTooltip>
         ) : null}
 
-        {urls?.avivator ? (
+        {urls?.avivator !== undefined ? (
           <FgTooltip
             as={Button}
             variant="ghost"
@@ -125,7 +125,7 @@ export default function DataToolLinks({
           </FgTooltip>
         ) : null}
 
-        {urls?.validator ? (
+        {urls?.validator !== undefined ? (
           <FgTooltip
             as={Button}
             variant="ghost"
@@ -147,7 +147,7 @@ export default function DataToolLinks({
           </FgTooltip>
         ) : null}
 
-        {urls?.copy ? (
+        {urls?.copy !== undefined ? (
           <FgTooltip
             as={Button}
             variant="ghost"

--- a/src/components/ui/BrowsePage/DataToolLinks.tsx
+++ b/src/components/ui/BrowsePage/DataToolLinks.tsx
@@ -8,17 +8,26 @@ import volE_logo from '@/assets/aics_website-3d-cell-viewer.png';
 import avivator_logo from '@/assets/vizarr_logo.png';
 import copy_logo from '@/assets/copy-link-64.png';
 import type { OpenWithToolUrls } from '@/hooks/useZarrMetadata';
+import type { ProxiedPath } from '@/contexts/ProxiedPathContext';
 import { copyToClipboard } from '@/utils/copyText';
-import FgTooltip from '../widgets/FgTooltip';
+import FgTooltip from '@/components/ui/widgets/FgTooltip';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
 
 export default function DataToolLinks({
   title,
-  urls
+  proxiedPath,
+  urls,
+  setShowDataLinkDialog,
+  setPendingNavigationUrl
 }: {
   title: string;
-  urls: OpenWithToolUrls;
+  proxiedPath: ProxiedPath | null;
+  urls: OpenWithToolUrls | null;
+  setShowDataLinkDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  setPendingNavigationUrl?: React.Dispatch<React.SetStateAction<string | null>>;
 }): React.ReactNode {
   const [showCopiedTooltip, setShowCopiedTooltip] = React.useState(false);
+  const { automaticDataLinks } = usePreferencesContext();
 
   const handleCopyUrl = async () => {
     if (urls?.copy) {
@@ -27,6 +36,14 @@ export default function DataToolLinks({
       setTimeout(() => {
         setShowCopiedTooltip(false);
       }, 2000);
+    }
+  };
+
+  const handleLinkClick = (url: string, event: React.MouseEvent) => {
+    if (!proxiedPath && !automaticDataLinks && setPendingNavigationUrl) {
+      event.preventDefault();
+      setPendingNavigationUrl(url);
+      setShowDataLinkDialog(true);
     }
   };
 
@@ -39,7 +56,7 @@ export default function DataToolLinks({
         {title}
       </Typography>
       <ButtonGroup className="relative">
-        {urls.neuroglancer ? (
+        {urls?.neuroglancer ? (
           <FgTooltip
             as={Button}
             variant="ghost"
@@ -51,6 +68,7 @@ export default function DataToolLinks({
               to={urls.neuroglancer}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={e => handleLinkClick(urls.neuroglancer, e)}
             >
               <img
                 src={neuroglancer_logo}
@@ -61,7 +79,7 @@ export default function DataToolLinks({
           </FgTooltip>
         ) : null}
 
-        {urls.vole ? (
+        {urls?.vole ? (
           <FgTooltip
             as={Button}
             variant="ghost"
@@ -69,7 +87,12 @@ export default function DataToolLinks({
             label="View in Vol-E"
           >
             {' '}
-            <Link to={urls.vole} target="_blank" rel="noopener noreferrer">
+            <Link
+              to={urls.vole}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={e => handleLinkClick(urls.vole, e)}
+            >
               <img
                 src={volE_logo}
                 alt="Vol-E logo"
@@ -79,7 +102,7 @@ export default function DataToolLinks({
           </FgTooltip>
         ) : null}
 
-        {urls.avivator ? (
+        {urls?.avivator ? (
           <FgTooltip
             as={Button}
             variant="ghost"
@@ -87,7 +110,12 @@ export default function DataToolLinks({
             label="View in Avivator"
           >
             {' '}
-            <Link to={urls.avivator} target="_blank" rel="noopener noreferrer">
+            <Link
+              to={urls.avivator}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={e => handleLinkClick(urls.avivator, e)}
+            >
               <img
                 src={avivator_logo}
                 alt="Avivator logo"
@@ -97,14 +125,19 @@ export default function DataToolLinks({
           </FgTooltip>
         ) : null}
 
-        {urls.validator ? (
+        {urls?.validator ? (
           <FgTooltip
             as={Button}
             variant="ghost"
             triggerClasses={tooltipTriggerClasses}
             label="View in OME-Zarr Validator"
           >
-            <Link to={urls.validator} target="_blank" rel="noopener noreferrer">
+            <Link
+              to={urls.validator}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={e => handleLinkClick(urls.validator!, e)}
+            >
               <img
                 src={validator_logo}
                 alt="OME-Zarr Validator logo"
@@ -114,7 +147,7 @@ export default function DataToolLinks({
           </FgTooltip>
         ) : null}
 
-        {urls.copy ? (
+        {urls?.copy ? (
           <FgTooltip
             as={Button}
             variant="ghost"

--- a/src/components/ui/BrowsePage/ZarrPreview.tsx
+++ b/src/components/ui/BrowsePage/ZarrPreview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Typography } from '@material-tailwind/react';
+import { Typography } from '@material-tailwind/react';
 
 import zarrLogo from '@/assets/zarr.jpg';
 import ZarrMetadataTable from '@/components/ui/BrowsePage/ZarrMetadataTable';
@@ -26,14 +26,12 @@ export default function ZarrPreview({
   metadata,
   thumbnailError
 }: ZarrPreviewProps): React.ReactNode {
-  const [isImageShared, setIsImageShared] = React.useState(false);
+  const [pendingNavigationUrl, setPendingNavigationUrl] = React.useState<
+    string | null
+  >(null);
   const { showDataLinkDialog, setShowDataLinkDialog } = useDataLinkDialog();
   const { proxiedPath } = useProxiedPathContext();
   const { externalDataUrl } = useExternalBucketContext();
-
-  React.useEffect(() => {
-    setIsImageShared(proxiedPath !== null);
-  }, [proxiedPath]);
 
   return (
     <div className="my-4 p-4 shadow-sm rounded-md bg-primary-light/30">
@@ -68,52 +66,24 @@ export default function ZarrPreview({
             ) : null}
           </div>
 
-          <div className="flex items-center gap-2">
-            <Switch
-              id="share-switch"
-              className="mt-2 bg-secondary-light border-secondary-light hover:!bg-secondary-light/80 hover:!border-secondary-light/80"
-              onChange={() => {
-                setShowDataLinkDialog(true);
-              }}
-              checked={externalDataUrl ? true : isImageShared}
-              disabled={externalDataUrl ? true : false}
-            />
-            <label
-              htmlFor="share-switch"
-              className="-translate-y-0.5 flex flex-col gap-1"
-            >
-              <Typography
-                as="label"
-                htmlFor="share-switch"
-                className={`${externalDataUrl ? 'cursor-default' : 'cursor-pointer'} text-foreground font-semibold`}
-              >
-                Data Link
-              </Typography>
-              <Typography
-                type="small"
-                className="text-foreground whitespace-normal max-w-[300px]"
-              >
-                {externalDataUrl
-                  ? 'Public data link already exists since this data is on s3.janelia.org.'
-                  : 'Creating a data link for this image allows you to open it in external viewers like Neuroglancer.'}
-              </Typography>
-            </label>
-          </div>
-
-          {showDataLinkDialog ? (
-            <DataLinkDialog
-              isImageShared={isImageShared}
-              setIsImageShared={setIsImageShared}
-              showDataLinkDialog={showDataLinkDialog}
-              setShowDataLinkDialog={setShowDataLinkDialog}
+          {openWithToolUrls || externalDataUrl ? (
+            <DataToolLinks
+              title="Open with:"
               proxiedPath={proxiedPath}
+              urls={openWithToolUrls as OpenWithToolUrls}
+              setShowDataLinkDialog={setShowDataLinkDialog}
+              setPendingNavigationUrl={setPendingNavigationUrl}
             />
           ) : null}
 
-          {openWithToolUrls && (externalDataUrl || isImageShared) ? (
-            <DataToolLinks
-              title="Open with:"
-              urls={openWithToolUrls as OpenWithToolUrls}
+          {showDataLinkDialog ? (
+            <DataLinkDialog
+              action="create"
+              showDataLinkDialog={showDataLinkDialog}
+              setShowDataLinkDialog={setShowDataLinkDialog}
+              proxiedPath={proxiedPath}
+              pendingNavigationUrl={pendingNavigationUrl}
+              setPendingNavigationUrl={setPendingNavigationUrl}
             />
           ) : null}
         </div>

--- a/src/components/ui/Dialogs/ConvertFile.tsx
+++ b/src/components/ui/Dialogs/ConvertFile.tsx
@@ -78,7 +78,7 @@ export default function ConvertFileDialog({
         }}
       >
         <TextWithFilePath text="Source Folder" path={displayPath} />
-        <div className="flex flex-col gap-2 mb-4">
+        <div className="flex flex-col gap-2 my-4">
           <Typography
             as="label"
             htmlFor="destination_folder"

--- a/src/components/ui/Dialogs/Delete.tsx
+++ b/src/components/ui/Dialogs/Delete.tsx
@@ -47,7 +47,7 @@ export default function DeleteDialog({
       />
       <Button
         color="error"
-        className="!rounded-md"
+        className="!rounded-md mt-4"
         onClick={async () => {
           const result = await handleDelete(fileBrowserState.propertiesTarget!);
           if (!result.success) {

--- a/src/components/ui/Dialogs/TextWithFilePath.tsx
+++ b/src/components/ui/Dialogs/TextWithFilePath.tsx
@@ -8,7 +8,7 @@ export default function TextWithFilePath({
   path: string;
 }): JSX.Element {
   return (
-    <div className="flex flex-col gap-2 mb-4">
+    <div className="flex flex-col gap-2">
       <Typography className="text-foreground font-semibold">{text}</Typography>
       <Typography className="text-foreground text-sm font-mono break-all">
         {path}

--- a/src/components/ui/LinksPage/ProxiedPathRow.tsx
+++ b/src/components/ui/LinksPage/ProxiedPathRow.tsx
@@ -140,7 +140,7 @@ export default function ProxiedPathRow({ item }: ProxiedPathRowProps) {
       {/* Sharing dialog */}
       {showDataLinkDialog ? (
         <DataLinkDialog
-          isImageShared={true}
+          action="delete"
           showDataLinkDialog={showDataLinkDialog}
           setShowDataLinkDialog={setShowDataLinkDialog}
           proxiedPath={item}

--- a/src/components/ui/Notifications.tsx
+++ b/src/components/ui/Notifications.tsx
@@ -28,32 +28,40 @@ const getNotificationStyles = (type: string) => {
   switch (type) {
     case 'warning':
       return {
-        container: 'bg-warning-light border border-warning-dark',
+        container:
+          'bg-warning-light dark:bg-warning-dark border border-warning-dark dark:border-warning',
         icon: 'text-warning',
-        text: 'text-warning-foreground',
-        close: 'text-warning hover:text-warning-foreground'
+        text: 'text-warning-dark dark:text-warning-light',
+        close:
+          'text-warning dark:text-warning-light hover:text-warning-dark dark:hover:text-warning-foreground'
       };
     case 'success':
       return {
-        container: 'bg-success-light border border-success-dark',
+        container:
+          'bg-success-light dark:bg-success-dark border border-success-dark dark:border-success',
         icon: 'text-success',
-        text: 'text-success-foreground',
-        close: 'text-success hover:text-success-foreground'
+        text: 'text-success-dark dark:text-success-light',
+        close:
+          'text-success dark:text-success-light hover:text-success-dark dark:hover:text-success-foreground'
       };
     case 'error':
       return {
-        container: 'bg-error-light border border-error-dark',
+        container:
+          'bg-error-light dark:bg-error-dark border border-error-dark dark:border-error',
         icon: 'text-error',
-        text: 'text-error-foreground',
-        close: 'text-error hover:text-error-foreground'
+        text: 'text-error-dark dark:text-error-light',
+        close:
+          'text-error dark:text-error-light hover:text-error-dark dark:hover:text-error-foreground'
       };
     case 'info':
     default:
       return {
-        container: 'bg-info-light border border-info-dark',
+        container:
+          'bg-info-light dark:bg-info-dark border border-info-dark dark:border-info',
         icon: 'text-info',
-        text: 'text-info-foreground',
-        close: 'text-info hover:text-info-foreground'
+        text: 'text-info-dark dark:text-info-light',
+        close:
+          'text-info dark:text-info-light hover:text-info-dark dark:hover:text-info-foreground'
       };
   }
 };

--- a/src/components/ui/PreferencesPage/AutomaticLinksToggle.tsx
+++ b/src/components/ui/PreferencesPage/AutomaticLinksToggle.tsx
@@ -1,0 +1,38 @@
+import toast from 'react-hot-toast';
+import { Typography } from '@material-tailwind/react';
+
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
+
+export default function AutomaticLinksToggle() {
+  const { automaticDataLinks, toggleAutomaticDataLinks } =
+    usePreferencesContext();
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        className="icon-small checked:accent-secondary-light"
+        type="checkbox"
+        id="automatic_data_links"
+        checked={automaticDataLinks}
+        onChange={async () => {
+          const result = await toggleAutomaticDataLinks();
+          if (result.success) {
+            toast.success(
+              automaticDataLinks
+                ? 'Disabled automatic data links'
+                : 'Enabled automatic data links'
+            );
+          } else {
+            toast.error(result.error);
+          }
+        }}
+      />
+      <Typography
+        as="label"
+        htmlFor="automatic_data_links"
+        className="text-foreground"
+      >
+        Enable automatic data link creation
+      </Typography>
+    </div>
+  );
+}

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -77,7 +77,8 @@ export const PreferencesProvider = ({
     ['linux_path'] | ['windows_path'] | ['mac_path']
   >(['linux_path']);
   const [hideDotFiles, setHideDotFiles] = React.useState<boolean>(false);
-  const [automaticDataLinks, setAutomaticDataLinks] = React.useState<boolean>(false);
+  const [automaticDataLinks, setAutomaticDataLinks] =
+    React.useState<boolean>(false);
   const [
     disableNeuroglancerStateGeneration,
     setDisableNeuroglancerStateGeneration

--- a/src/contexts/ProxiedPathContext.tsx
+++ b/src/contexts/ProxiedPathContext.tsx
@@ -27,6 +27,7 @@ type ProxiedPathContextType = {
   createProxiedPath: () => Promise<Result<ProxiedPath | void>>;
   deleteProxiedPath: (proxiedPath: ProxiedPath) => Promise<Result<void>>;
   refreshProxiedPaths: () => Promise<Result<ProxiedPath[] | void>>;
+  fetchProxiedPath: () => Promise<Result<ProxiedPath | void>>;
   notifyZarrDetected: () => void;
 };
 
@@ -296,6 +297,7 @@ export const ProxiedPathProvider = ({
         createProxiedPath,
         deleteProxiedPath,
         refreshProxiedPaths,
+        fetchProxiedPath,
         notifyZarrDetected
       }}
     >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,28 +43,28 @@ const config = {
           foreground: '#FFFFFF'
         },
         success: {
-          default: '#00a450', // HHMI primary brand color - icon color
-          dark: '#bbf7d0', // border color (green-200 equivalent)
-          light: '#f0fdf4', // background color (green-50 equivalent)
-          foreground: '#15803d' // text color (green-700 equivalent)
+          default: '#16a34a', // main success color (green-600)
+          dark: '#15803d', // darker variant (green-700)
+          light: '#f0fdf4', // lighter variant (green-50)
+          foreground: '#FFFFFF' // text color for use on default/dark backgrounds
         },
         info: {
-          default: '#2563EB', // icon color
-          dark: '#bfdbfe', // border color (blue-200 equivalent)
-          light: '#eff6ff', // background color (blue-50 equivalent)
-          foreground: '#1d4ed8' // text color (blue-700 equivalent)
+          default: '#2563eb', // main info color (blue-600)
+          dark: '#1d4ed8', // darker variant (blue-700)
+          light: '#eff6ff', // lighter variant (blue-50)
+          foreground: '#FFFFFF' // text color for use on default/dark backgrounds
         },
         warning: {
-          default: '#d97706', // icon color (amber-600)
-          dark: '#fed7aa', // border color (amber-200 equivalent)
-          light: '#fffbeb', // background color (amber-50 equivalent)
-          foreground: '#92400e' // text color (amber-800 equivalent)
+          default: '#d97706', // main warning color (amber-600)
+          dark: '#92400e', // darker variant (amber-800)
+          light: '#fffbeb', // lighter variant (amber-50)
+          foreground: '#FFFFFF' // text color for use on default/dark backgrounds
         },
         error: {
-          default: '#dc2626', // icon color
-          dark: '#fecaca', // border color (red-200 equivalent)
-          light: '#fef2f2', // background color (red-50 equivalent)
-          foreground: '#991b1b' // text color (red-800 equivalent)
+          default: '#dc2626', // main error color (red-600)
+          dark: '#991b1b', // darker variant (red-800)
+          light: '#fef2f2', // lighter variant (red-50)
+          foreground: '#FFFFFF' // text color for use on default/dark backgrounds
         }
       },
       darkColors: {
@@ -80,37 +80,37 @@ const config = {
           default: '#36a9b0',
           dark: '#058d96',
           light: '#66c7d0',
-          foreground: '#030712'
+          foreground: '#E5E7EB'
         },
         secondary: {
           default: '#8B5CF6',
           dark: '#6D28D9',
           light: '#C4B5FD',
-          foreground: '#FFFFFF'
+          foreground: '#E5E7EB'
         },
         success: {
-          default: '#33b473', // icon color (lighter green for dark theme)
-          dark: '#166534', // border color (green-800 equivalent)
-          light: '#052e16', // background color (green-950 equivalent)
-          foreground: '#bbf7d0' // text color (green-200 equivalent)
+          default: '#22c55e', // main success color (green-500)
+          dark: '#052e16', // darker variant (green-950)
+          light: '#6ee7b7', // lighter variant (emerald-300)
+          foreground: '#E5E7EB' // text color for use on default/dark backgrounds
         },
         info: {
-          default: '#3B82F6', // icon color
-          dark: '#1e40af', // border color (blue-800 equivalent)
-          light: '#172554', // background color (blue-950 equivalent)
-          foreground: '#bfdbfe' // text color (blue-200 equivalent)
+          default: '#3b82f6', // main info color (blue-500)
+          dark: '#172554', // darker variant (blue-950) - visually darker
+          light: '#93c5fd', // lighter variant (blue-300) - visually lighter
+          foreground: '#E5E7EB' // text color for use on default/dark backgrounds
         },
         warning: {
-          default: '#f59e0b', // icon color (amber-500)
-          dark: '#92400e', // border color (amber-800 equivalent)
-          light: '#451a03', // background color (amber-950 equivalent)
-          foreground: '#fed7aa' // text color (amber-200 equivalent)
+          default: '#f59e0b', // main warning color (amber-500)
+          dark: '#451a03', // darker variant (amber-950) - visually darker
+          light: '#fcd34d', // lighter variant (amber-300) - visually lighter
+          foreground: '#E5E7EB' // text color for use on default/dark backgrounds
         },
         error: {
-          default: '#ef4444', // icon color
-          dark: '#991b1b', // border color (red-800 equivalent)
-          light: '#450a0a', // background color (red-950 equivalent)
-          foreground: '#fecaca' // text color (red-200 equivalent)
+          default: '#ef4444', // main error color (red-500)
+          dark: '#450a0a', // darker variant (red-950) - visually darker
+          light: '#fca5a5', // lighter variant (red-300) - visually lighter
+          foreground: '#E5E7EB' // text color for use on default/dark backgrounds
         }
       }
     })


### PR DESCRIPTION
Clickup id: 86aata5u9

This PR adds a user preference to enable automatic data link creation. This preference can be changed on the preference page, or from the data link dialog. The data link toggle switch is removed from Zarr directories. Instead, the data viewer icons are shown immediately. The first time a user clicks on an icon to make a data link, a modal appears offering options to "create link" or "cancel" and a checkbox to enable automatic data links going forward (this is the same checkbox as on the preference page). Once automatic data links are enabled, the user does not see this modal, and when they navigate to Zarr directory, the data link is automatically created, so when they click on a data viewer icon, they are immediately taken to the data viewer.


https://github.com/user-attachments/assets/4dde0df2-deb3-4db0-a97d-d60eba6dd601


I also refactored some styles, specifically, the custom colors. The "error" colors were not providing sufficient contrast for the "delete" and "create data link" buttons when the user hovered on them.

@krokicki @neomorphic 