### PR TITLE
test: fileQueries handling of a 500 Internal Server Error

### DIFF
--- a/frontend/src/__tests__/unitTests/fileQueries.errorHandling.test.tsx
+++ b/frontend/src/__tests__/unitTests/fileQueries.errorHandling.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import useFileQuery from './fileQueries';
+import useFileQuery from '../../queries/fileQueries';
 import * as utils from '@/utils';
 
 // Mock the utils module


### PR DESCRIPTION
Resolve #283 in part by adding a test for error handling by 
fileQueries.js.

When a 500 Internal Server Error was created, we would attempt to parse 
the response content as JSON, resulting in another error:

```
Unexpected token 'I', "Internal S"... is not valid JSON
```

This pull request adds a new test to check for this kind of error message.

- **test: add reproduction case for frontend 500 error handling (expected fail)**
- **test: refine reproduction test (rename and add assertion)**

The test is expected to fail until #285 is merged.

Assisted by Gemini 3 Pro (Low) via Antigravity.