### PR TITLE
bug: response body already consumed

### DIFF
--- a/src/__tests__/componentTests/ChangePermissions.test.tsx
+++ b/src/__tests__/componentTests/ChangePermissions.test.tsx
@@ -108,7 +108,7 @@ describe('Change Permissions dialog', () => {
       http.patch('http://localhost:3000/api/fileglancer/files/:fspName', () => {
         return HttpResponse.json(
           { error: 'Permission denied' },
-          { status: 500 }
+          { status: 403 }
         );
       })
     );
@@ -123,7 +123,7 @@ describe('Change Permissions dialog', () => {
     );
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        'Error changing permissions: 500: Permission denied'
+        'Error changing permissions: Permission denied'
       );
     });
   });

--- a/src/__tests__/componentTests/ConvertFile.test.tsx
+++ b/src/__tests__/componentTests/ConvertFile.test.tsx
@@ -83,7 +83,10 @@ describe('Convert File dialog', () => {
 
     server.use(
       http.post('http://localhost:3000/api/fileglancer/ticket', () => {
-        return HttpResponse.json({ error: 'Unknown error' }, { status: 500 });
+        return HttpResponse.json(
+          { error: 'Could not create ticket' },
+          { status: 500 }
+        );
       })
     );
 
@@ -99,7 +102,7 @@ describe('Convert File dialog', () => {
     );
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        'Error creating ticket: 500: Unknown error'
+        'Error creating ticket: Could not create ticket'
       );
     });
   });

--- a/src/__tests__/componentTests/DataLink.test.tsx
+++ b/src/__tests__/componentTests/DataLink.test.tsx
@@ -42,7 +42,10 @@ describe('Data Link dialog', () => {
 
     server.use(
       http.post('http://localhost:3000/api/fileglancer/proxied-path', () => {
-        return HttpResponse.json({ error: 'Unknown error' }, { status: 500 });
+        return HttpResponse.json(
+          { error: 'Could not create data link' },
+          { status: 500 }
+        );
       })
     );
 
@@ -50,7 +53,7 @@ describe('Data Link dialog', () => {
     await user.click(screen.getByText('Create Data Link'));
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        'Error creating data link: 500: Unknown error'
+        'Error creating data link: Could not create data link'
       );
     });
   });

--- a/src/__tests__/componentTests/DeleteDialog.test.tsx
+++ b/src/__tests__/componentTests/DeleteDialog.test.tsx
@@ -78,7 +78,10 @@ describe('Delete dialog', () => {
       http.delete(
         'http://localhost:3000/api/fileglancer/files/test_fsp',
         () => {
-          return HttpResponse.json({ error: 'Unknown error' }, { status: 500 });
+          return HttpResponse.json(
+            { error: 'Could not delete item' },
+            { status: 500 }
+          );
         }
       )
     );
@@ -87,7 +90,7 @@ describe('Delete dialog', () => {
     await user.click(screen.getByText('Delete'));
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
-        'Error deleting item: 500: Unknown error'
+        'Error deleting item: Could not delete item'
       );
     });
   });

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -3,7 +3,7 @@
 
 import { afterAll, afterEach, beforeAll, expect, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
-import * as matchers from '@testing-library/jest-dom/matchers';
+import * as matchers from '@testing-library/jest-dom/vitest';
 import { server } from './mocks/node';
 
 expect.extend(matchers);

--- a/src/contexts/FileBrowserContext.tsx
+++ b/src/contexts/FileBrowserContext.tsx
@@ -259,7 +259,7 @@ export const FileBrowserContextProvider = ({
           throw new Error('Folder not found');
         } else {
           throw new Error(
-            `Error: ${response.status}: ${body.error ? body.error : 'Unknown error'}`
+            `${body.error ? body.error : 'Unknown error'}`
           );
         }
       }

--- a/src/contexts/FileBrowserContext.tsx
+++ b/src/contexts/FileBrowserContext.tsx
@@ -382,10 +382,12 @@ export const FileBrowserContextProvider = ({
 
   // Effect to update currentFolder and propertiesTarget when URL params change
   React.useEffect(() => {
-    log.debug('URL changed: fspName=', fspName, 'filePath=', filePath);
     let cancelled = false;
     const updateCurrentFileSharePathAndFolder = async () => {
-      if (!isZonesMapReady || !zonesAndFileSharePathsMap || !fspName) {
+      if (!isZonesMapReady || !zonesAndFileSharePathsMap) {
+        return;
+      }
+      if (!fspName) {
         if (cancelled) {
           return;
         }
@@ -395,7 +397,7 @@ export const FileBrowserContextProvider = ({
           [],
           null,
           [],
-          'Invalid file share path name'
+          'No file share path name in URL'
         );
         return;
       }

--- a/src/contexts/FileBrowserContext.tsx
+++ b/src/contexts/FileBrowserContext.tsx
@@ -259,7 +259,7 @@ export const FileBrowserContextProvider = ({
           throw new Error('Folder not found');
         } else {
           throw new Error(
-            `${body.error ? body.error : 'Unknown error'}`
+            body.error ? body.error : `Unknown error (${response.status})`
           );
         }
       }

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -6,7 +6,14 @@ function createSuccess<T>(data: T): Success<T> {
 }
 
 async function toHttpError(response: Response): Promise<Error> {
-  const body = await response.json();
+  let body = { error: null };
+  try {
+    if (!response.bodyUsed) {
+      body = await response.json();
+    }
+  } catch (error) {
+    logger.error('Error parsing JSON response:', error);
+  }
   return new Error(
     body.error ? body.error : `Unknown error (${response.status})`
   );

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -8,7 +8,7 @@ function createSuccess<T>(data: T): Success<T> {
 async function toHttpError(response: Response): Promise<Error> {
   const body = await response.json();
   return new Error(
-    `${response.status}: ${body.error ? body.error : 'Unknown error'}`
+    body.error ? body.error : `Unknown error (${response.status})`
   );
 }
 


### PR DESCRIPTION
Clickup id: 86abrcxqh
@krokicki @neomorphic 

The body of the response was already getting consumed at the top of the `fetchFileInfo()` method, to provide info about the owner if there was a permissions error. Therefore, the error handling utility method `toHttpError()` couldn't consume it again when a non-permissions error was thrown to it. Now `fetchFileInfo()` uses the response body to construct a new `Error` directly, which is then displayed in the UI.