### PR TITLE
fix: set layer type to 'image' for zarrs without thumbnail

### DIFF
--- a/frontend/src/hooks/useZarrMetadata.ts
+++ b/frontend/src/hooks/useZarrMetadata.ts
@@ -55,10 +55,8 @@ export default function useZarrMetadata() {
 
   useEffect(() => {
     if (!thumbnailSrc || disableHeuristicalLayerTypeDetection) {
-      // Set default layer type if heuristics are disabled
-      if (disableHeuristicalLayerTypeDetection) {
-        setLayerType('image');
-      }
+      // Set layer type to 'image' if no thumbnail or detection disabled
+      setLayerType('image');
       return;
     }
 


### PR DESCRIPTION
@krokicki @neomorphic 
This fixes a bug where Zarrs without thumbnails would not generate Neuroglancer links.