### PR TITLE
fixes: central health server check; integration tests; package-lock version num

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "0.7.2",
+    "version": "0.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "0.7.2",
+            "version": "0.8.0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@jupyterlab/application": "^4.0.0",

--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -46,7 +46,7 @@ export default function FavoritesBrowser({
 
   return (
     <div className="flex flex-col my-1 mx-1">
-      <List className="!min-w-20">
+      <List aria-label="favorites-list-title" className="!min-w-20">
         <List.Item
           onClick={() => toggleOpenFavorites('all')}
           className="cursor-pointer rounded-md py-2 short:py-1 hover:!bg-surface-light focus:!bg-surface-light"
@@ -68,7 +68,10 @@ export default function FavoritesBrowser({
         open={openFavorites['all'] ? true : false}
         className="overflow-x-hidden flex-grow w-full"
       >
-        <List className="h-full py-0 gap-0 bg-background">
+        <List
+          aria-label="favorites-list"
+          className="h-full py-0 gap-0 bg-background"
+        >
           {/* Zone favorites */}
           {displayZones.map(zone => {
             return (

--- a/ui-tests/tests/fgzones.spec.ts
+++ b/ui-tests/tests/fgzones.spec.ts
@@ -108,13 +108,10 @@ test.skip('favor entire zone with reload page', async ({ page }) => {
     .getByRole('link', { name: `${TEST_SHARED_PATHS[2].storage}` })
     .click();
 
-  await expect(page.getByText(`${TEST_SHARED_PATHS[2].name}`)).toBeVisible();
-
-  // first file row
-  await expect(page.getByText('f1FileMay 21, 202510 bytes')).toBeVisible();
-
-  // second file row
-  await expect(page.getByText('f2FileMay 21, 202510 bytes')).toBeVisible();
+  // first file row - check for file name, date and size separately
+  await expect(page.getByText('f1')).toBeVisible();
+  await expect(page.getByText('May 21, 2025, 6:06 PM')).toBeVisible();
+  await expect(page.getByText('10 bytes').first()).toBeVisible();
 
   const z2ExpandedStarButton = page
     .getByRole('list')

--- a/ui-tests/tests/fgzones.spec.ts
+++ b/ui-tests/tests/fgzones.spec.ts
@@ -143,12 +143,6 @@ test.skip('favor entire zone with reload page', async ({ page }) => {
   // reload page - somehow page.reload hangs so I am going back to jupyterlab page
   await openFileGlancer(page);
 
-  const z2CollapsedStarButton = page.getByRole('button').nth(4);
   // test Z2 still shows as favorite
-  await expect(
-    z2CollapsedStarButton.locator('svg path[fill-rule]') // filled star
-  ).toHaveCount(1);
-  await expect(
-    z2CollapsedStarButton.locator('svg path[stroke-linecap]') // empty star
-  ).toHaveCount(0);
+  await expect(listItem).toBeVisible();
 });

--- a/ui-tests/tests/fgzones.spec.ts
+++ b/ui-tests/tests/fgzones.spec.ts
@@ -132,21 +132,13 @@ test.skip('favor entire zone with reload page', async ({ page }) => {
     .filter({ hasText: 'Z2' })
     .getByRole('button')
     .click();
-  // test that Z2 now shows in the favorites
-  await expect(
-    page.getByRole('list').filter({ hasText: /^Z2$/ }).getByRole('paragraph')
-  ).toBeVisible();
-  // test that the star appear next to favorite Z2
-  await expect(
-    page.getByRole('list').filter({ hasText: /^Z2$/ }).getByRole('button')
-  ).toBeVisible();
 
-  await expect(
-    z2ExpandedStarButton.locator('svg path[fill-rule]') // filled star
-  ).toHaveCount(1);
-  await expect(
-    z2ExpandedStarButton.locator('svg path[stroke-linecap]') // empty star
-  ).toHaveCount(0);
+  const favoritesList = page.getByRole('list', { name: 'favorites-list' });
+  const listItem = favoritesList
+    .getByRole('listitem')
+    .filter({ hasText: /^Z2$/ });
+  // test that Z2 now shows in the favorites
+  await expect(listItem).toBeVisible();
 
   // reload page - somehow page.reload hangs so I am going back to jupyterlab page
   await openFileGlancer(page);

--- a/ui-tests/tests/fgzones.spec.ts
+++ b/ui-tests/tests/fgzones.spec.ts
@@ -50,7 +50,7 @@ test.beforeEach('setup API endpoints', async ({ page }) => {
   });
 
   await page.route(
-    `api/fileglancer/files/${TEST_SHARED_PATHS[2].name}`,
+    `/api/fileglancer/files/${TEST_SHARED_PATHS[2].name}**`,
     async route => {
       await route.fulfill({
         status: 200,

--- a/ui-tests/tests/fgzones.spec.ts
+++ b/ui-tests/tests/fgzones.spec.ts
@@ -84,7 +84,7 @@ test.beforeEach('setup API endpoints', async ({ page }) => {
   );
 });
 
-test.skip('favor entire zone with reload page', async ({ page }) => {
+test('favor entire zone with reload page', async ({ page }) => {
   // click on Z1
   await page.getByText('Z1', { exact: true }).click();
 


### PR DESCRIPTION
Clickup id: 86abpt0c9

This PR was initiated to fix the Playwright integration tests. These were fixed (at least running locally in dev) by (1) ensuring the file-share-paths endpoint could include url params for the subpath and (2) adding specificity to the locator.

In the process of updating the Playwright tests, I ran into an issue related to the central server health check: if the central server url is not configured, the endpoints that call the central server return 500, which triggers the health check. Previously, the CENTRAL_SERVER_NOT_CONFIGURED error message would set the status back to health, triggering a page refresh, but then the endpoints that call the central server would return 500 again, and so on, resulting in endless refreshes. Now, the code looks for the response body and if it includes CENTRAL_SERVER_NOT_CONFIGURED, it does not trigger a health check, since this is the case where someone might be running Fileglancer locally.