### PR TITLE
fix: recently viewed folders bug

### DIFF
--- a/frontend/src/contexts/PreferencesContext.tsx
+++ b/frontend/src/contexts/PreferencesContext.tsx
@@ -358,11 +358,15 @@ export const PreferencesProvider = ({
   };
 
   const updateRecentlyViewedFolders = useCallback(
-    (
-      folderPath: string,
-      fspName: string,
-      currentRecentlyViewedFolders: FolderPreference[]
-    ): FolderPreference[] => {
+    ({
+      folderPath,
+      fspName,
+      currentRecentlyViewedFolders
+    }: {
+      folderPath: string;
+      fspName: string;
+      currentRecentlyViewedFolders: FolderPreference[];
+    }): FolderPreference[] => {
       const updatedFolders = [...currentRecentlyViewedFolders];
 
       // Do not save file share paths in the recently viewed folders
@@ -447,11 +451,12 @@ export const PreferencesProvider = ({
     lastFolderPathRef.current = filePath;
 
     // Calculate updated folders and trigger mutation
-    const updatedFolders = updateRecentlyViewedFolders(
-      filePath,
+    const updatedFolders = updateRecentlyViewedFolders({
+      folderPath: filePath,
       fspName,
-      preferencesQuery.data?.recentlyViewedFolders || []
-    );
+      currentRecentlyViewedFolders:
+        preferencesQuery.data?.recentlyViewedFolders || []
+    });
 
     updatePreferenceListMutation.mutate({
       preferenceKey: 'recentlyViewedFolders',


### PR DESCRIPTION
@krokicki 
Recently viewed folders appeared to be coming back correctly from the /preference endpoint, but were disappearing from the dashboard. In a [previous PR](https://github.com/JaneliaSciComp/fileglancer/commit/95be239a1bafc9d6fa237578666a778fb796e1aa), I introduced a bug by swapping the `filePath` and `fspName` parameters in the function that updates the recently viewed folders. This resulted in the frontend logic being unable to form and display the folder links because the `fspNames` provided from the backend were incorrect (they were actually `filePaths`). So each time you navigated to a new folder that was added to recently viewed folders, it effectively deleted one recently viewed folder from the display in the dashboard, until all the data was bad and the display was empty.

This PR also adds a fix to address a linter warning that `filePath` or `fspName` could be `undefined` when passed to updateRecentlyViewedFolders.

To test this fix, you will need to delete any existing recentlyViewedFolders in your database (specifically if you used the database at all while the bug existed, over the past week or so):
`sqlite3 fileglancer.db "DELETE FROM user_preferences WHERE key='recentlyViewedFolders';"`