### PR TITLE
fix: prevents file_share_mounts errors.

### DIFF
--- a/config.yaml.template
+++ b/config.yaml.template
@@ -30,7 +30,7 @@ db_url: sqlite:///fileglancer.db
 use_access_flags: True
 
 #
-# File share mount paths to view in the UI. 
+# File share mount paths to view in the UI.
 # (this setting will override atlassian_url, set below)
 #
 # file_share_mounts:

--- a/fileglancer/app.py
+++ b/fileglancer/app.py
@@ -110,7 +110,7 @@ def create_app(settings):
     @cache
     def _get_fsp_names_to_mount_paths() -> Dict[str, str]:
         if settings.file_share_mounts:
-            return {fsp.name: fsp.mount_path for fsp in settings.file_share_mounts}
+            return {slugify_path(path): path for path in settings.file_share_mounts}
         else:
             with db.get_db_session(settings.db_url) as session:
                 return {fsp.name: fsp.mount_path for fsp in db.get_all_paths(session)}
@@ -592,18 +592,18 @@ def create_app(settings):
         fsp = None
 
         if file_share_mounts:
-            for mount in file_share_mounts:
-                name = slugify_path(mount.mount_path)
+            for path in file_share_mounts:
+                name = slugify_path(path)
                 if name == path_name:
                     fsp = FileSharePath(
                         name=name,
                         zone='Local',
                         group='local',
                         storage='local',
-                        mount_path=mount.mount_path,
-                        mac_path=mount.mount_path,
-                        windows_path=mount.mount_path,
-                        linux_path=mount.mount_path,
+                        mount_path=path,
+                        mac_path=path,
+                        windows_path=path,
+                        linux_path=path,
                     )
                     break
         else:
@@ -684,9 +684,9 @@ def create_app(settings):
         home_fsp_name = None
         file_share_mounts = settings.file_share_mounts
         if file_share_mounts:
-            for mount in file_share_mounts:
-                if mount.mount_path == home_parent:
-                    home_fsp_name = slugify_path(mount.mount_path)
+            for path in file_share_mounts:
+                if path == home_parent:
+                    home_fsp_name = slugify_path(path)
                     break
         else:
             with db.get_db_session(settings.db_url) as session:

--- a/src/components/ui/Sidebar/FavoritesBrowser.tsx
+++ b/src/components/ui/Sidebar/FavoritesBrowser.tsx
@@ -107,7 +107,7 @@ export default function FavoritesBrowser({
                     folderPath={folderFavorite.folderPath}
                     fsp={folderFavorite.fsp}
                     key={
-                      folderFavorite.fsp.name + '-' + folderFavorite.folderPath
+                      folderFavorite.fsp?.name + '-' + folderFavorite.folderPath
                     }
                   />
                 );

--- a/src/components/ui/Sidebar/Folder.tsx
+++ b/src/components/ui/Sidebar/Folder.tsx
@@ -58,13 +58,13 @@ export default function Folder({
     folderPath
   );
 
-  const mapKey = makeMapKey('folder', `${fsp.name}_${folderPath}`) as string;
-
-  const link = makeBrowseLink(fsp.name, folderPath);
-
   if (!fsp) {
     return null;
   }
+
+  const mapKey = makeMapKey('folder', `${fsp.name}_${folderPath}`) as string;
+
+  const link = makeBrowseLink(fsp.name, folderPath);
 
   async function checkFavFolderExists() {
     if (!folderFavorite || !isFavoritable) {

--- a/src/utils/pathHandling.ts
+++ b/src/utils/pathHandling.ts
@@ -234,7 +234,7 @@ function getPreferredPathForDisplay(
     return '';
   }
 
-  const basePath = fsp[pathKey] ?? fsp.linux_path;
+  const basePath = fsp[pathKey] ?? fsp.linux_path ?? fsp.mount_path;
 
   if (!basePath) {
     return '';


### PR DESCRIPTION
The site was getting strings and expecting objects, because the database returns objects, but the configuration returned strings. Now the server startup converts the file_share_mounts strings into objects, to match the ones returned by the database.