### PR TITLE
fix: Forces a page reload on central server reconnect.

### DIFF
--- a/src/contexts/CentralServerHealthContext.tsx
+++ b/src/contexts/CentralServerHealthContext.tsx
@@ -111,6 +111,8 @@ export const CentralServerHealthProvider = ({
         if (healthStatus === 'healthy') {
           setShowWarningOverlay(false);
           logger.debug('Central server detected as healthy during retry');
+          // reload the page to ensure full recovery
+          window.location.reload();
           return true; // Success - stop retrying
         } else if (healthStatus === 'down') {
           return false; // Continue retrying
@@ -186,6 +188,8 @@ export const CentralServerHealthProvider = ({
         logger.debug('Central server detected as healthy');
         // Stop retrying since server is healthy
         stopRetrying();
+        // reload the page to ensure full recovery
+        window.location.reload();
       }
     } catch (error) {
       logger.error('Error during health check:', error);


### PR DESCRIPTION
clickup id: [86ac3hcfz](https://app.clickup.com/t/86ac3hcfz)

The page will reload to make sure the page contents are up to date when
the central server is reconnected after an outage.

@krokicki 