### PR TITLE
Fixed env variable setting

### DIFF
--- a/fileglancer/app.py
+++ b/fileglancer/app.py
@@ -169,6 +169,7 @@ def create_app(settings):
         if settings.db_admin_url:
             logger.debug(f"  db_admin_url: {mask_password(settings.db_admin_url)}")
         logger.debug(f"  use_access_flags: {settings.use_access_flags}")
+        logger.debug(f"  external_proxy_url: {settings.external_proxy_url}")
         logger.debug(f"  atlassian_url: {settings.atlassian_url}")
 
         # Initialize database (run migrations once at startup)

--- a/fileglancer/settings.py
+++ b/fileglancer/settings.py
@@ -101,3 +101,10 @@ class Settings(BaseSettings):
 @cache
 def get_settings():
     return Settings()
+
+
+def reload_settings():
+    """Clear the settings cache and reload from environment/config files.
+    Useful when environment variables are set after initial settings load."""
+    get_settings.cache_clear()
+    return get_settings()


### PR DESCRIPTION
Env variable setting for the CLI was broken somewhere along the way. This fixes it in a way that preserves using settings for logger settings at the beginning, and then reloads them after the env variables are set.