### PR TITLE
fix: Prevents continuous reload when central server not configured

### DIFF
--- a/src/contexts/CentralServerHealthContext.tsx
+++ b/src/contexts/CentralServerHealthContext.tsx
@@ -190,6 +190,12 @@ export const CentralServerHealthProvider = ({
         stopRetrying();
         // reload the page to ensure full recovery
         window.location.reload();
+      } else if (healthStatus === 'ignore') {
+        // Configuration issue, not connectivity issue
+        setShowWarningOverlay(false);
+        logger.info('Central server configuration issue detected, ignoring');
+        // Stop retrying since this is not a connectivity issue
+        stopRetrying();
       }
     } catch (error) {
       logger.error('Error during health check:', error);

--- a/src/utils/centralServerHealth.ts
+++ b/src/utils/centralServerHealth.ts
@@ -2,7 +2,7 @@ import { sendFetchRequest } from '@/utils';
 import { getErrorString } from '@/utils/errorHandling';
 import logger from '@/logger';
 
-export type CentralServerStatus = 'healthy' | 'down' | 'checking';
+export type CentralServerStatus = 'healthy' | 'down' | 'checking' | 'ignore';
 
 // Structured error response types
 export interface ApiErrorResponse {
@@ -119,7 +119,7 @@ export async function checkCentralServerHealth(
         logger.info(
           `Central server configuration issue detected: ${errorData.message}`
         );
-        return 'healthy'; // Configuration issue, not connectivity issue
+        return 'ignore'; // Configuration issue, not connectivity issue
       }
 
       // If we can't parse the error or it's not a config issue, treat as server down


### PR DESCRIPTION
- Adds 'ignore' status to CentralServerStatus type.
- Prevents page reload when central server not configured.

This allows the fileglancer site to be started without a central server configured. This is important for testing environments where a central server might not be available.

@krokicki 