### PR TITLE
fix: Adds Auto logout when a users session expires

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -60,6 +60,21 @@ class HTTPError extends Error {
   }
 }
 
+async function checkSessionValidity(xrsfCookie: string): Promise<boolean> {
+  try {
+    const response = await fetch(getFullPath('/api/fileglancer/profile'), {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'X-Xsrftoken': xrsfCookie
+      }
+    });
+    return response.ok;
+  } catch (error) {
+    return false;
+  }
+}
+
 async function sendFetchRequest(
   apiPath: string,
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
@@ -78,7 +93,22 @@ async function sendFetchRequest(
       method !== 'DELETE' &&
       body && { body: JSON.stringify(body) })
   };
-  return await fetch(getFullPath(apiPath), options);
+
+  const response = await fetch(getFullPath(apiPath), options);
+
+  // Check for 403 Forbidden - could be permission denied or session expired
+  if (response.status === 403) {
+    // Check if session is still valid by testing a stable endpoint
+    const sessionValid = await checkSessionValidity(xrsfCookie);
+    if (!sessionValid) {
+      // Session has expired, redirect to logout
+      window.location.href = `${window.location.origin}/logout`;
+      throw new HTTPError('Session expired', 401);
+    }
+    // If session is valid, this is just a permission denied for this specific resource
+  }
+
+  return response;
 }
 
 // Parse the Unix-style permissions string (e.g., "drwxr-xr-x")
@@ -177,6 +207,7 @@ async function fetchFileWithTextDetection(
 }
 
 export {
+  checkSessionValidity,
   escapePathForUrl,
   fetchFileAsJson,
   fetchFileAsText,


### PR DESCRIPTION
clickup id: [86abdmqxu](https://app.clickup.com/t/86abdmqxu)

To prevent the site from exhibiting abnormal behavior when a users session expires, I added  a`checkSessionValidity` function. The reason I had to add this function is because there are some API end points that return a 403 even when the session is still valid. To prevent logging a user out from a valid 403, the `checkSessionValidity` function makes an additional request to the `/api/fileglancer/profile` endpoint, which should always return a 200 OK response if the users session is valid. If that request returns a 403 response, then the user is redirected to the logout url and is then asked to log back in again. One can test this by modifying or deleting the `jupyterhub-session-id` cookie and then navigating to another page on the site, or just waiting for the notifications up to fire, which occurs once a minute.

@krokicki 
