### PR TITLE
refactor: provide initial value in rename dialog

### DIFF
--- a/frontend/src/hooks/useRenameDialog.ts
+++ b/frontend/src/hooks/useRenameDialog.ts
@@ -6,9 +6,10 @@ import { handleError, createSuccess } from '@/utils/errorHandling';
 import type { Result } from '@/shared.types';
 
 export default function useRenameDialog() {
-  const [newName, setNewName] = useState<string>('');
-
-  const { fileQuery, mutations } = useFileBrowserContext();
+  const { fileQuery, fileBrowserState, mutations } = useFileBrowserContext();
+  const [newName, setNewName] = useState<string>(
+    fileBrowserState.propertiesTarget?.name || ''
+  );
   const currentFileSharePath = fileQuery.data?.currentFileSharePath;
 
   async function handleRenameSubmit(path: string): Promise<Result<void>> {


### PR DESCRIPTION
Clickup id: 86ad60yxm

This PR changes the rename dialog so that it initially populates with the current name of the file. I found I wanted this feature when I was working on the fix for the URL encoding, and changing file names back and forth from having special characters to not.