### PR TITLE
fix: change from query to path param

### DIFF
--- a/src/contexts/ProxiedPathContext.tsx
+++ b/src/contexts/ProxiedPathContext.tsx
@@ -191,7 +191,7 @@ export const ProxiedPathProvider = ({
     async (proxiedPath: ProxiedPath): Promise<Result<void>> => {
       try {
         const response = await sendFetchRequest(
-          `/api/proxied-path?sharing_key=${proxiedPath.sharing_key}`,
+          `/api/proxied-path/${proxiedPath.sharing_key}`,
           'DELETE',
           cookies['_xsrf']
         );


### PR DESCRIPTION
@krokicki @neomorphic 

Changed the API endpoint in `ProxiedPathProvider` to use a path parameter for `sharing_key` instead of a query parameter when sending a DELETE request (`src/contexts/ProxiedPathContext.tsx`). This conforms to what the updated backend, which no longer proxies to fileglancer-central, expects.