### PR TITLE
refactor: reduce prop drilling in ContextMenu component

### DIFF
--- a/frontend/src/components/ui/BrowsePage/FileBrowser.tsx
+++ b/frontend/src/components/ui/BrowsePage/FileBrowser.tsx
@@ -56,13 +56,8 @@ export default function FileBrowser({
   const { displayFiles } = useHideDotFiles();
   const { handleDownload } = useHandleDownload();
 
-  const {
-    contextMenuCoords,
-    showContextMenu,
-    menuRef,
-    openContextMenu,
-    closeContextMenu
-  } = useContextMenu();
+  const { showContextMenu, menuRef, openContextMenu, closeContextMenu } =
+    useContextMenu();
 
   const {
     zarrMetadataQuery,
@@ -221,8 +216,6 @@ export default function FileBrowser({
           items={getContextMenuItems()}
           menuRef={menuRef}
           onClose={closeContextMenu}
-          x={contextMenuCoords.x}
-          y={contextMenuCoords.y}
         />
       ) : null}
     </>

--- a/frontend/src/components/ui/Menus/ContextMenu.tsx
+++ b/frontend/src/components/ui/Menus/ContextMenu.tsx
@@ -1,6 +1,7 @@
 import type { RefObject } from 'react';
 import { createPortal } from 'react-dom';
 import { Menu, Typography } from '@material-tailwind/react';
+import useContextMenu from '@/hooks/useContextMenu';
 
 export type ContextMenuItem = {
   name: string;
@@ -10,20 +11,18 @@ export type ContextMenuItem = {
 };
 
 type ContextMenuProps = {
-  readonly x: number;
-  readonly y: number;
   readonly menuRef: RefObject<HTMLDivElement | null>;
   readonly items: ContextMenuItem[];
   readonly onClose: () => void;
 };
 
 export default function ContextMenu({
-  x,
-  y,
   menuRef,
   items,
   onClose
 }: ContextMenuProps) {
+  const { contextMenuCoords } = useContextMenu();
+
   const handleItemClick = async (item: ContextMenuItem) => {
     const result = await item.action();
     if (result !== false) {
@@ -36,8 +35,8 @@ export default function ContextMenu({
       className="fixed z-[9999] min-w-40 rounded-lg space-y-0.5 border border-surface bg-background p-1"
       ref={menuRef}
       style={{
-        left: `${x}px`,
-        top: `${y}px`
+        left: `${contextMenuCoords.x}px`,
+        top: `${contextMenuCoords.y}px`
       }}
     >
       {items

--- a/frontend/src/components/ui/Table/TableCard.tsx
+++ b/frontend/src/components/ui/Table/TableCard.tsx
@@ -340,7 +340,6 @@ function Table<TData>({
 
   // Context menu state
   const {
-    contextMenuCoords,
     showContextMenu,
     contextData,
     menuRef,
@@ -478,8 +477,6 @@ function Table<TData>({
           items={contextMenuItems}
           menuRef={menuRef}
           onClose={closeContextMenu}
-          x={contextMenuCoords.x}
-          y={contextMenuCoords.y}
         />
       ) : null}
     </>


### PR DESCRIPTION
Move contextMenuCoords state management into ContextMenu component by accessing useContextMenu hook directly, eliminating the need to pass x and y coordinates as props from FileBrowser and TableCard components