### PR TITLE
fix: Adds validation of new folder submissions

### DIFF
--- a/fileglancer/handlers.py
+++ b/fileglancer/handlers.py
@@ -299,7 +299,11 @@ class FileMetadataHandler(FileShareHandler):
                 filestore.create_empty_file(subpath)
             else:
                 raise web.HTTPError(400, "Invalid file type")
-        
+
+        except FileExistsError as e:
+            self.set_status(409)  # Conflict status code
+            self.finish(json.dumps({"error": "A file or directory with this name already exists"}))
+            return
         except PermissionError as e:
             self.set_status(403)
             self.finish(json.dumps({"error": str(e)}))

--- a/src/components/ui/BrowsePage/NewFolderButton.tsx
+++ b/src/components/ui/BrowsePage/NewFolderButton.tsx
@@ -20,7 +20,9 @@ export default function NewFolderButton({
   const { handleNewFolderSubmit, newName, setNewName } = useNewFolderDialog();
 
   const isDuplicateName = React.useMemo(() => {
-    if (!newName.trim()) return false;
+    if (!newName.trim()) {
+      return false;
+    }
     return fileBrowserState.files.some(
       file => file.name.toLowerCase() === newName.trim().toLowerCase()
     );

--- a/src/components/ui/BrowsePage/NewFolderButton.tsx
+++ b/src/components/ui/BrowsePage/NewFolderButton.tsx
@@ -19,6 +19,15 @@ export default function NewFolderButton({
   const { fileBrowserState } = useFileBrowserContext();
   const { handleNewFolderSubmit, newName, setNewName } = useNewFolderDialog();
 
+  const isDuplicateName = React.useMemo(() => {
+    if (!newName.trim()) return false;
+    return fileBrowserState.files.some(
+      file => file.name.toLowerCase() === newName.trim().toLowerCase()
+    );
+  }, [newName, fileBrowserState.files]);
+
+  const isSubmitDisabled = !newName.trim() || isDuplicateName;
+
   return (
     <>
       <FgTooltip
@@ -55,23 +64,39 @@ export default function NewFolderButton({
                 htmlFor="new_name"
                 className="text-foreground font-semibold"
               >
-                New Folder Name
+                Create a New Folder
               </Typography>
               <input
                 type="text"
                 id="new_name"
                 autoFocus
                 value={newName}
-                placeholder="Enter name"
+                placeholder="Folder name ..."
                 onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                   setNewName(event.target.value);
                 }}
                 className="mb-4 p-2 text-foreground text-lg border border-primary-light rounded-sm focus:outline-none focus:border-primary bg-background"
               />
             </div>
-            <Button className="!rounded-md" type="submit">
-              Submit
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                className="!rounded-md"
+                type="submit"
+                disabled={isSubmitDisabled}
+              >
+                Submit
+              </Button>
+              {!newName.trim() && (
+                <Typography className="text-sm text-gray-500">
+                  Please enter a folder name
+                </Typography>
+              )}
+              {newName.trim() && isDuplicateName && (
+                <Typography className="text-sm text-red-500">
+                  A file or folder with this name already exists
+                </Typography>
+              )}
+            </div>
           </form>
         </FgDialog>
       )}

--- a/src/components/ui/BrowsePage/NewFolderButton.tsx
+++ b/src/components/ui/BrowsePage/NewFolderButton.tsx
@@ -17,16 +17,8 @@ export default function NewFolderButton({
 }: NewFolderButtonProps): JSX.Element {
   const [showNewFolderDialog, setShowNewFolderDialog] = React.useState(false);
   const { fileBrowserState } = useFileBrowserContext();
-  const { handleNewFolderSubmit, newName, setNewName } = useNewFolderDialog();
-
-  const isDuplicateName = React.useMemo(() => {
-    if (!newName.trim()) {
-      return false;
-    }
-    return fileBrowserState.files.some(
-      file => file.name.toLowerCase() === newName.trim().toLowerCase()
-    );
-  }, [newName, fileBrowserState.files]);
+  const { handleNewFolderSubmit, newName, setNewName, isDuplicateName } =
+    useNewFolderDialog();
 
   const isSubmitDisabled = !newName.trim() || isDuplicateName;
 

--- a/src/components/ui/BrowsePage/NewFolderButton.tsx
+++ b/src/components/ui/BrowsePage/NewFolderButton.tsx
@@ -80,16 +80,15 @@ export default function NewFolderButton({
               >
                 Submit
               </Button>
-              {!newName.trim() && (
+              {!newName.trim() ? (
                 <Typography className="text-sm text-gray-500">
                   Please enter a folder name
                 </Typography>
-              )}
-              {newName.trim() && isDuplicateName && (
+              ) : newName.trim() && isDuplicateName ? (
                 <Typography className="text-sm text-red-500">
                   A file or folder with this name already exists
                 </Typography>
-              )}
+              ) : null}
             </div>
           </form>
         </FgDialog>

--- a/src/contexts/ProxiedPathContext.tsx
+++ b/src/contexts/ProxiedPathContext.tsx
@@ -194,7 +194,7 @@ export const ProxiedPathProvider = ({
           cookies['_xsrf']
         );
         if (!response.ok) {
-          throw toHttpError(response);
+          throw await toHttpError(response);
         } else {
           updateProxiedPath(null);
           return createSuccess(undefined);

--- a/src/hooks/useNewFolderDialog.ts
+++ b/src/hooks/useNewFolderDialog.ts
@@ -46,13 +46,6 @@ export default function useNewFolderDialog() {
       } else {
         if (response.status === 403) {
           return handleError(new Error('Permission denied'));
-        } else if (response.status === 409) {
-          const body = await response.json();
-          return handleError(
-            new Error(
-              body.error || 'A file or directory with this name already exists'
-            )
-          );
         } else {
           throw await toHttpError(response);
         }

--- a/src/hooks/useNewFolderDialog.ts
+++ b/src/hooks/useNewFolderDialog.ts
@@ -45,7 +45,7 @@ export default function useNewFolderDialog() {
             )
           );
         } else {
-          throw toHttpError(response);
+          throw await toHttpError(response);
         }
       }
     } catch (error) {

--- a/src/hooks/useNewFolderDialog.ts
+++ b/src/hooks/useNewFolderDialog.ts
@@ -37,6 +37,13 @@ export default function useNewFolderDialog() {
       } else {
         if (response.status === 403) {
           return handleError(new Error('Permission denied'));
+        } else if (response.status === 409) {
+          const body = await response.json();
+          return handleError(
+            new Error(
+              body.error || 'A file or directory with this name already exists'
+            )
+          );
         } else {
           throw toHttpError(response);
         }

--- a/src/hooks/useNewFolderDialog.ts
+++ b/src/hooks/useNewFolderDialog.ts
@@ -13,6 +13,15 @@ export default function useNewFolderDialog() {
   const { currentFileOrFolder, currentFileSharePath } = fileBrowserState;
   const { cookies } = useCookiesContext();
 
+  const isDuplicateName = React.useMemo(() => {
+    if (!newName.trim()) {
+      return false;
+    }
+    return fileBrowserState.files.some(
+      file => file.name.toLowerCase() === newName.trim().toLowerCase()
+    );
+  }, [newName, fileBrowserState.files]);
+
   async function handleNewFolderSubmit(): Promise<Result<void>> {
     if (!currentFileSharePath) {
       return handleError(new Error('No file share path selected.'));
@@ -56,6 +65,7 @@ export default function useNewFolderDialog() {
   return {
     handleNewFolderSubmit,
     newName,
-    setNewName
+    setNewName,
+    isDuplicateName
   };
 }


### PR DESCRIPTION
clickup id: [86a8mfd0r](https://app.clickup.com/t/86a8mfd0r)

Adds client side validation for empty submissions and for submissions of
folders that already exist. The client side validation provides faster
feedback, than a server round trip, but it doesn't prevent the case
where someone else creates a new directory with the same name as the one
you chose, between your submission and the initial browser page load.

@krokicki 
