### PR TITLE
Fix issue with N5 data links in Neuroglancer

### DIFF
--- a/fileglancer/app.py
+++ b/fileglancer/app.py
@@ -177,7 +177,7 @@ def create_app(settings):
             #   1. Properly encoded requests (sharing_name matches DB value of proxied_path.sharing_name)
             #   2. Vol-E's unencoded requests (unquote(proxied_path.sharing_name) matches the garbled request value)
             if proxied_path.sharing_name != sharing_name and unquote(proxied_path.sharing_name) != sharing_name:
-                return get_error_response(400, "InvalidArgument", f"Sharing name mismatch for sharing key {sharing_key}", sharing_name), None
+                return get_error_response(404, "NoSuchKey", f"Sharing name mismatch for sharing key {sharing_key}", sharing_name), None
 
             fsp = db.get_file_share_path(session, proxied_path.fsp_name)
             if not fsp:


### PR DESCRIPTION
Clickup id: 86ae0r6ek

When loading N5 data, for some reason Neuroglancer keeps walking up the file tree until it encounters a 404. We currently return a `400 Bad Request` response if you strip the sharing name off the data URL (like it ends up doing), and when it sees that error it seems to fail entirely. 

I changed this to return a 404 instead, and now N5 data will load. 

@JaneliaSciComp/fileglancer @StephanPreibisch 


