### PR TITLE
Try to import and add omero_figure app and static files

### DIFF
--- a/fileglancer/app.py
+++ b/fileglancer/app.py
@@ -268,6 +268,15 @@ def create_app(settings):
 
     app = FastAPI(lifespan=lifespan)
 
+    try:
+        from omero_figure.fileglancer import app as figure_app
+        app.include_router(figure_app.router, prefix="/omero-figure", tags=["figure"])
+        static_dir = figure_app.get_static_dir()
+        # NB: vite must build the figure app with "base: '/omero-figure/'" for this to work correctly
+        app.mount("/omero-figure/", StaticFiles(directory=static_dir, html=True), name="omero_figure")
+    except Exception:
+        logger.info("Could not import figure app. Figure-related endpoints will not be available.")
+
     # Add custom access log middleware
     # This logs HTTP access information with authenticated username
     app.add_middleware(AccessLogMiddleware, settings=settings)


### PR DESCRIPTION
Hi - I'm not really proposing to merge these changes in, but I just wanted to start a discussion...

I've been experimenting with using Fileglancer as a back-end to OMERO.figure, which currently involves a bunch of changes in a branch of OMERO.figure at https://github.com/will-moore/omero-figure/pull/6 and the smaller changes in this PR.

This comes off the back of work in progress that adds OME-Zarr support to OMERO.figure. This frees up the app from using OMERO.web as the backend. It's possible to use OMERO.figure as a pure static app, but it's much nicer to have a server for:

 - Serving local OME-Zarr images
 - Running the `Figure_To_Pdf.py` script that converts from the figure (saved as JSON) to the PDF (or TIFF) figure
 - Opening and Saving figure.json files

I haven't implemented the Opening and saving of local figure.json files yet, but the other stuff is kinda working (see PR above for my current dev set-up).

The main issues I want to ask about...

 - In OMERO.web (based on Django) we can `pip install omero-figure` (which is not included with omero-web) then we set some config to `omero_figure` module to the list of Django apps. However, I'm not familiar with FastAPI and I couldn't work out if there's a way to do something equivalent? In the code below, I simply hard-code the import of `omero_figure`, but maybe there's a nicer way of doing this?
 - To run the `Figure_To_Pdf.py`, the figure app POSTs to `http://127.0.0.1:7878/omero-figure/export` (with the figure.json and a `path/to/save/figure.pdf` and a background task runs the script and saves the pdf. The frontend app keeps pinging the file path location (using Fileglancer endpoint `http://127.0.0.1:7878/api/files/home?subpath=path/to/save/` until it sees the file appear. However, if something goes wrong with the export script and it throws an error, I don't have anyway for the frontend to know about it, or get the error message. Do you know if FastAPI might provide some way to handle this?

I'm really excited to allow non-OMERO users to use OMERO.figure for the first time (we may actually rename it to drop "OMERO") and I think that Fileglancer is going to be the best way for most of these users to adopt it. Would be great to hear what you think? Thanks.
