### PR TITLE
fix: show data link creation errors

### DIFF
--- a/src/hooks/useDataToolLinks.ts
+++ b/src/hooks/useDataToolLinks.ts
@@ -127,7 +127,9 @@ export default function useDataToolLinks(
       }
 
       if (attempts >= maxAttempts) {
-        toast.error('Timeout waiting for data link URLs to be ready');
+        toast.error(
+          `${toolKey === 'copy' ? 'Error copying data link' : `Error navigating to ${toolKey}`}`
+        );
       }
     } else if (result.error) {
       toast.error(`Error refreshing links: ${result.error}`);


### PR DESCRIPTION
Clickup id: 86abn3hp7
@krokicki @neomorphic 

Update after merging PR #156: that PR fixed the problem of data link creation silently failing. In the creation of the automatic link functionality - `handleCreateDataLink` and `createLinkAndExecuteAction` have toast error message for failed data link creation and failed tool actions, respectively. You can ignore the initial commit in this PR below (https://github.com/JaneliaSciComp/fileglancer/pull/162/commits/d902e3e9d49023405dadd387b7bb4cb5b80f66d2) - I deleted this code in the merge reconciliation process.

~This PR should only be reviewed after PR #156 is merged. It builds off the data link auto-creation features.~

~This PR adds `automaticLinkError` state to ProxiedPathContext.tsx. In the useEffect that auto-creates data links when the preference is set and a Zarr is detected, this error state is set if there is an error when creating the link. The error message is displayed under the data viewer tools. For links made through the data link dialog, the usual toast error notification displays if there is an error.~