### PR TITLE
Use neuronglancer's multichannel support

### DIFF
--- a/src/components/Preferences.tsx
+++ b/src/components/Preferences.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast';
 
 import { usePreferencesContext } from '@/contexts/PreferencesContext';
 import AutomaticLinksToggle from '@/components/ui/PreferencesPage/AutomaticLinksToggle';
+import LegacyMultichannelToggle from '@/components/ui/PreferencesPage/LegacyMultichannelToggle';
 
 export default function Preferences() {
   const {
@@ -153,6 +154,10 @@ export default function Preferences() {
 
           <div className="flex items-center gap-2">
             <AutomaticLinksToggle />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <LegacyMultichannelToggle />
           </div>
 
           <div className="flex items-center gap-2">

--- a/src/components/ui/PreferencesPage/LegacyMultichannelToggle.tsx
+++ b/src/components/ui/PreferencesPage/LegacyMultichannelToggle.tsx
@@ -1,0 +1,38 @@
+import toast from 'react-hot-toast';
+import { Typography } from '@material-tailwind/react';
+
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
+
+export default function LegacyMultichannelToggle() {
+  const { useLegacyMultichannelApproach, toggleUseLegacyMultichannelApproach } =
+    usePreferencesContext();
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        className="icon-small checked:accent-secondary-light"
+        type="checkbox"
+        id="use_legacy_multichannel_approach"
+        checked={useLegacyMultichannelApproach ?? false}
+        onChange={async () => {
+          const result = await toggleUseLegacyMultichannelApproach();
+          if (result.success) {
+            toast.success(
+              useLegacyMultichannelApproach
+                ? 'Disabled legacy multichannel approach for Neuroglancer'
+                : 'Enabled legacy multichannel approach for Neuroglancer'
+            );
+          } else {
+            toast.error(result.error);
+          }
+        }}
+      />
+      <Typography
+        as="label"
+        htmlFor="use_legacy_multichannel_approach"
+        className="text-foreground"
+      >
+        Use legacy multichannel approach for Neuroglancer
+      </Typography>
+    </div>
+  );
+}

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -37,6 +37,8 @@ type PreferencesContextType = {
   toggleDisableNeuroglancerStateGeneration: () => Promise<Result<void>>;
   disableHeuristicalLayerTypeDetection: boolean;
   toggleDisableHeuristicalLayerTypeDetection: () => Promise<Result<void>>;
+  useLegacyMultichannelApproach: boolean;
+  toggleUseLegacyMultichannelApproach: () => Promise<Result<void>>;
   zonePreferenceMap: Record<string, ZonePreference>;
   zoneFavorites: Zone[];
   fileSharePathPreferenceMap: Record<string, FileSharePathPreference>;
@@ -89,6 +91,8 @@ export const PreferencesProvider = ({
     disableHeuristicalLayerTypeDetection,
     setDisableHeuristicalLayerTypeDetection
   ] = React.useState<boolean>(false);
+  const [useLegacyMultichannelApproach, setUseLegacyMultichannelApproach] =
+    React.useState<boolean>(false);
   const [zonePreferenceMap, setZonePreferenceMap] = React.useState<
     Record<string, ZonePreference>
   >({});
@@ -291,6 +295,14 @@ export const PreferencesProvider = ({
       }
       return createSuccess(undefined);
     }, [savePreferencesToBackend]);
+
+  const toggleUseLegacyMultichannelApproach =
+    React.useCallback(async (): Promise<Result<void>> => {
+      return togglePreference(
+        'useLegacyMultichannelApproach',
+        setUseLegacyMultichannelApproach
+      );
+    }, [togglePreference]);
 
   function updatePreferenceList<T>(
     key: string,
@@ -562,6 +574,17 @@ export const PreferencesProvider = ({
   }, [fetchPreferences]);
 
   React.useEffect(() => {
+    (async function () {
+      const rawUseLegacyMultichannelApproach = await fetchPreferences(
+        'useLegacyMultichannelApproach'
+      );
+      if (rawUseLegacyMultichannelApproach !== null) {
+        setUseLegacyMultichannelApproach(rawUseLegacyMultichannelApproach);
+      }
+    })();
+  }, [fetchPreferences]);
+
+  React.useEffect(() => {
     if (!isZonesMapReady) {
       return;
     }
@@ -714,6 +737,8 @@ export const PreferencesProvider = ({
         toggleDisableNeuroglancerStateGeneration,
         disableHeuristicalLayerTypeDetection,
         toggleDisableHeuristicalLayerTypeDetection,
+        useLegacyMultichannelApproach,
+        toggleUseLegacyMultichannelApproach,
         zonePreferenceMap,
         zoneFavorites,
         fileSharePathPreferenceMap,

--- a/src/hooks/useZarrMetadata.ts
+++ b/src/hooks/useZarrMetadata.ts
@@ -54,7 +54,8 @@ export default function useZarrMetadata() {
   const { externalDataUrl } = useExternalBucketContext();
   const {
     disableNeuroglancerStateGeneration,
-    disableHeuristicalLayerTypeDetection
+    disableHeuristicalLayerTypeDetection,
+    useLegacyMultichannelApproach
   } = usePreferencesContext();
   const [cookies] = useCookies(['_xsrf']);
 
@@ -325,7 +326,8 @@ export default function useZarrMetadata() {
                   layerType || 'image',
                   metadata.multiscale,
                   metadata.arr,
-                  metadata.omero
+                  metadata.omero,
+                  useLegacyMultichannelApproach
                 );
             } catch (error) {
               log.error(
@@ -378,7 +380,8 @@ export default function useZarrMetadata() {
     dataUrl,
     externalDataUrl,
     disableNeuroglancerStateGeneration,
-    layerType
+    layerType,
+    useLegacyMultichannelApproach
   ]);
 
   return {


### PR DESCRIPTION
Clickup id: 86abyvjr2

I made the default behavior of the Neuroglancer links such that they take advantage of Neuroglancer's new multichannel support, rather than generating the multichannel configuration from the metadata. There is a preference that allows users to go back to the old behavior if they prefer it. 

@StephanPreibisch @neomorphic @allison-truhlar 

