### PR TITLE
style: make full paths on dashboard cards lighter; make dashboard layout responsive

### DIFF
--- a/src/components/Browse.tsx
+++ b/src/components/Browse.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useOutletContext } from 'react-router';
 import { default as log } from '@/logger';
 import type { OutletContextType } from '@/layouts/BrowseLayout';
@@ -32,6 +32,8 @@ export default function Browse() {
   const [showRenameDialog, setShowRenameDialog] = React.useState(false);
   const [showNavigationDialog, setShowNavigationDialog] = React.useState(false);
   const [pastedPath, setPastedPath] = React.useState<string>('');
+  const [componentWidth, setComponentWidth] = useState<number>(0);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Auto-focus the container when component mounts so it can receive paste events
   useEffect(() => {
@@ -43,9 +45,30 @@ export default function Browse() {
     }
   }, []);
 
+  // Monitor component width changes
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const resizeObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setComponentWidth(entry.contentRect.width);
+      }
+    });
+    resizeObserver.observe(container);
+    // Set initial width
+    setComponentWidth(container.offsetWidth);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
   return (
     <div
-      className="flex flex-col h-full min-w-fit max-h-full"
+      ref={containerRef}
+      className="flex flex-col h-full max-h-full w-full max-w-full"
       tabIndex={0}
       data-browse-container
       onPaste={async event => {
@@ -93,16 +116,18 @@ export default function Browse() {
         toggleSidebar={toggleSidebar}
       />
       <div
-        className={`relative grow shrink-0 max-h-[calc(100%-55px)] flex flex-col overflow-y-auto px-2 ${!fileBrowserState.currentFileSharePath ? 'grid grid-cols-2 grid-rows-[60px_1fr] bg-surface-light gap-6 p-6' : ''}`}
+        className={`relative grow shrink-0 max-h-[calc(100%-55px)] flex flex-col overflow-y-auto px-2 ${!fileBrowserState.currentFileSharePath ? 'bg-surface-light py-6' : ''}`}
       >
         {!fileBrowserState.currentFileSharePath ? (
-          <>
-            <div className="col-span-2">
-              <NavigationInput location="dashboard" />
+          <div className="flex flex-col max-w-full gap-6 px-6">
+            <NavigationInput location="dashboard" />
+            <div
+              className={`flex gap-6 ${componentWidth > 800 ? '' : 'flex-col'}`}
+            >
+              <RecentlyViewedCard />
+              <RecentDataLinksCard />
             </div>
-            <RecentlyViewedCard />
-            <RecentDataLinksCard />
-          </>
+          </div>
         ) : (
           <FileBrowser
             showPropertiesDrawer={showPropertiesDrawer}

--- a/src/components/ui/BrowsePage/Dashboard/FgDashboardCard.tsx
+++ b/src/components/ui/BrowsePage/Dashboard/FgDashboardCard.tsx
@@ -8,7 +8,7 @@ export default function DashboardCard({
   children: React.ReactNode;
 }) {
   return (
-    <Card className="w-full border bg-background border-surface overflow-y-auto min-h-32 max-h-full">
+    <Card className="w-full border bg-background border-surface overflow-y-auto h-fit max-h-[50%]">
       <Card.Header className="pt-4 pl-4">
         <Typography className="font-semibold text-surface-foreground">
           {title}

--- a/src/components/ui/BrowsePage/NavigateInput.tsx
+++ b/src/components/ui/BrowsePage/NavigateInput.tsx
@@ -37,7 +37,7 @@ export default function NavigationInput({
 
   return (
     <div
-      className={`flex flex-col ${location === 'dashboard' ? '' : 'w-full gap-3 mt-8'}`}
+      className={`flex flex-col w-full ${location === 'dashboard' ? '' : 'gap-3 mt-8'}`}
     >
       <Typography
         as="label"

--- a/src/components/ui/Sidebar/FileSharePath.tsx
+++ b/src/components/ui/Sidebar/FileSharePath.tsx
@@ -44,7 +44,9 @@ export default function FileSharePathComponent({
           </Typography>
         </div>
 
-        <Typography className="text-sm short:text-xs truncate max-w-full">
+        <Typography
+          className={`text-sm short:text-xs truncate max-w-full ${isFavoritable ? '' : 'text-foreground/80'}`}
+        >
           {fspPath}
         </Typography>
       </Link>

--- a/src/components/ui/Sidebar/Folder.tsx
+++ b/src/components/ui/Sidebar/Folder.tsx
@@ -107,7 +107,7 @@ export default function Folder({
               }
             : undefined
         }
-        className="pl-6 w-full flex gap-2 items-center justify-between rounded-md cursor-pointer text-foreground hover:bg-primary-light/30 focus:bg-primary-light/30 "
+        className="group pl-6 w-full flex gap-2 items-center justify-between rounded-md cursor-pointer text-foreground hover:bg-primary-light/30 focus:bg-primary-light/30 "
       >
         <Link
           to={link}
@@ -122,7 +122,9 @@ export default function Folder({
             </Typography>
           </div>
           <FgTooltip label={displayPath} triggerClasses="w-full">
-            <Typography className="text-left text-sm short:text-xs truncate">
+            <Typography
+              className={`text-left text-sm short:text-xs truncate ${isFavoritable ? '' : 'text-foreground/60 group-hover:text-black group-hover:dark:text-white'}`}
+            >
               {displayPath}
             </Typography>
           </FgTooltip>


### PR DESCRIPTION
Clickup ids: 86abrcz49 and 86ac7n65u
@krokicki @neomorphic 

This PR makes the font of the full paths on the two dashboard cards lighter until hovered over. It also makes the dashboard card layout responsive.