### PR TITLE
fix: remove unneeded e.currentTarget.blur() calls

### DIFF
--- a/frontend/src/components/ui/BrowsePage/NavigationButton.tsx
+++ b/frontend/src/components/ui/BrowsePage/NavigationButton.tsx
@@ -24,7 +24,6 @@ export default function NavigationButton({
         label="Navigate to a path"
         onClick={(e: MouseEvent<HTMLButtonElement>) => {
           setShowNavigationDialog(true);
-          e.currentTarget.blur();
         }}
         triggerClasses={triggerClasses}
       />

--- a/frontend/src/components/ui/BrowsePage/NewFolderButton.tsx
+++ b/frontend/src/components/ui/BrowsePage/NewFolderButton.tsx
@@ -51,7 +51,6 @@ export default function NewFolderButton({
         label="New folder"
         onClick={(e: MouseEvent<HTMLButtonElement>) => {
           setShowNewFolderDialog(true);
-          e.currentTarget.blur();
         }}
         triggerClasses={triggerClasses}
       />

--- a/frontend/src/components/ui/BrowsePage/Toolbar.tsx
+++ b/frontend/src/components/ui/BrowsePage/Toolbar.tsx
@@ -92,7 +92,6 @@ export default function Toolbar({
 
   const handleToggleSidebar = (e: React.MouseEvent<HTMLButtonElement>) => {
     toggleSidebar();
-    e.currentTarget.blur();
   };
 
   const handleToggleHideDotFiles = async (
@@ -106,7 +105,6 @@ export default function Toolbar({
     } else {
       toast.error(result.error);
     }
-    e.currentTarget.blur();
   };
 
   const handleToggleFavorite = async (
@@ -136,7 +134,6 @@ export default function Toolbar({
     e: React.MouseEvent<HTMLButtonElement>
   ) => {
     togglePropertiesDrawer();
-    e.currentTarget.blur();
   };
 
   return (


### PR DESCRIPTION
Clickup id: 86adx9mee

This PR removes the `e.currentTarget.blur()` calls from the end of each `onClick` method for the Toolbar buttons. This has the benefit of eliminating the error printed to the console related to the target being null for the view dot file button. This removal did not change the visual appearance of the buttons/tooltips, and is better for accessibility by not breaking the expected tab behavior. Further, one button (add new folder), did not have `e.currentTarget.blur()`, so this makes the button logic more consistent.

@krokicki 