### PR TITLE
feat: add link to user manual on help page; update help page layout

### DIFF
--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -2,6 +2,7 @@ import { Card, List, Typography } from '@material-tailwind/react';
 import { TbBrandGithub } from 'react-icons/tb';
 import { SiClickup, SiSlack } from 'react-icons/si';
 import { IconType } from 'react-icons/lib';
+import { LuBookOpenText } from 'react-icons/lu';
 
 import useVersionNo from '@/hooks/useVersionState';
 import useCentralVersion from '@/hooks/useCentralVersion';
@@ -18,6 +19,11 @@ export default function Help() {
   const { centralVersionState } = useCentralVersion();
 
   const helpLinks: HelpLink[] = [
+    {
+      icon: LuBookOpenText,
+      title: `Read the user manual`,
+      url: `https://janeliascicomp.github.io/fileglancer-user-docs/`
+    },
     {
       icon: TbBrandGithub,
       title: `View ${versionNo} release notes`,

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -36,7 +36,7 @@ export default function Help() {
     },
     {
       icon: SiClickup,
-      title: 'Submit Issues & Requests',
+      title: 'Submit Tickets',
       description: 'Report bugs or request features through a ClickUp form',
       url: `https://forms.clickup.com/10502797/f/a0gmd-713/NBUCBCIN78SI2BE71G?Version=${versionNo}&URL=${window.location}`
     },
@@ -85,21 +85,18 @@ export default function Help() {
             to={url}
             target="_blank"
             rel="noopener noreferrer"
-            className="group h-44 p-12 flex flex-col gap-2 text-left w-full hover:shadow-lg transition-shadow duration-200"
+            className="group min-h-44 p-8 md:p-12 flex flex-col gap-2 text-left w-full hover:shadow-lg transition-shadow duration-200"
           >
-            <div className="flex items-center gap-4">
-              <Icon className="icon-large text-primary" />
-              <div className="flex items-center gap-1 ">
-                <Typography
-                  type="h6"
-                  className="text-primary font-semibold group-hover:underline"
-                >
+            <div className="flex items-center gap-2">
+              <Icon className="hidden md:block icon-default lg:icon-large text-primary" />
+              <div className="flex items-center gap-1 text-nowrap">
+                <Typography className="text-base md:text-lg lg:text-xl text-primary font-semibold group-hover:underline">
                   {title}
                 </Typography>
-                <HiExternalLink className="icon-small text-primary" />
+                <HiExternalLink className="icon-xsmall md:icon-small text-primary" />
               </div>
             </div>
-            <Typography className="text-muted-foreground">
+            <Typography className="text-sm md:text-base text-muted-foreground">
               {description}
             </Typography>
           </Card>

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -1,16 +1,18 @@
-import { Card, List, Typography } from '@material-tailwind/react';
+import { Card, Typography } from '@material-tailwind/react';
+import { Link } from 'react-router';
 import { TbBrandGithub } from 'react-icons/tb';
 import { SiClickup, SiSlack } from 'react-icons/si';
 import { IconType } from 'react-icons/lib';
 import { LuBookOpenText } from 'react-icons/lu';
+import { HiExternalLink } from 'react-icons/hi';
 
 import useVersionNo from '@/hooks/useVersionState';
 import useCentralVersion from '@/hooks/useCentralVersion';
-import { FgStyledLink } from './ui/widgets/FgLink';
 
 type HelpLink = {
   icon: IconType;
   title: string;
+  description: string;
   url: string;
 };
 
@@ -21,22 +23,27 @@ export default function Help() {
   const helpLinks: HelpLink[] = [
     {
       icon: LuBookOpenText,
-      title: `Read the user manual`,
+      title: 'User Manual',
+      description:
+        'Comprehensive guide to Fileglancer features and functionality',
       url: `https://janeliascicomp.github.io/fileglancer-user-docs/`
     },
     {
       icon: TbBrandGithub,
-      title: `View ${versionNo} release notes`,
+      title: 'Release Notes',
+      description: `What's new and improved in Fileglancer version ${versionNo}`,
       url: `https://github.com/JaneliaSciComp/fileglancer/releases/tag/${versionNo}`
     },
     {
       icon: SiClickup,
-      title: 'Submit feedback, bug reports, or feature requests',
+      title: 'Submit Issues & Requests',
+      description: 'Report bugs or request features through a ClickUp form',
       url: `https://forms.clickup.com/10502797/f/a0gmd-713/NBUCBCIN78SI2BE71G?Version=${versionNo}&URL=${window.location}`
     },
     {
       icon: SiSlack,
-      title: 'Get help on the #fileglancer-support Slack channel',
+      title: 'Community Support',
+      description: 'Get help from the community on our dedicated Slack channel',
       url: 'https://hhmi.enterprise.slack.com/archives/C0938N06YN8'
     }
   ];
@@ -70,29 +77,34 @@ export default function Help() {
           ) : null}
         </div>
       </div>
-      <Card className="min-h-max shrink-0">
-        <List className="w-fit gap-2 p-4">
-          {helpLinks.map(({ icon: Icon, title, url }) => (
-            <List.Item
-              key={url}
-              className="hover:bg-transparent focus:bg-transparent"
-            >
-              <List.ItemStart>
-                <Icon className="icon-large" />
-              </List.ItemStart>
-              <Typography
-                as={FgStyledLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                textSize="large"
-                to={url}
-              >
-                {title}
-              </Typography>
-            </List.Item>
-          ))}
-        </List>
-      </Card>
+      <div className="grid grid-cols-2 gap-10">
+        {helpLinks.map(({ icon: Icon, title, description, url }, index) => (
+          <Card
+            key={url}
+            as={Link}
+            to={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group h-44 p-12 flex flex-col gap-2 text-left w-full hover:shadow-lg transition-shadow duration-200"
+          >
+            <div className="flex items-center gap-4">
+              <Icon className="icon-large text-primary" />
+              <div className="flex items-center gap-1 ">
+                <Typography
+                  type="h6"
+                  className="text-primary font-semibold group-hover:underline"
+                >
+                  {title}
+                </Typography>
+                <HiExternalLink className="icon-small text-primary" />
+              </div>
+            </div>
+            <Typography className="text-muted-foreground">
+              {description}
+            </Typography>
+          </Card>
+        ))}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
Clickup id: 86ac70qk8 and 86ac7n307

@krokicki @neomorphic 

For now, the link is to janeliascicomp.github.io/fileglancer-user-docs. 

I accidentally pushed the commit to this branch to "spruce up" the help page. Instead of being in a list in a single card, the help links are now in four separate cards.
<img width="1017" height="608" alt="Screenshot 2025-10-02 at 4 35 14 PM" src="https://github.com/user-attachments/assets/168f0d14-525f-40ab-9a74-1cd709147cae" />
