### PR TITLE
fix: text color in central server down dialog

### DIFF
--- a/src/components/ui/Dialogs/CentralServerDownOverlay.tsx
+++ b/src/components/ui/Dialogs/CentralServerDownOverlay.tsx
@@ -56,10 +56,13 @@ export function CentralServerDownOverlay({
             </div>
 
             <div className="space-y-2">
-              <Typography type="h5" className="text-foreground font-bold">
+              <Typography
+                type="h5"
+                className="text-surface-foreground font-bold"
+              >
                 Central Server Unavailable
               </Typography>
-              <Typography type="p" className="text-muted-foreground">
+              <Typography type="p" className="text-foreground">
                 The Fileglancer Central server is currently down or unreachable.
               </Typography>
             </div>
@@ -80,11 +83,11 @@ export function CentralServerDownOverlay({
               <div className="text-left space-y-2">
                 <Typography
                   type="small"
-                  className="text-muted-foreground font-medium"
+                  className="text-foreground font-medium"
                 >
                   What you can do:
                 </Typography>
-                <ul className="text-sm text-muted-foreground space-y-1 list-disc list-inside">
+                <ul className="text-sm text-foreground space-y-1 list-disc list-inside">
                   <li>Try again in a few moments</li>
                   <li>
                     Contact{' '}


### PR DESCRIPTION
Clickup id: 86ac3hc0d

@krokicki @neomorphic 
Updated the text color of the central server down dialog so it works in both the light and dark mode.

Dark mode:
<img width="1006" height="712" alt="Screenshot 2025-09-26 at 2 23 13 PM" src="https://github.com/user-attachments/assets/fe4ec956-8667-441d-8be3-734dbc660229" />


Light mode:
<img width="740" height="608" alt="Screenshot 2025-09-26 at 2 25 11 PM" src="https://github.com/user-attachments/assets/05055b26-3ac7-457d-a402-70c2efc3eefd" />
