### PR TITLE
fix: disable convert btn if hasRead is false, not hasWrite

### DIFF
--- a/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
+++ b/src/components/ui/PropertiesDrawer/PropertiesDrawer.tsx
@@ -267,7 +267,7 @@ export default function PropertiesDrawer({
                   </Typography>
                   <Button
                     disabled={
-                      fileBrowserState.propertiesTarget.hasWrite === false
+                      fileBrowserState.propertiesTarget.hasRead === false
                     }
                     onClick={() => {
                       setShowConvertFileDialog(true);


### PR DESCRIPTION
@krokicki @neomorphic 

This PR changes when the "convert" button is disabled on the properties panel to be only when the user doesn't have read permission, as opposed to when the user doesn't have write permission.