### PR TITLE
fix: Prevents concurrent alembic migrations with file-based locking

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -508,8 +506,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1127,8 +1123,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2996,8 +2990,8 @@ packages:
   timestamp: 1760972937564
 - pypi: ./
   name: fileglancer
-  version: 2.2.1
-  sha256: 0128c34e0ae7fe36a12ca9c59571488b221877ac4b330783a3daaa722312af1d
+  version: 2.4.0
+  sha256: bfbde34083039b00f72e03149635389893177139077a5e3547ada6c65dca7da0
   requires_dist:
   - aiosqlite>=0.21.0
   - alembic>=1.17.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ dev-watch = { cmd = "cd frontend && NODE_ENV=development npm run watch" }
 dev-launch = "pixi run uvicorn fileglancer.app:app --no-access-log --port 7878 --reload"
 dev-launch-remote = "pixi run uvicorn fileglancer.app:app --host 0.0.0.0 --port 7878 --reload --ssl-keyfile /opt/certs/cert.key --ssl-certfile /opt/certs/cert.crt"
 prod-launch-remote = "pixi run uvicorn fileglancer.app:app --workers 10 --host 0.0.0.0 --port 7878 --ssl-keyfile /opt/certs/cert.key --ssl-certfile /opt/certs/cert.crt"
+test-multi-worker = "pixi run uvicorn fileglancer.app:app --host 127.0.0.1 --workers 10 --port 8989 --no-access-log"
 dev-launch-secure = "python fileglancer/dev_launch.py"
 migrate = "alembic upgrade head"
 migrate-create = "alembic revision --autogenerate"


### PR DESCRIPTION
When running uvicorn with multiple workers (--workers 10), all worker
processes were attempting to run alembic migrations simultaneously,
causing race conditions and errors.

Implemented file-based locking using fcntl to ensure only one process
runs migrations while other workers wait. The lock file is created in
the system temp directory with a hash of the database URL to support
multiple databases.

Also removed the redundant global _migrations_run flag which only
prevented duplicate runs within a single process, not across multiple
worker processes.

Added test-multi-worker task to pyproject.toml for testing with 10 workers.

@krokicki 