### PR TITLE
Further fixes to job submission

### DIFF
--- a/docs/config.yaml.template
+++ b/docs/config.yaml.template
@@ -142,6 +142,8 @@ cluster:
 #     - /opt/lsf/bin           # startup so scheduler commands (bsub, bjobs,
 #                              # bkill) are findable. Useful when running as a
 #                              # systemd service with a minimal default PATH.
+#   extra_env:                 # Extra environment variables set at startup.
+#     LSF_ENVDIR: /misc/lsf/conf  # Required for LSF to find lsf.conf.
 #   job_name_prefix: fg        # Prefix for cluster job names. REQUIRED for job
 #                              # reconnection after server restarts. Without this,
 #                              # active jobs will not be re-tracked and will

--- a/docs/config.yaml.template
+++ b/docs/config.yaml.template
@@ -138,6 +138,10 @@ session_cookie_secure: true
 #
 cluster:
   executor: local            # "local" or "lsf"
+#   extra_paths:               # Directories prepended to the server's PATH at
+#     - /opt/lsf/bin           # startup so scheduler commands (bsub, bjobs,
+#                              # bkill) are findable. Useful when running as a
+#                              # systemd service with a minimal default PATH.
 #   job_name_prefix: fg        # Prefix for cluster job names. REQUIRED for job
 #                              # reconnection after server restarts. Without this,
 #                              # active jobs will not be re-tracked and will

--- a/docs/config.yaml.template
+++ b/docs/config.yaml.template
@@ -129,10 +129,6 @@ session_cookie_secure: true
 # Useful when running as a systemd service where login scripts don't run.
 #
 # env_source_script: /misc/lsf/conf/profile.lsf  # Source a shell script to set env vars
-# extra_paths:               # Directories prepended to the server's PATH
-#   - /opt/lsf/bin
-# extra_env:                 # Extra environment variables set at startup
-#   LSF_ENVDIR: /misc/lsf/conf
 
 #
 # Settings for the Apps feature

--- a/docs/config.yaml.template
+++ b/docs/config.yaml.template
@@ -125,6 +125,16 @@ session_cookie_name: fg_session
 session_cookie_secure: true
 
 #
+# Environment setup — sourced at startup before any scheduler commands.
+# Useful when running as a systemd service where login scripts don't run.
+#
+# env_source_script: /misc/lsf/conf/profile.lsf  # Source a shell script to set env vars
+# extra_paths:               # Directories prepended to the server's PATH
+#   - /opt/lsf/bin
+# extra_env:                 # Extra environment variables set at startup
+#   LSF_ENVDIR: /misc/lsf/conf
+
+#
 # Settings for the Apps feature
 #
 # apps:
@@ -138,12 +148,6 @@ session_cookie_secure: true
 #
 cluster:
   executor: local            # "local" or "lsf"
-#   extra_paths:               # Directories prepended to the server's PATH at
-#     - /opt/lsf/bin           # startup so scheduler commands (bsub, bjobs,
-#                              # bkill) are findable. Useful when running as a
-#                              # systemd service with a minimal default PATH.
-#   extra_env:                 # Extra environment variables set at startup.
-#     LSF_ENVDIR: /misc/lsf/conf  # Required for LSF to find lsf.conf.
 #   job_name_prefix: fg        # Prefix for cluster job names. REQUIRED for job
 #                              # reconnection after server restarts. Without this,
 #                              # active jobs will not be re-tracked and will

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -585,8 +585,6 @@ async def get_executor():
         # extra_args are handled via ResourceSpec in _build_resource_spec
         # to avoid double-application (config + per-job merge in py-cluster-api)
         config.pop("extra_args", None)
-        config.pop("extra_paths", None)
-        config.pop("extra_env", None)
         _executor = create_executor(**config)
     return _executor
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -712,15 +712,12 @@ _POLL_LOCK_PATH = os.path.join(tempfile.gettempdir(), "fileglancer_poll.lock")
 
 
 async def start_job_monitor():
-    """Start the background job poll loop.
+    """Reconnect any in-flight jobs and start polling if needed.
 
-    Every uvicorn worker starts a poll loop, but each iteration acquires
-    a file lock before polling.  Only the worker that wins the lock
-    actually runs ``bjobs``; the rest sleep and try again next cycle.
-    This means if the active worker dies, another picks up automatically.
+    Only one uvicorn worker performs the reconnect (via file lock).
+    The poll loop is only started if there are active jobs in the DB;
+    otherwise it waits until a job is submitted (see ensure_poll_loop).
     """
-    global _poll_task
-
     settings = get_settings()
 
     # Only one worker should reconnect at startup — use the same lock.
@@ -733,7 +730,29 @@ async def start_job_monitor():
     except OSError:
         logger.info("Job monitor started (reconnect handled by another worker)")
 
+    # Only start the poll loop if there are already active jobs
+    if _get_any_active_username(settings) is not None:
+        ensure_poll_loop()
+        logger.info("Poll loop started (active jobs found at startup)")
+    else:
+        logger.info("Poll loop deferred (no active jobs)")
+
+
+def ensure_poll_loop():
+    """Start the poll loop if it is not already running.
+
+    Called by submit_job after a new job is created, and by
+    start_job_monitor if active jobs exist at startup.
+    Safe to call multiple times — only one loop runs at a time.
+    """
+    global _poll_task
+
+    if _poll_task is not None and not _poll_task.done():
+        return  # already running
+
+    settings = get_settings()
     _poll_task = asyncio.create_task(_poll_loop(settings))
+    logger.info("Poll loop started")
 
 
 async def stop_job_monitor():
@@ -812,21 +831,32 @@ async def _poll_loop(settings):
     poll and the sleep, so staggered workers can't double-poll within
     the same interval.  If the lock-holding worker dies, the OS
     releases the lock and another worker takes over next cycle.
+
+    The loop exits automatically when there are no active jobs,
+    and is restarted on the next job submission via ensure_poll_loop().
     """
+    global _poll_task
+
     while True:
         lock_fd = None
         try:
             lock_fd = open(_POLL_LOCK_PATH, "w")
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             try:
-                _poll_jobs(settings)
+                has_jobs = _poll_jobs(settings)
             except Exception:
                 logger.exception("Error in job poll loop")
+                has_jobs = True  # keep polling on error
             # Hold lock through the sleep so no other worker polls
             # until this interval is over
             await asyncio.sleep(settings.cluster.poll_interval)
             fcntl.flock(lock_fd, fcntl.LOCK_UN)
             lock_fd.close()
+
+            if not has_jobs:
+                logger.info("No active jobs — poll loop stopping")
+                _poll_task = None
+                return
         except OSError:
             # Another worker is polling this cycle — skip and retry
             if lock_fd:
@@ -835,9 +865,16 @@ async def _poll_loop(settings):
 
 
 def _poll_jobs(settings):
-    """Run one poll cycle: query bjobs via worker, update DB."""
+    """Run one poll cycle: query bjobs via worker, update DB.
+
+    Returns True if there are active jobs to continue polling,
+    False if the loop can stop.
+    """
     with db.get_db_session(settings.db_url) as session:
         active_jobs = db.get_active_jobs(session)
+
+        if not active_jobs:
+            return False
 
         # Handle zombie jobs (no cluster_job_id after timeout)
         jobs_to_poll = []
@@ -855,7 +892,7 @@ def _poll_jobs(settings):
             jobs_to_poll.append(db_job)
 
         if not jobs_to_poll:
-            return
+            return True  # zombie jobs still pending, keep polling
 
         # Pick any user to run bjobs as (bjobs -u all sees all users' jobs)
         poll_username = jobs_to_poll[0].username
@@ -876,7 +913,7 @@ def _poll_jobs(settings):
             })
         except ValueError as e:
             logger.warning(f"Poll failed: {e}")
-            return
+            return True  # keep polling on error
 
         polled_jobs = result.get("jobs", {})
 
@@ -898,6 +935,8 @@ def _poll_jobs(settings):
                 finished_at=finished_at,
             )
             logger.info(f"Job {db_job.id} status updated: {old_status} -> {new_status}")
+
+        return True
 
 
 def _parse_iso_dt(s: str | None) -> datetime | None:
@@ -1204,6 +1243,7 @@ async def submit_job(
         db_job = db.get_job(session, job_id, username)
         session.expunge(db_job)
 
+    ensure_poll_loop()
     logger.info(f"Job {db_job.id} submitted for user {username} in {work_dir}")
     return db_job
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -993,6 +993,8 @@ async def submit_job(
     with user_context if user_context is not None else nullcontext():
         work_dir.mkdir(parents=True, exist_ok=True)
         repo_link = work_dir / "repo"
+        if repo_link.is_symlink() or repo_link.exists():
+            repo_link.unlink()
         repo_link.symlink_to(cached_repo_dir)
         cluster_job = await executor.submit(
             command=full_command,

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -20,8 +20,7 @@ from loguru import logger
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from cluster_api import create_executor, ResourceSpec, JobMonitor
-from cluster_api._types import JobStatus
+from cluster_api import ResourceSpec
 
 from fileglancer import database as db
 from fileglancer.apps.adapters import try_adapt
@@ -634,92 +633,119 @@ def _run_as_user(username: str, request: dict) -> dict:
     return response
 
 
-# --- Executor Management ---
+# --- Job Monitoring ---
+#
+# The server process runs as root, which cannot execute LSF commands
+# (bjobs, bsub, bkill) due to HPC root-squash policy.  All LSF
+# operations go through worker subprocesses running as a real user.
+#
+# The poll loop picks any user with active jobs and spawns a worker
+# that runs ``bjobs -u all`` to get statuses for ALL users' jobs.
 
-_executor = None
-_monitor = None
-_monitor_task = None
-
-
-async def get_executor():
-    """Get or create the cluster executor singleton."""
-    global _executor
-    if _executor is None:
-        settings = get_settings()
-        config = settings.cluster.model_dump(exclude_none=True)
-        # extra_args are handled via ResourceSpec in _build_resource_spec
-        # to avoid double-application (config + per-job merge in py-cluster-api)
-        config.pop("extra_args", None)
-        _executor = create_executor(**config)
-    return _executor
+_poll_task = None
 
 
 async def start_job_monitor():
-    """Start the background job monitoring loop."""
-    global _monitor, _monitor_task
+    """Start the background job poll loop."""
+    global _poll_task
 
     settings = get_settings()
-    executor = await get_executor()
 
     # Reconnect to any previously submitted jobs (e.g. after server restart)
-    try:
-        reconnected = await executor.reconnect()
-        if reconnected:
-            for record in reconnected:
-                record.on_exit(_on_job_exit)
-            logger.info(f"Reconnected to {len(reconnected)} existing cluster jobs")
-    except Exception as e:
-        logger.debug(f"Job reconnection skipped: {e}")
+    _reconnect_as_any_user(settings)
 
-    _monitor = JobMonitor(executor, poll_interval=settings.cluster.poll_interval)
-    await _monitor.start()
-
-    # Start reconciliation loop
-    _monitor_task = asyncio.create_task(_reconcile_loop(settings))
+    _poll_task = asyncio.create_task(_poll_loop(settings))
     logger.info("Job monitor started")
 
 
 async def stop_job_monitor():
-    """Stop the background job monitoring loop."""
-    global _monitor, _monitor_task
+    """Stop the background job poll loop."""
+    global _poll_task
 
-    if _monitor_task:
-        _monitor_task.cancel()
+    if _poll_task:
+        _poll_task.cancel()
         try:
-            await _monitor_task
+            await _poll_task
         except asyncio.CancelledError:
             pass
-        _monitor_task = None
-
-    if _monitor:
-        await _monitor.stop()
-        _monitor = None
+        _poll_task = None
 
     logger.info("Job monitor stopped")
 
 
-async def _reconcile_loop(settings):
-    """Periodically reconcile DB job statuses with cluster state."""
+def _get_any_active_username(settings) -> str | None:
+    """Return any username that has active (PENDING/RUNNING) jobs, or None."""
+    with db.get_db_session(settings.db_url) as session:
+        active_jobs = db.get_active_jobs(session)
+        for job in active_jobs:
+            if job.username:
+                return job.username
+    return None
+
+
+def _reconnect_as_any_user(settings):
+    """Reconnect to existing cluster jobs via a worker subprocess.
+
+    Picks any user with active jobs to run bjobs as.  If no active jobs
+    exist, reconnection is skipped (nothing to reconnect to).
+    """
+    username = _get_any_active_username(settings)
+    if not username:
+        logger.debug("No active jobs, skipping reconnect")
+        return
+
+    cluster_config = settings.cluster.model_dump(exclude_none=True)
+    try:
+        result = _run_as_user(username, {
+            "action": "reconnect",
+            "cluster_config": cluster_config,
+        })
+    except ValueError as e:
+        logger.debug(f"Job reconnection skipped: {e}")
+        return
+
+    jobs = result.get("jobs", {})
+    if jobs:
+        logger.info(f"Reconnected to {len(jobs)} existing cluster jobs")
+
+    # Update DB for any reconnected jobs that we're tracking
+    with db.get_db_session(settings.db_url) as session:
+        for cluster_job_id, info in jobs.items():
+            db_job = db.get_job_by_cluster_id(session, cluster_job_id)
+            if db_job is None:
+                continue
+            new_status = info["status"].upper()
+            if new_status != db_job.status:
+                is_terminal = new_status in ("DONE", "FAILED", "KILLED")
+                finished_at = _parse_iso_dt(info.get("finish_time")) if is_terminal else None
+                db.update_job_status(
+                    session, db_job.id, new_status,
+                    exit_code=info.get("exit_code"),
+                    started_at=_parse_iso_dt(info.get("start_time")),
+                    finished_at=finished_at,
+                )
+
+
+async def _poll_loop(settings):
+    """Periodically poll cluster job statuses via a worker subprocess."""
     while True:
         try:
-            await _reconcile_jobs(settings)
+            _poll_jobs(settings)
         except Exception:
-            logger.exception("Error in job reconciliation loop")
+            logger.exception("Error in job poll loop")
 
         await asyncio.sleep(settings.cluster.poll_interval)
 
 
-async def _reconcile_jobs(settings):
-    """Reconcile DB job statuses with the executor's tracked jobs."""
-    executor = await get_executor()
-
+def _poll_jobs(settings):
+    """Run one poll cycle: query bjobs via worker, update DB."""
     with db.get_db_session(settings.db_url) as session:
         active_jobs = db.get_active_jobs(session)
 
+        # Handle zombie jobs (no cluster_job_id after timeout)
+        jobs_to_poll = []
         for db_job in active_jobs:
             if not db_job.cluster_job_id:
-                # Job never got a cluster_job_id - submission didn't complete.
-                # Mark FAILED if it's been stuck longer than zombie_timeout.
                 created = db_job.created_at.replace(tzinfo=None) if db_job.created_at.tzinfo else db_job.created_at
                 age_minutes = (datetime.now(UTC).replace(tzinfo=None) - created).total_seconds() / 60
                 if age_minutes > settings.cluster.zombie_timeout_minutes:
@@ -729,75 +755,55 @@ async def _reconcile_jobs(settings):
                         f"{age_minutes:.0f} minutes, marked FAILED"
                     )
                 continue
+            jobs_to_poll.append(db_job)
 
-            # Check if executor is tracking this job
-            tracked = executor.jobs.get(db_job.cluster_job_id)
-            if tracked is None:
-                # Job was purged from executor tracking. Terminal status
-                # updates are handled by the on_exit callback, so this
-                # means either the callback already fired or the job was
-                # lost (e.g. server restart without reconnection).
-                # Skip it here — the zombie timeout above will catch
-                # truly stuck jobs that never got a cluster_job_id.
+        if not jobs_to_poll:
+            return
+
+        # Pick any user to run bjobs as (bjobs -u all sees all users' jobs)
+        poll_username = jobs_to_poll[0].username
+        cluster_job_ids = [j.cluster_job_id for j in jobs_to_poll]
+
+        cluster_config = settings.cluster.model_dump(exclude_none=True)
+        try:
+            result = _run_as_user(poll_username, {
+                "action": "poll",
+                "cluster_config": cluster_config,
+                "cluster_job_ids": cluster_job_ids,
+            })
+        except ValueError as e:
+            logger.warning(f"Poll failed: {e}")
+            return
+
+        polled_jobs = result.get("jobs", {})
+
+        # Update DB with polled statuses
+        for db_job in jobs_to_poll:
+            info = polled_jobs.get(db_job.cluster_job_id)
+            if info is None:
                 continue
-
-            # Sync non-terminal status changes (e.g. PENDING -> RUNNING).
-            # Terminal transitions are handled by the on_exit callback.
-            new_status = _map_status(tracked.status)
-            if new_status != db_job.status:
-                # Only store finished_at for terminal states. LSF may report
-                # a FINISH_TIME for running jobs (projected walltime end),
-                # which we must not store as an actual finish time.
-                is_terminal = new_status in ("DONE", "FAILED", "KILLED")
-                db.update_job_status(
-                    session, db_job.id, new_status,
-                    exit_code=tracked.exit_code if is_terminal else None,
-                    started_at=tracked.start_time,
-                    finished_at=tracked.finish_time if is_terminal else None,
-                )
-                logger.info(f"Job {db_job.id} status updated: {db_job.status} -> {new_status}")
+            new_status = info["status"].upper()
+            if new_status == db_job.status:
+                continue
+            is_terminal = new_status in ("DONE", "FAILED", "KILLED")
+            finished_at = _parse_iso_dt(info.get("finish_time")) if is_terminal else None
+            db.update_job_status(
+                session, db_job.id, new_status,
+                exit_code=info.get("exit_code") if is_terminal else None,
+                started_at=_parse_iso_dt(info.get("start_time")),
+                finished_at=finished_at,
+            )
+            logger.info(f"Job {db_job.id} status updated: {db_job.status} -> {new_status}")
 
 
-def _map_status(status: JobStatus) -> str:
-    """Map py-cluster-api JobStatus to our string status."""
-    mapping = {
-        JobStatus.PENDING: "PENDING",
-        JobStatus.RUNNING: "RUNNING",
-        JobStatus.DONE: "DONE",
-        JobStatus.FAILED: "FAILED",
-        JobStatus.KILLED: "KILLED",
-        JobStatus.UNKNOWN: "FAILED",
-    }
-    return mapping.get(status, "FAILED")
-
-
-def _on_job_exit(record):
-    """Callback fired by JobMonitor when a job reaches terminal state.
-
-    This runs inside the monitor's poll loop, before completed jobs are
-    purged, so we are guaranteed to capture the final status.
-    """
-    settings = get_settings()
-    new_status = _map_status(record.status)
-
-    with db.get_db_session(settings.db_url) as session:
-        db_job = db.get_job_by_cluster_id(session, record.job_id)
-        if db_job is None:
-            logger.warning(f"No DB job found for cluster job {record.job_id}")
-            return
-        if db_job.status == new_status:
-            return
-        # Don't overwrite a terminal status (e.g. KILLED by user) with
-        # another terminal status from the executor callback.
-        if db_job.status in ("DONE", "FAILED", "KILLED"):
-            return
-        db.update_job_status(
-            session, db_job.id, new_status,
-            exit_code=record.exit_code,
-            started_at=record.start_time,
-            finished_at=record.finish_time,
-        )
-        logger.info(f"Job {db_job.id} completed: {db_job.status} -> {new_status}")
+def _parse_iso_dt(s: str | None) -> datetime | None:
+    """Parse an ISO 8601 datetime string, or return None."""
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
 
 
 # --- Job Submission ---
@@ -1081,16 +1087,7 @@ async def submit_job(
 
     cluster_job_id = worker_result["job_id"]
 
-    # Reconnect so the parent's monitor picks up the new job
-    executor = await get_executor()
-    try:
-        reconnected = await executor.reconnect()
-        for record in reconnected:
-            record.on_exit(_on_job_exit)
-    except Exception as e:
-        logger.debug(f"Post-submit reconnect: {e}")
-
-    # Update DB with cluster job ID and return fresh object
+    # Update DB with cluster job ID — the poll loop will track status from here
     with db.get_db_session(settings.db_url) as session:
         db.update_job_status(
             session, job_id, "PENDING",

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -596,17 +596,25 @@ def _run_as_user(username: str, request: dict) -> dict:
     Raises ValueError on worker failure.
     """
     pw = pwd.getpwnam(username)
-    groups = [g.gr_gid for g in grp.getgrall() if username in g.gr_mem]
-    if pw.pw_gid not in groups:
-        groups.append(pw.pw_gid)
+
+    # Only switch identity if running as root; otherwise we're already
+    # the target user (e.g. development mode).
+    identity_kwargs: dict = {}
+    if os.geteuid() == 0:
+        groups = [g.gr_gid for g in grp.getgrall() if username in g.gr_mem]
+        if pw.pw_gid not in groups:
+            groups.append(pw.pw_gid)
+        identity_kwargs = {
+            "user": pw.pw_uid,
+            "group": pw.pw_gid,
+            "extra_groups": groups,
+        }
 
     result = subprocess.run(
         [sys.executable, "-m", "fileglancer.apps.worker"],
         input=json.dumps(request).encode(),
         capture_output=True,
-        user=pw.pw_uid,
-        group=pw.pw_gid,
-        extra_groups=groups,
+        **identity_kwargs,
     )
 
     if result.stdout:

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -586,6 +586,7 @@ async def get_executor():
         # to avoid double-application (config + per-job merge in py-cluster-api)
         config.pop("extra_args", None)
         config.pop("extra_paths", None)
+        config.pop("extra_env", None)
         _executor = create_executor(**config)
     return _executor
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -27,7 +27,13 @@ from fileglancer.settings import get_settings
 
 _MANIFEST_FILENAME = "runnables.yaml"
 
-_REPO_CACHE_BASE = Path(os.path.expanduser("~/.fileglancer/apps"))
+def _repo_cache_base(username: str | None = None) -> Path:
+    """Return the repo cache base directory, optionally for a specific user."""
+    if username:
+        home = os.path.expanduser(f"~{username}")
+    else:
+        home = os.path.expanduser("~")
+    return Path(home) / ".fileglancer" / "apps"
 _repo_locks: dict[str, asyncio.Lock] = {}
 
 
@@ -121,18 +127,21 @@ async def _resolve_default_branch(clone_url: str) -> str:
     return "main"
 
 
-async def _ensure_repo_cache(url: str, pull: bool = False) -> Path:
+async def _ensure_repo_cache(url: str, pull: bool = False,
+                             username: str | None = None) -> Path:
     """Clone or update the GitHub repo in per-user cache. Returns repo path.
 
     Cache is keyed by owner/repo/branch to avoid checkout races between branches.
     An asyncio lock serializes git operations for the same repo+branch.
+    When username is provided, the cache is placed under ~username/.fileglancer/apps.
     """
     owner, repo, branch = _parse_github_url(url)
     clone_url = f"https://github.com/{owner}/{repo}.git"
     if not branch:
         branch = await _resolve_default_branch(clone_url)
-    repo_dir = (_REPO_CACHE_BASE / owner / repo / branch).resolve()
-    repo_dir.relative_to(_REPO_CACHE_BASE.resolve())
+    cache_base = _repo_cache_base(username)
+    repo_dir = (cache_base / owner / repo / branch).resolve()
+    repo_dir.relative_to(cache_base.resolve())
     lock = _get_repo_lock(owner, repo, branch)
 
     async with lock:
@@ -227,22 +236,24 @@ def _find_manifests_in_repo(repo_dir: Path) -> list[tuple[str, AppManifest]]:
 MANIFEST_FILENAME = _MANIFEST_FILENAME
 
 
-async def discover_app_manifests(url: str) -> list[tuple[str, AppManifest]]:
+async def discover_app_manifests(url: str,
+                                 username: str | None = None) -> list[tuple[str, AppManifest]]:
     """Clone/pull a GitHub repo and discover all manifest files.
 
     Returns a list of (relative_dir_path, AppManifest) tuples.
     Raises ValueError if the URL is invalid or the clone fails.
     """
-    repo_dir = await _ensure_repo_cache(url, pull=True)
+    repo_dir = await _ensure_repo_cache(url, pull=True, username=username)
     return _find_manifests_in_repo(repo_dir)
 
 
-async def fetch_app_manifest(url: str, manifest_path: str = "") -> AppManifest:
+async def fetch_app_manifest(url: str, manifest_path: str = "",
+                             username: str | None = None) -> AppManifest:
     """Fetch and validate an app manifest from a cloned repo.
 
     Clones the repo if needed, then reads the manifest from disk.
     """
-    repo_dir = await _ensure_repo_cache(url)
+    repo_dir = await _ensure_repo_cache(url, username=username)
     target_dir = repo_dir / manifest_path if manifest_path else repo_dir
     return _read_manifest_file(target_dir)
 
@@ -828,7 +839,7 @@ async def submit_job(
     settings = get_settings()
 
     # Fetch and validate manifest
-    manifest = await fetch_app_manifest(app_url, manifest_path)
+    manifest = await fetch_app_manifest(app_url, manifest_path, username=username)
 
     # Find entry point
     entry_point = None
@@ -851,6 +862,12 @@ async def submit_job(
     if extra_args is not None:
         overrides["extra_args"] = extra_args
     resource_spec = _build_resource_spec(entry_point, overrides or None, settings)
+
+    # When running as root, tell LSF to execute the job as the actual user.
+    if user_context is not None:
+        if resource_spec.extra_args is None:
+            resource_spec.extra_args = []
+        resource_spec.extra_args.append(f"-U {username}")
 
     # Merge env/pre_run/post_run: manifest defaults overridden by user values
     merged_env = dict(entry_point.env or {})
@@ -904,14 +921,14 @@ async def submit_job(
         db_job.work_dir = str(work_dir)
         session.commit()
 
-    # Pre-fetch repo into the shared server-owned cache. This must run as the
-    # server/root user because the cache lives under the server's home directory
-    # (~/.fileglancer/apps), which the authenticated user cannot write to.
+    # Clone/pull repo into the user's cache (~username/.fileglancer/apps).
     if manifest.repo_url:
-        cached_repo_dir = await _ensure_repo_cache(manifest.repo_url, pull=pull_latest)
+        cached_repo_dir = await _ensure_repo_cache(manifest.repo_url, pull=pull_latest,
+                                                   username=username)
         cd_suffix = "repo"
     else:
-        cached_repo_dir = await _ensure_repo_cache(app_url, pull=pull_latest)
+        cached_repo_dir = await _ensure_repo_cache(app_url, pull=pull_latest,
+                                                   username=username)
         cd_suffix = f"repo/{manifest_path}" if manifest_path else "repo"
 
     # Build environment variable export lines

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -1,11 +1,15 @@
 """Apps module for fetching manifests, building commands, and managing cluster jobs."""
 
 import asyncio
+import grp
+import json
 import os
+import pwd
 import re
 import shlex
 import shutil
 import subprocess
+import sys
 from contextlib import nullcontext
 from pathlib import Path
 from datetime import datetime, UTC
@@ -580,6 +584,48 @@ def build_command(entry_point: AppEntryPoint, parameters: dict, session=None) ->
     return (" \\\n  ").join(parts)
 
 
+def _run_as_user(username: str, request: dict) -> dict:
+    """Run a worker action as the given user in a subprocess.
+
+    Spawns a child process with the target user's identity using
+    Python 3.9+ ``user``/``group``/``extra_groups`` subprocess kwargs.
+    The child runs fileglancer.apps.worker, which creates a fresh
+    py-cluster-api executor and performs the requested action.
+
+    Returns the parsed JSON response from the worker.
+    Raises ValueError on worker failure.
+    """
+    pw = pwd.getpwnam(username)
+    groups = [g.gr_gid for g in grp.getgrall() if username in g.gr_mem]
+    if pw.pw_gid not in groups:
+        groups.append(pw.pw_gid)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "fileglancer.apps.worker"],
+        input=json.dumps(request).encode(),
+        capture_output=True,
+        user=pw.pw_uid,
+        group=pw.pw_gid,
+        extra_groups=groups,
+    )
+
+    if result.stdout:
+        try:
+            response = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            raise ValueError(
+                f"Worker produced invalid JSON: {result.stdout.decode()[:500]}"
+            )
+    else:
+        response = {}
+
+    if result.returncode != 0:
+        error = response.get("error", result.stderr.decode()[:500])
+        raise ValueError(f"Worker failed: {error}")
+
+    return response
+
+
 # --- Executor Management ---
 
 _executor = None
@@ -838,8 +884,9 @@ async def submit_job(
     """
     settings = get_settings()
 
-    # Fetch and validate manifest
-    manifest = await fetch_app_manifest(app_url, manifest_path, username=username)
+    # Fetch and validate manifest (clones repo into user's cache)
+    with user_context if user_context is not None else nullcontext():
+        manifest = await fetch_app_manifest(app_url, manifest_path, username=username)
 
     # Find entry point
     entry_point = None
@@ -916,14 +963,15 @@ async def submit_job(
         session.commit()
 
     # Clone/pull repo into the user's cache (~username/.fileglancer/apps).
-    if manifest.repo_url:
-        cached_repo_dir = await _ensure_repo_cache(manifest.repo_url, pull=pull_latest,
-                                                   username=username)
-        cd_suffix = "repo"
-    else:
-        cached_repo_dir = await _ensure_repo_cache(app_url, pull=pull_latest,
-                                                   username=username)
-        cd_suffix = f"repo/{manifest_path}" if manifest_path else "repo"
+    with user_context if user_context is not None else nullcontext():
+        if manifest.repo_url:
+            cached_repo_dir = await _ensure_repo_cache(manifest.repo_url, pull=pull_latest,
+                                                       username=username)
+            cd_suffix = "repo"
+        else:
+            cached_repo_dir = await _ensure_repo_cache(app_url, pull=pull_latest,
+                                                       username=username)
+            cd_suffix = f"repo/{manifest_path}" if manifest_path else "repo"
 
     # Build environment variable export lines
     env_lines = ""
@@ -997,30 +1045,48 @@ async def submit_job(
     resource_spec.stdout_path = str(work_dir / "stdout.log")
     resource_spec.stderr_path = str(work_dir / "stderr.log")
 
-    # Create work directory, symlink the cached repo, and submit to the cluster —
-    # all as the authenticated user so the job runs with correct ownership.
-    executor = await get_executor()
+    # Submit to the cluster as the target user.  The worker subprocess
+    # creates the work directory, symlinks the repo, and calls
+    # executor.submit() — all with the user's identity.
     job_name = f"{manifest.name}-{entry_point.id}"
-    with user_context if user_context is not None else nullcontext():
-        work_dir.mkdir(parents=True, exist_ok=True)
-        repo_link = work_dir / "repo"
-        if repo_link.is_symlink() or repo_link.exists():
-            repo_link.unlink()
-        repo_link.symlink_to(cached_repo_dir)
-        cluster_job = await executor.submit(
-            command=full_command,
-            name=job_name,
-            resources=resource_spec,
-        )
+    cluster_config = settings.cluster.model_dump(exclude_none=True)
+    worker_result = _run_as_user(username, {
+        "action": "submit",
+        "cluster_config": cluster_config,
+        "command": full_command,
+        "job_name": job_name,
+        "resources": {
+            "cpus": resource_spec.cpus,
+            "gpus": resource_spec.gpus,
+            "memory": resource_spec.memory,
+            "walltime": resource_spec.walltime,
+            "queue": resource_spec.queue,
+            "work_dir": resource_spec.work_dir,
+            "stdout_path": resource_spec.stdout_path,
+            "stderr_path": resource_spec.stderr_path,
+            "extra_directives": resource_spec.extra_directives,
+            "extra_args": resource_spec.extra_args,
+        },
+        "work_dir": str(work_dir),
+        "cached_repo_dir": cached_repo_dir,
+    })
 
-    # Register callback to update DB when job reaches terminal state
-    cluster_job.on_exit(_on_job_exit)
+    cluster_job_id = worker_result["job_id"]
+
+    # Reconnect so the parent's monitor picks up the new job
+    executor = await get_executor()
+    try:
+        reconnected = await executor.reconnect()
+        for record in reconnected:
+            record.on_exit(_on_job_exit)
+    except Exception as e:
+        logger.debug(f"Post-submit reconnect: {e}")
 
     # Update DB with cluster job ID and return fresh object
     with db.get_db_session(settings.db_url) as session:
         db.update_job_status(
             session, job_id, "PENDING",
-            cluster_job_id=cluster_job.job_id,
+            cluster_job_id=cluster_job_id,
         )
         db_job = db.get_job(session, job_id, username)
         session.expunge(db_job)
@@ -1082,10 +1148,14 @@ async def cancel_job(job_id: int, username: str) -> db.JobDB:
         if db_job.status not in ("PENDING", "RUNNING"):
             raise ValueError(f"Job {job_id} is not cancellable (status: {db_job.status})")
 
-        # Cancel on cluster
+        # Cancel on cluster as the target user
         if db_job.cluster_job_id:
-            executor = await get_executor()
-            await executor.cancel(db_job.cluster_job_id)
+            cluster_config = settings.cluster.model_dump(exclude_none=True)
+            _run_as_user(username, {
+                "action": "cancel",
+                "cluster_config": cluster_config,
+                "job_id": db_job.cluster_job_id,
+            })
 
         # Update DB
         now = datetime.now(UTC)

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -10,7 +10,6 @@ import shlex
 import shutil
 import subprocess
 import sys
-from contextlib import nullcontext
 from pathlib import Path
 from datetime import datetime, UTC
 from typing import Optional
@@ -136,13 +135,30 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
 
     Cache is keyed by owner/repo/branch to avoid checkout races between branches.
     An asyncio lock serializes git operations for the same repo+branch.
-    When username is provided, the cache is placed under ~username/.fileglancer/apps.
+
+    When username is provided, the work is delegated to a worker subprocess
+    that runs with the target user's real UID/GID, avoiding the process-wide
+    euid race condition that EffectiveUserContext has with concurrent async
+    requests.  When username is None, git commands run in-process (used by
+    the worker subprocess itself, or in single-user dev mode).
     """
     owner, repo, branch = _parse_github_url(url)
     clone_url = f"https://github.com/{owner}/{repo}.git"
     if not branch:
         branch = await _resolve_default_branch(clone_url)
-    cache_base = _repo_cache_base(username)
+
+    if username:
+        lock = _get_repo_lock(owner, repo, branch)
+        async with lock:
+            result = await _run_as_user_async(username, {
+                "action": "ensure_repo",
+                "url": url,
+                "pull": pull,
+            })
+            return Path(result["repo_dir"])
+
+    # Running as the current user (worker subprocess or dev mode)
+    cache_base = _repo_cache_base()
     repo_dir = (cache_base / owner / repo / branch).resolve()
     repo_dir.relative_to(cache_base.resolve())
     lock = _get_repo_lock(owner, repo, branch)
@@ -245,8 +261,21 @@ async def discover_app_manifests(url: str,
 
     Returns a list of (relative_dir_path, AppManifest) tuples.
     Raises ValueError if the URL is invalid or the clone fails.
+
+    When username is provided, the work is delegated to a worker subprocess
+    running as the target user.
     """
-    repo_dir = await _ensure_repo_cache(url, pull=True, username=username)
+    if username:
+        result = await _run_as_user_async(username, {
+            "action": "discover_manifests",
+            "url": url,
+        })
+        return [
+            (item["path"], AppManifest(**item["manifest"]))
+            for item in result["manifests"]
+        ]
+
+    repo_dir = await _ensure_repo_cache(url, pull=True)
     return _find_manifests_in_repo(repo_dir)
 
 
@@ -255,8 +284,19 @@ async def fetch_app_manifest(url: str, manifest_path: str = "",
     """Fetch and validate an app manifest from a cloned repo.
 
     Clones the repo if needed, then reads the manifest from disk.
+
+    When username is provided, the work is delegated to a worker subprocess
+    running as the target user.
     """
-    repo_dir = await _ensure_repo_cache(url, username=username)
+    if username:
+        result = await _run_as_user_async(username, {
+            "action": "read_manifest",
+            "url": url,
+            "manifest_path": manifest_path,
+        })
+        return AppManifest(**result["manifest"])
+
+    repo_dir = await _ensure_repo_cache(url)
     target_dir = repo_dir / manifest_path if manifest_path else repo_dir
     return _read_manifest_file(target_dir)
 
@@ -613,6 +653,7 @@ def _run_as_user(username: str, request: dict) -> dict:
         [sys.executable, "-m", "fileglancer.apps.worker"],
         input=json.dumps(request).encode(),
         capture_output=True,
+        env={**os.environ, "HOME": pw.pw_dir},
         **identity_kwargs,
     )
 
@@ -631,6 +672,11 @@ def _run_as_user(username: str, request: dict) -> dict:
         raise ValueError(f"Worker failed: {error}")
 
     return response
+
+
+async def _run_as_user_async(username: str, request: dict) -> dict:
+    """Async wrapper for _run_as_user that doesn't block the event loop."""
+    return await asyncio.to_thread(_run_as_user, username, request)
 
 
 # --- Job Monitoring ---
@@ -888,7 +934,6 @@ async def submit_job(
     post_run: Optional[str] = None,
     container: Optional[str] = None,
     container_args: Optional[str] = None,
-    user_context=None,
 ) -> db.JobDB:
     """Submit a new job to the cluster.
 
@@ -899,8 +944,7 @@ async def submit_job(
     settings = get_settings()
 
     # Fetch and validate manifest (clones repo into user's cache)
-    with user_context if user_context is not None else nullcontext():
-        manifest = await fetch_app_manifest(app_url, manifest_path, username=username)
+    manifest = await fetch_app_manifest(app_url, manifest_path, username=username)
 
     # Find entry point
     entry_point = None
@@ -977,15 +1021,14 @@ async def submit_job(
         session.commit()
 
     # Clone/pull repo into the user's cache (~username/.fileglancer/apps).
-    with user_context if user_context is not None else nullcontext():
-        if manifest.repo_url:
-            cached_repo_dir = await _ensure_repo_cache(manifest.repo_url, pull=pull_latest,
-                                                       username=username)
-            cd_suffix = "repo"
-        else:
-            cached_repo_dir = await _ensure_repo_cache(app_url, pull=pull_latest,
-                                                       username=username)
-            cd_suffix = f"repo/{manifest_path}" if manifest_path else "repo"
+    if manifest.repo_url:
+        cached_repo_dir = await _ensure_repo_cache(manifest.repo_url, pull=pull_latest,
+                                                   username=username)
+        cd_suffix = "repo"
+    else:
+        cached_repo_dir = await _ensure_repo_cache(app_url, pull=pull_latest,
+                                                   username=username)
+        cd_suffix = f"repo/{manifest_path}" if manifest_path else "repo"
 
     # Build environment variable export lines
     env_lines = ""

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -585,16 +585,8 @@ async def get_executor():
         # extra_args are handled via ResourceSpec in _build_resource_spec
         # to avoid double-application (config + per-job merge in py-cluster-api)
         config.pop("extra_args", None)
+        config.pop("extra_paths", None)
         _executor = create_executor(**config)
-        # Resolve scheduler commands to absolute paths so that subprocess
-        # spawning works even when euid has been switched (uvloop/libuv
-        # may fail PATH resolution in that context).
-        for attr in ("submit_command", "cancel_command", "status_command"):
-            cmd = getattr(_executor, attr, None)
-            if cmd and not os.path.isabs(cmd):
-                full_path = shutil.which(cmd)
-                if full_path:
-                    setattr(_executor, attr, full_path)
     return _executor
 
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -808,14 +808,20 @@ def _poll_jobs(settings):
 
         # Pick any user to run bjobs as (bjobs -u all sees all users' jobs)
         poll_username = jobs_to_poll[0].username
-        cluster_job_ids = [j.cluster_job_id for j in jobs_to_poll]
+        # Pass current known statuses so stubs are seeded correctly.
+        # Without this, stubs default to PENDING and jobs whose status
+        # bjobs doesn't return would revert to PENDING in the DB.
+        job_statuses = {
+            j.cluster_job_id: j.status for j in jobs_to_poll
+        }
 
         cluster_config = settings.cluster.model_dump(exclude_none=True)
         try:
             result = _run_as_user(poll_username, {
                 "action": "poll",
                 "cluster_config": cluster_config,
-                "cluster_job_ids": cluster_job_ids,
+                "cluster_job_ids": list(job_statuses.keys()),
+                "job_statuses": job_statuses,
             })
         except ValueError as e:
             logger.warning(f"Poll failed: {e}")

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -586,6 +586,15 @@ async def get_executor():
         # to avoid double-application (config + per-job merge in py-cluster-api)
         config.pop("extra_args", None)
         _executor = create_executor(**config)
+        # Resolve scheduler commands to absolute paths so that subprocess
+        # spawning works even when euid has been switched (uvloop/libuv
+        # may fail PATH resolution in that context).
+        for attr in ("submit_command", "cancel_command", "status_command"):
+            cmd = getattr(_executor, attr, None)
+            if cmd and not os.path.isabs(cmd):
+                full_path = shutil.which(cmd)
+                if full_path:
+                    setattr(_executor, attr, full_path)
     return _executor
 
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -863,12 +863,6 @@ async def submit_job(
         overrides["extra_args"] = extra_args
     resource_spec = _build_resource_spec(entry_point, overrides or None, settings)
 
-    # When running as root, tell LSF to execute the job as the actual user.
-    if user_context is not None:
-        if resource_spec.extra_args is None:
-            resource_spec.extra_args = []
-        resource_spec.extra_args.append(f"-U {username}")
-
     # Merge env/pre_run/post_run: manifest defaults overridden by user values
     merged_env = dict(entry_point.env or {})
     if env:

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -1068,7 +1068,7 @@ async def submit_job(
             "extra_args": resource_spec.extra_args,
         },
         "work_dir": str(work_dir),
-        "cached_repo_dir": cached_repo_dir,
+        "cached_repo_dir": str(cached_repo_dir),
     })
 
     cluster_job_id = worker_result["job_id"]

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -1064,26 +1064,33 @@ async def submit_job(
     # executor.submit() — all with the user's identity.
     job_name = f"{manifest.name}-{entry_point.id}"
     cluster_config = settings.cluster.model_dump(exclude_none=True)
-    worker_result = _run_as_user(username, {
-        "action": "submit",
-        "cluster_config": cluster_config,
-        "command": full_command,
-        "job_name": job_name,
-        "resources": {
-            "cpus": resource_spec.cpus,
-            "gpus": resource_spec.gpus,
-            "memory": resource_spec.memory,
-            "walltime": resource_spec.walltime,
-            "queue": resource_spec.queue,
-            "work_dir": resource_spec.work_dir,
-            "stdout_path": resource_spec.stdout_path,
-            "stderr_path": resource_spec.stderr_path,
-            "extra_directives": resource_spec.extra_directives,
-            "extra_args": resource_spec.extra_args,
-        },
-        "work_dir": str(work_dir),
-        "cached_repo_dir": str(cached_repo_dir),
-    })
+    try:
+        worker_result = _run_as_user(username, {
+            "action": "submit",
+            "cluster_config": cluster_config,
+            "command": full_command,
+            "job_name": job_name,
+            "resources": {
+                "cpus": resource_spec.cpus,
+                "gpus": resource_spec.gpus,
+                "memory": resource_spec.memory,
+                "walltime": resource_spec.walltime,
+                "queue": resource_spec.queue,
+                "work_dir": resource_spec.work_dir,
+                "stdout_path": resource_spec.stdout_path,
+                "stderr_path": resource_spec.stderr_path,
+                "extra_directives": resource_spec.extra_directives,
+                "extra_args": resource_spec.extra_args,
+            },
+            "work_dir": str(work_dir),
+            "cached_repo_dir": str(cached_repo_dir),
+        })
+    except Exception:
+        # Cluster submission failed — remove the PENDING DB record so
+        # the job does not appear in the user's jobs list.
+        with db.get_db_session(settings.db_url) as session:
+            db.delete_job(session, job_id, username)
+        raise
 
     cluster_job_id = worker_result["job_id"]
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -148,6 +148,10 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
         branch = await _resolve_default_branch(clone_url)
 
     if username:
+        logger.debug(
+            f"Delegating ensure_repo to worker for user={username} "
+            f"repo={owner}/{repo} ({branch}) pull={pull}"
+        )
         lock = _get_repo_lock(owner, repo, branch)
         async with lock:
             result = await _run_as_user_async(username, {
@@ -158,6 +162,7 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
             return Path(result["repo_dir"])
 
     # Running as the current user (worker subprocess or dev mode)
+    logger.debug(f"ensure_repo running in-process as euid={os.geteuid()}")
     cache_base = _repo_cache_base()
     repo_dir = (cache_base / owner / repo / branch).resolve()
     repo_dir.relative_to(cache_base.resolve())
@@ -266,6 +271,7 @@ async def discover_app_manifests(url: str,
     running as the target user.
     """
     if username:
+        logger.debug(f"Delegating discover_manifests to worker for user={username} url={url}")
         result = await _run_as_user_async(username, {
             "action": "discover_manifests",
             "url": url,
@@ -289,6 +295,7 @@ async def fetch_app_manifest(url: str, manifest_path: str = "",
     running as the target user.
     """
     if username:
+        logger.debug(f"Delegating read_manifest to worker for user={username} url={url}")
         result = await _run_as_user_async(username, {
             "action": "read_manifest",
             "url": url,
@@ -635,6 +642,7 @@ def _run_as_user(username: str, request: dict) -> dict:
     Raises ValueError on worker failure.
     """
     pw = pwd.getpwnam(username)
+    action = request.get("action", "unknown")
 
     # Only switch identity if running as root; otherwise we're already
     # the target user (e.g. development mode).
@@ -648,6 +656,15 @@ def _run_as_user(username: str, request: dict) -> dict:
             "group": pw.pw_gid,
             "extra_groups": groups,
         }
+        logger.debug(
+            f"Spawning worker action={action} as user={username} "
+            f"uid={pw.pw_uid} gid={pw.pw_gid} HOME={pw.pw_dir}"
+        )
+    else:
+        logger.debug(
+            f"Spawning worker action={action} as current user "
+            f"(euid={os.geteuid()}, not root — no identity switch)"
+        )
 
     result = subprocess.run(
         [sys.executable, "-m", "fileglancer.apps.worker"],

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -808,25 +808,30 @@ async def _poll_loop(settings):
     """Periodically poll cluster job statuses via a worker subprocess.
 
     All uvicorn workers run this loop, but only the one that acquires
-    the file lock actually polls.  The lock is held only for the
-    duration of a single poll cycle, so if a worker dies another
-    takes over on the next interval.
+    the file lock actually polls.  The lock is held through both the
+    poll and the sleep, so staggered workers can't double-poll within
+    the same interval.  If the lock-holding worker dies, the OS
+    releases the lock and another worker takes over next cycle.
     """
     while True:
+        lock_fd = None
         try:
-            with open(_POLL_LOCK_PATH, "w") as f:
-                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                try:
-                    _poll_jobs(settings)
-                finally:
-                    fcntl.flock(f, fcntl.LOCK_UN)
+            lock_fd = open(_POLL_LOCK_PATH, "w")
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                _poll_jobs(settings)
+            except Exception:
+                logger.exception("Error in job poll loop")
+            # Hold lock through the sleep so no other worker polls
+            # until this interval is over
+            await asyncio.sleep(settings.cluster.poll_interval)
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            lock_fd.close()
         except OSError:
-            # Another worker is polling this cycle — skip
-            pass
-        except Exception:
-            logger.exception("Error in job poll loop")
-
-        await asyncio.sleep(settings.cluster.poll_interval)
+            # Another worker is polling this cycle — skip and retry
+            if lock_fd:
+                lock_fd.close()
+            await asyncio.sleep(settings.cluster.poll_interval)
 
 
 def _poll_jobs(settings):
@@ -881,7 +886,8 @@ def _poll_jobs(settings):
             if info is None:
                 continue
             new_status = info["status"].upper()
-            if new_status == db_job.status:
+            old_status = db_job.status
+            if new_status == old_status:
                 continue
             is_terminal = new_status in ("DONE", "FAILED", "KILLED")
             finished_at = _parse_iso_dt(info.get("finish_time")) if is_terminal else None
@@ -891,7 +897,7 @@ def _poll_jobs(settings):
                 started_at=_parse_iso_dt(info.get("start_time")),
                 finished_at=finished_at,
             )
-            logger.info(f"Job {db_job.id} status updated: {db_job.status} -> {new_status}")
+            logger.info(f"Job {db_job.id} status updated: {old_status} -> {new_status}")
 
 
 def _parse_iso_dt(s: str | None) -> datetime | None:

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -1,6 +1,7 @@
 """Apps module for fetching manifests, building commands, and managing cluster jobs."""
 
 import asyncio
+import fcntl
 import grp
 import json
 import os
@@ -10,6 +11,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from datetime import datetime, UTC
 from typing import Optional
@@ -706,19 +708,32 @@ async def _run_as_user_async(username: str, request: dict) -> dict:
 # that runs ``bjobs -u all`` to get statuses for ALL users' jobs.
 
 _poll_task = None
+_POLL_LOCK_PATH = os.path.join(tempfile.gettempdir(), "fileglancer_poll.lock")
 
 
 async def start_job_monitor():
-    """Start the background job poll loop."""
+    """Start the background job poll loop.
+
+    Every uvicorn worker starts a poll loop, but each iteration acquires
+    a file lock before polling.  Only the worker that wins the lock
+    actually runs ``bjobs``; the rest sleep and try again next cycle.
+    This means if the active worker dies, another picks up automatically.
+    """
     global _poll_task
 
     settings = get_settings()
 
-    # Reconnect to any previously submitted jobs (e.g. after server restart)
-    _reconnect_as_any_user(settings)
+    # Only one worker should reconnect at startup — use the same lock.
+    try:
+        with open(_POLL_LOCK_PATH, "w") as f:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            _reconnect_as_any_user(settings)
+            fcntl.flock(f, fcntl.LOCK_UN)
+        logger.info("Job monitor started (reconnected existing jobs)")
+    except OSError:
+        logger.info("Job monitor started (reconnect handled by another worker)")
 
     _poll_task = asyncio.create_task(_poll_loop(settings))
-    logger.info("Job monitor started")
 
 
 async def stop_job_monitor():
@@ -790,10 +805,24 @@ def _reconnect_as_any_user(settings):
 
 
 async def _poll_loop(settings):
-    """Periodically poll cluster job statuses via a worker subprocess."""
+    """Periodically poll cluster job statuses via a worker subprocess.
+
+    All uvicorn workers run this loop, but only the one that acquires
+    the file lock actually polls.  The lock is held only for the
+    duration of a single poll cycle, so if a worker dies another
+    takes over on the next interval.
+    """
     while True:
         try:
-            _poll_jobs(settings)
+            with open(_POLL_LOCK_PATH, "w") as f:
+                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                try:
+                    _poll_jobs(settings)
+                finally:
+                    fcntl.flock(f, fcntl.LOCK_UN)
+        except OSError:
+            # Another worker is polling this cycle — skip
+            pass
         except Exception:
             logger.exception("Error in job poll loop")
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -6,6 +6,7 @@ import re
 import shlex
 import shutil
 import subprocess
+from contextlib import nullcontext
 from pathlib import Path
 from datetime import datetime, UTC
 from typing import Optional
@@ -810,6 +811,7 @@ async def submit_job(
     post_run: Optional[str] = None,
     container: Optional[str] = None,
     container_args: Optional[str] = None,
+    user_context=None,
 ) -> db.JobDB:
     """Submit a new job to the cluster.
 
@@ -895,21 +897,14 @@ async def submit_job(
         db_job.work_dir = str(work_dir)
         session.commit()
 
-    # Create work directory on disk
-    work_dir.mkdir(parents=True, exist_ok=True)
-
-    # Determine which repo to symlink and where to cd
+    # Pre-fetch repo into the shared server-owned cache. This must run as the
+    # server/root user because the cache lives under the server's home directory
+    # (~/.fileglancer/apps), which the authenticated user cannot write to.
     if manifest.repo_url:
-        # Tool code lives in a separate repo — clone it and cd to its root
-        tool_repo_dir = await _ensure_repo_cache(manifest.repo_url, pull=pull_latest)
-        repo_link = work_dir / "repo"
-        repo_link.symlink_to(tool_repo_dir)
+        cached_repo_dir = await _ensure_repo_cache(manifest.repo_url, pull=pull_latest)
         cd_suffix = "repo"
     else:
-        # Tool code is in the discovery repo — cd into manifest's subdirectory
-        repo_dir = await _ensure_repo_cache(app_url, pull=pull_latest)
-        repo_link = work_dir / "repo"
-        repo_link.symlink_to(repo_dir)
+        cached_repo_dir = await _ensure_repo_cache(app_url, pull=pull_latest)
         cd_suffix = f"repo/{manifest_path}" if manifest_path else "repo"
 
     # Build environment variable export lines
@@ -984,14 +979,19 @@ async def submit_job(
     resource_spec.stdout_path = str(work_dir / "stdout.log")
     resource_spec.stderr_path = str(work_dir / "stderr.log")
 
-    # Submit to executor
+    # Create work directory, symlink the cached repo, and submit to the cluster —
+    # all as the authenticated user so the job runs with correct ownership.
     executor = await get_executor()
     job_name = f"{manifest.name}-{entry_point.id}"
-    cluster_job = await executor.submit(
-        command=full_command,
-        name=job_name,
-        resources=resource_spec,
-    )
+    with user_context if user_context is not None else nullcontext():
+        work_dir.mkdir(parents=True, exist_ok=True)
+        repo_link = work_dir / "repo"
+        repo_link.symlink_to(cached_repo_dir)
+        cluster_job = await executor.submit(
+            command=full_command,
+            name=job_name,
+            resources=resource_spec,
+        )
 
     # Register callback to update DB when job reaches terminal state
     cluster_job.on_exit(_on_job_exit)

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -789,12 +789,18 @@ def _build_container_script(
 
 
 def _build_work_dir(job_id: int, app_name: str, entry_point_id: str,
-                    job_name_prefix: Optional[str] = None) -> Path:
-    """Build a working directory path under ~/.fileglancer/jobs/."""
+                    job_name_prefix: Optional[str] = None,
+                    username: Optional[str] = None) -> Path:
+    """Build a working directory path under ~/.fileglancer/jobs/.
+
+    When username is provided, expands ~username to the user's home directory
+    instead of the server process's home (which is typically root).
+    """
     safe_app = _sanitize_for_path(app_name)
     safe_ep = _sanitize_for_path(entry_point_id)
     prefix = f"{_sanitize_for_path(job_name_prefix)}-" if job_name_prefix else ""
-    return Path(os.path.expanduser(f"~/.fileglancer/jobs/{prefix}{job_id}-{safe_app}-{safe_ep}"))
+    home = os.path.expanduser(f"~{username}") if username else os.path.expanduser("~")
+    return Path(f"{home}/.fileglancer/jobs/{prefix}{job_id}-{safe_app}-{safe_ep}")
 
 
 async def submit_job(
@@ -893,7 +899,8 @@ async def submit_job(
 
         # Compute and persist work_dir now that we have the job ID
         work_dir = _build_work_dir(job_id, manifest.name, entry_point.id,
-                                   job_name_prefix=settings.cluster.job_name_prefix)
+                                   job_name_prefix=settings.cluster.job_name_prefix,
+                                   username=username)
         db_job.work_dir = str(work_dir)
         session.commit()
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -854,14 +854,6 @@ async def submit_job(
         overrides["extra_args"] = extra_args
     resource_spec = _build_resource_spec(entry_point, overrides or None, settings)
 
-    # When running as root, tell LSF to execute the job as the actual user.
-    # bsub uses getuid() (real UID) to determine the submitting user, so
-    # seteuid alone is not sufficient — the -U flag is needed.
-    if user_context is not None:
-        if resource_spec.extra_args is None:
-            resource_spec.extra_args = []
-        resource_spec.extra_args.append(f"-U {username}")
-
     # Merge env/pre_run/post_run: manifest defaults overridden by user values
     merged_env = dict(entry_point.env or {})
     if env:

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -861,6 +861,14 @@ async def submit_job(
         overrides["extra_args"] = extra_args
     resource_spec = _build_resource_spec(entry_point, overrides or None, settings)
 
+    # When running as root, tell LSF to execute the job as the actual user.
+    # bsub uses getuid() (real UID) to determine the submitting user, so
+    # seteuid alone is not sufficient — the -U flag is needed.
+    if user_context is not None:
+        if resource_spec.extra_args is None:
+            resource_spec.extra_args = []
+        resource_spec.extra_args.append(f"-U {username}")
+
     # Merge env/pre_run/post_run: manifest defaults overridden by user values
     merged_env = dict(entry_point.env or {})
     if env:

--- a/fileglancer/apps/pixi.py
+++ b/fileglancer/apps/pixi.py
@@ -170,6 +170,7 @@ def _task_to_entry_point(name: str, task: dict) -> AppEntryPoint | None:
         description=description,
         command=command,
         parameters=parameters,
+        pre_run='export PATH="$HOME/.pixi/bin:$PATH"',
     )
 
 

--- a/fileglancer/apps/worker.py
+++ b/fileglancer/apps/worker.py
@@ -83,9 +83,73 @@ async def _cancel(request: dict) -> dict:
     return {"status": "ok"}
 
 
+async def _poll(request: dict) -> dict:
+    """Poll job statuses via py-cluster-api (bjobs -u all).
+
+    The executor needs to know which jobs to track, so we seed it with
+    the cluster_job_ids from the DB before polling. After poll(), we
+    return the updated statuses and metadata for each tracked job.
+    """
+    from cluster_api._types import JobRecord, JobStatus
+
+    config = request["cluster_config"]
+    config.pop("extra_args", None)
+
+    executor = create_executor(**config)
+
+    # Seed the executor with stub JobRecords so poll() knows what to track.
+    # poll() queries bjobs and updates these records in-place.
+    for cid in request["cluster_job_ids"]:
+        executor._jobs[cid] = JobRecord(
+            job_id=cid,
+            name="",
+            command="",
+            status=JobStatus.PENDING,
+        )
+
+    await executor.poll()
+
+    # Return the updated state for each job
+    jobs = {}
+    for cid, record in executor.jobs.items():
+        jobs[cid] = {
+            "status": record.status.value,
+            "exit_code": record.exit_code,
+            "exec_host": record.exec_host,
+            "start_time": record.start_time.isoformat() if record.start_time else None,
+            "finish_time": record.finish_time.isoformat() if record.finish_time else None,
+        }
+
+    return {"jobs": jobs}
+
+
+async def _reconnect(request: dict) -> dict:
+    """Reconnect to existing jobs via py-cluster-api (bjobs -u all)."""
+    config = request["cluster_config"]
+    config.pop("extra_args", None)
+
+    executor = create_executor(**config)
+    reconnected = await executor.reconnect()
+
+    jobs = {}
+    for record in reconnected:
+        jobs[record.job_id] = {
+            "status": record.status.value,
+            "name": record.name,
+            "exit_code": record.exit_code,
+            "exec_host": record.exec_host,
+            "start_time": record.start_time.isoformat() if record.start_time else None,
+            "finish_time": record.finish_time.isoformat() if record.finish_time else None,
+        }
+
+    return {"jobs": jobs}
+
+
 _ACTIONS = {
     "submit": _submit,
     "cancel": _cancel,
+    "poll": _poll,
+    "reconnect": _reconnect,
 }
 
 

--- a/fileglancer/apps/worker.py
+++ b/fileglancer/apps/worker.py
@@ -1,0 +1,110 @@
+"""Subprocess worker for running cluster operations as a target user.
+
+This module is invoked as a subprocess by fileglancer to run py-cluster-api
+operations (submit, cancel) with the identity of the authenticated user.
+The parent process uses Python 3.9+ ``user``/``group``/``extra_groups``
+subprocess kwargs to set the child's identity before any code runs.
+
+Protocol:
+    - Input:  JSON on stdin
+    - Output: JSON on stdout ({"job_id": ...} or {"error": ...})
+    - Errors: non-zero exit code + JSON error on stdout
+
+Usage (called by fileglancer, not directly):
+    subprocess.run(
+        [sys.executable, "-m", "fileglancer.apps.worker"],
+        input=json.dumps(request).encode(),
+        capture_output=True,
+        user=uid, group=gid, extra_groups=groups,
+    )
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+from cluster_api import create_executor, ResourceSpec
+
+
+async def _submit(request: dict) -> dict:
+    """Create work dir, symlink repo, submit job via py-cluster-api."""
+    config = request["cluster_config"]
+    # extra_args are handled via ResourceSpec, not config
+    config.pop("extra_args", None)
+
+    executor = create_executor(**config)
+
+    work_dir = Path(request["work_dir"])
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    # Symlink the cached repo into the work directory
+    cached_repo_dir = request["cached_repo_dir"]
+    repo_link = work_dir / "repo"
+    if repo_link.is_symlink() or repo_link.exists():
+        repo_link.unlink()
+    repo_link.symlink_to(cached_repo_dir)
+
+    # Build ResourceSpec from the serialized dict
+    res = request["resources"]
+    resource_spec = ResourceSpec(
+        cpus=res.get("cpus"),
+        gpus=res.get("gpus"),
+        memory=res.get("memory"),
+        walltime=res.get("walltime"),
+        queue=res.get("queue"),
+        work_dir=res["work_dir"],
+        stdout_path=res.get("stdout_path"),
+        stderr_path=res.get("stderr_path"),
+        extra_directives=res.get("extra_directives"),
+        extra_args=res.get("extra_args"),
+    )
+
+    job = await executor.submit(
+        command=request["command"],
+        name=request["job_name"],
+        resources=resource_spec,
+    )
+
+    return {"job_id": job.job_id, "script_path": job.script_path}
+
+
+async def _cancel(request: dict) -> dict:
+    """Cancel a cluster job via py-cluster-api."""
+    config = request["cluster_config"]
+    config.pop("extra_args", None)
+
+    executor = create_executor(**config)
+    await executor.cancel(request["job_id"])
+
+    return {"status": "ok"}
+
+
+_ACTIONS = {
+    "submit": _submit,
+    "cancel": _cancel,
+}
+
+
+def main():
+    request = json.loads(sys.stdin.buffer.read())
+    action = request.get("action")
+
+    handler = _ACTIONS.get(action)
+    if handler is None:
+        json.dump({"error": f"Unknown action: {action}"}, sys.stdout)
+        sys.exit(1)
+
+    try:
+        result = asyncio.run(handler(request))
+        json.dump(result, sys.stdout)
+    except Exception as e:
+        json.dump({"error": str(e)}, sys.stdout)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/fileglancer/apps/worker.py
+++ b/fileglancer/apps/worker.py
@@ -1,9 +1,10 @@
-"""Subprocess worker for running cluster operations as a target user.
+"""Subprocess worker for running operations as a target user.
 
 This module is invoked as a subprocess by fileglancer to run py-cluster-api
-operations (submit, cancel) with the identity of the authenticated user.
-The parent process uses Python 3.9+ ``user``/``group``/``extra_groups``
-subprocess kwargs to set the child's identity before any code runs.
+operations (submit, cancel, poll) and git/manifest operations (clone, pull,
+read) with the identity of the authenticated user.  The parent process uses
+Python 3.9+ ``user``/``group``/``extra_groups`` subprocess kwargs to set the
+child's identity before any code runs.
 
 Protocol:
     - Input:  JSON on stdin
@@ -15,6 +16,7 @@ Usage (called by fileglancer, not directly):
         [sys.executable, "-m", "fileglancer.apps.worker"],
         input=json.dumps(request).encode(),
         capture_output=True,
+        env={**os.environ, "HOME": pw.pw_dir},
         user=uid, group=gid, extra_groups=groups,
     )
 """
@@ -145,11 +147,56 @@ async def _reconnect(request: dict) -> dict:
     return {"jobs": jobs}
 
 
+async def _ensure_repo(request: dict) -> dict:
+    """Clone or update a GitHub repo in the current user's cache."""
+    from fileglancer.apps.core import _ensure_repo_cache
+
+    repo_dir = await _ensure_repo_cache(
+        url=request["url"],
+        pull=request.get("pull", False),
+    )
+    return {"repo_dir": str(repo_dir)}
+
+
+async def _discover_manifests(request: dict) -> dict:
+    """Clone/pull repo and discover all manifests."""
+    from fileglancer.apps.core import _ensure_repo_cache, _find_manifests_in_repo
+
+    repo_dir = await _ensure_repo_cache(
+        url=request["url"],
+        pull=True,
+    )
+    results = _find_manifests_in_repo(repo_dir)
+    return {
+        "manifests": [
+            {"path": path, "manifest": manifest.model_dump(mode="json")}
+            for path, manifest in results
+        ]
+    }
+
+
+async def _read_manifest(request: dict) -> dict:
+    """Fetch and read a single manifest from a cached repo."""
+    from fileglancer.apps.core import _ensure_repo_cache, _read_manifest_file
+
+    repo_dir = await _ensure_repo_cache(
+        url=request["url"],
+        pull=request.get("pull", False),
+    )
+    manifest_path = request.get("manifest_path", "")
+    target_dir = repo_dir / manifest_path if manifest_path else repo_dir
+    manifest = _read_manifest_file(target_dir)
+    return {"manifest": manifest.model_dump(mode="json")}
+
+
 _ACTIONS = {
     "submit": _submit,
     "cancel": _cancel,
     "poll": _poll,
     "reconnect": _reconnect,
+    "ensure_repo": _ensure_repo,
+    "discover_manifests": _discover_manifests,
+    "read_manifest": _read_manifest,
 }
 
 

--- a/fileglancer/apps/worker.py
+++ b/fileglancer/apps/worker.py
@@ -101,12 +101,20 @@ async def _poll(request: dict) -> dict:
 
     # Seed the executor with stub JobRecords so poll() knows what to track.
     # poll() queries bjobs and updates these records in-place.
+    # Use each job's current DB status so that jobs not found in bjobs
+    # output keep their real status instead of reverting to PENDING.
+    known_statuses = request.get("job_statuses", {})
     for cid in request["cluster_job_ids"]:
+        db_status = known_statuses.get(cid, "PENDING").lower()
+        try:
+            seed_status = JobStatus(db_status)
+        except ValueError:
+            seed_status = JobStatus.PENDING
         executor._jobs[cid] = JobRecord(
             job_id=cid,
             name="",
             command="",
-            status=JobStatus.PENDING,
+            status=seed_status,
         )
 
     await executor.poll()

--- a/fileglancer/apps/worker.py
+++ b/fileglancer/apps/worker.py
@@ -209,8 +209,22 @@ _ACTIONS = {
 
 
 def main():
+    import pwd as _pwd
+
     request = json.loads(sys.stdin.buffer.read())
     action = request.get("action")
+
+    uid = os.getuid()
+    euid = os.geteuid()
+    try:
+        uname = _pwd.getpwuid(uid).pw_name
+    except KeyError:
+        uname = str(uid)
+    print(
+        f"[worker] action={action} uid={uid}({uname}) euid={euid} "
+        f"HOME={os.environ.get('HOME', '<unset>')}",
+        file=sys.stderr,
+    )
 
     handler = _ACTIONS.get(action)
     if handler is None:

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -274,6 +274,14 @@ def create_app(settings):
             os.environ["PATH"] = extra + os.pathsep + os.environ.get("PATH", "")
             logger.debug(f"  cluster.extra_paths prepended to PATH: {extra}")
 
+        # Set extra environment variables needed by scheduler commands
+        # (e.g., LSF_ENVDIR for bsub to find lsf.conf). Pixi strips
+        # inherited env vars, so they must be set inside the process.
+        if settings.cluster.extra_env:
+            for key, value in settings.cluster.extra_env.items():
+                os.environ[key] = value
+                logger.debug(f"  cluster.extra_env set: {key}={value}")
+
         # Initialize database (run migrations once at startup)
         db.initialize_database(settings.db_url)
 

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -1771,7 +1771,8 @@ def create_app(settings):
                        username: str = Depends(get_current_user)):
         with db.get_db_session(settings.db_url) as session:
             db_jobs = db.get_jobs_by_username(session, username, status)
-            jobs = [_convert_job(j) for j in db_jobs]
+            with _get_user_context(username):
+                jobs = [_convert_job(j) for j in db_jobs]
             return JobResponse(jobs=jobs)
 
     @app.get("/api/jobs/{job_id}", response_model=Job,
@@ -1782,7 +1783,8 @@ def create_app(settings):
             db_job = db.get_job(session, job_id, username)
             if db_job is None:
                 raise HTTPException(status_code=404, detail="Job not found")
-            return _convert_job(db_job, include_files=True)
+            with _get_user_context(username):
+                return _convert_job(db_job, include_files=True)
 
     @app.post("/api/jobs/{job_id}/cancel",
               description="Cancel a running job")
@@ -1790,7 +1792,8 @@ def create_app(settings):
                          username: str = Depends(get_current_user)):
         try:
             db_job = await apps_module.cancel_job(job_id, username)
-            return _convert_job(db_job)
+            with _get_user_context(username):
+                return _convert_job(db_job)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
@@ -1812,7 +1815,8 @@ def create_app(settings):
         if file_type not in ("script", "stdout", "stderr"):
             raise HTTPException(status_code=400, detail="file_type must be script, stdout, or stderr")
         try:
-            content = await apps_module.get_job_file_content(job_id, username, file_type)
+            with _get_user_context(username):
+                content = await apps_module.get_job_file_content(job_id, username, file_type)
             if content is None:
                 raise HTTPException(status_code=404, detail=f"File not found: {file_type}")
             return PlainTextResponse(content)

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -1687,22 +1687,22 @@ def create_app(settings):
             if body.resources:
                 resources_dict = body.resources.model_dump(exclude_none=True)
 
-            with _get_user_context(username):
-                db_job = await apps_module.submit_job(
-                    username=username,
-                    app_url=body.app_url,
-                    entry_point_id=body.entry_point_id,
-                    parameters=body.parameters,
-                    resources=resources_dict,
-                    extra_args=body.extra_args,
-                    pull_latest=body.pull_latest,
-                    manifest_path=body.manifest_path,
-                    env=body.env,
-                    pre_run=body.pre_run,
-                    post_run=body.post_run,
-                    container=body.container,
-                    container_args=body.container_args,
-                )
+            db_job = await apps_module.submit_job(
+                username=username,
+                app_url=body.app_url,
+                entry_point_id=body.entry_point_id,
+                parameters=body.parameters,
+                resources=resources_dict,
+                extra_args=body.extra_args,
+                pull_latest=body.pull_latest,
+                manifest_path=body.manifest_path,
+                env=body.env,
+                pre_run=body.pre_run,
+                post_run=body.post_run,
+                container=body.container,
+                container_args=body.container_args,
+                user_context=_get_user_context(username),
+            )
             return _convert_job(db_job)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -1538,7 +1538,9 @@ def create_app(settings):
                              username: str = Depends(get_current_user)):
         try:
             logger.info(f"Fetching manifest for URL: '{body.url}' path: '{body.manifest_path}'")
-            manifest = await apps_module.fetch_app_manifest(body.url, body.manifest_path)
+            with _get_user_context(username):
+                manifest = await apps_module.fetch_app_manifest(body.url, body.manifest_path,
+                                                                    username=username)
             return manifest
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
@@ -1564,9 +1566,11 @@ def create_app(settings):
             )
             # Try to fetch manifest from local clone
             try:
-                user_app.manifest = await apps_module.fetch_app_manifest(
-                    app_entry["url"], app_entry.get("manifest_path", "")
-                )
+                with _get_user_context(username):
+                    user_app.manifest = await apps_module.fetch_app_manifest(
+                        app_entry["url"], app_entry.get("manifest_path", ""),
+                        username=username,
+                    )
                 # Update name/description from manifest
                 user_app.name = user_app.manifest.name
                 user_app.description = user_app.manifest.description
@@ -1582,7 +1586,9 @@ def create_app(settings):
                            username: str = Depends(get_current_user)):
         # Clone the repo and discover all manifests
         try:
-            discovered = await apps_module.discover_app_manifests(body.url)
+            with _get_user_context(username):
+                discovered = await apps_module.discover_app_manifests(body.url,
+                                                                       username=username)
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
@@ -1666,12 +1672,15 @@ def create_app(settings):
     async def update_user_app(body: ManifestFetchRequest,
                               username: str = Depends(get_current_user)):
         try:
-            await apps_module._ensure_repo_cache(body.url, pull=True)
+            with _get_user_context(username):
+                await apps_module._ensure_repo_cache(body.url, pull=True, username=username)
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Failed to pull latest code: {str(e)}")
 
         try:
-            manifest = await apps_module.fetch_app_manifest(body.url, body.manifest_path)
+            with _get_user_context(username):
+                manifest = await apps_module.fetch_app_manifest(body.url, body.manifest_path,
+                                                                username=username)
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -1524,9 +1524,8 @@ def create_app(settings):
                              username: str = Depends(get_current_user)):
         try:
             logger.info(f"Fetching manifest for URL: '{body.url}' path: '{body.manifest_path}'")
-            with _get_user_context(username):
-                manifest = await apps_module.fetch_app_manifest(body.url, body.manifest_path,
-                                                                    username=username)
+            manifest = await apps_module.fetch_app_manifest(body.url, body.manifest_path,
+                                                                username=username)
             return manifest
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
@@ -1552,11 +1551,10 @@ def create_app(settings):
             )
             # Try to fetch manifest from local clone
             try:
-                with _get_user_context(username):
-                    user_app.manifest = await apps_module.fetch_app_manifest(
-                        app_entry["url"], app_entry.get("manifest_path", ""),
-                        username=username,
-                    )
+                user_app.manifest = await apps_module.fetch_app_manifest(
+                    app_entry["url"], app_entry.get("manifest_path", ""),
+                    username=username,
+                )
                 # Update name/description from manifest
                 user_app.name = user_app.manifest.name
                 user_app.description = user_app.manifest.description
@@ -1572,9 +1570,8 @@ def create_app(settings):
                            username: str = Depends(get_current_user)):
         # Clone the repo and discover all manifests
         try:
-            with _get_user_context(username):
-                discovered = await apps_module.discover_app_manifests(body.url,
-                                                                       username=username)
+            discovered = await apps_module.discover_app_manifests(body.url,
+                                                                   username=username)
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
@@ -1658,15 +1655,13 @@ def create_app(settings):
     async def update_user_app(body: ManifestFetchRequest,
                               username: str = Depends(get_current_user)):
         try:
-            with _get_user_context(username):
-                await apps_module._ensure_repo_cache(body.url, pull=True, username=username)
+            await apps_module._ensure_repo_cache(body.url, pull=True, username=username)
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Failed to pull latest code: {str(e)}")
 
         try:
-            with _get_user_context(username):
-                manifest = await apps_module.fetch_app_manifest(body.url, body.manifest_path,
-                                                                username=username)
+            manifest = await apps_module.fetch_app_manifest(body.url, body.manifest_path,
+                                                            username=username)
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
         except Exception as e:
@@ -1742,7 +1737,6 @@ def create_app(settings):
                 post_run=body.post_run,
                 container=body.container,
                 container_args=body.container_args,
-                user_context=_get_user_context(username),
             )
             return _convert_job(db_job)
         except ValueError as e:

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -266,21 +266,19 @@ def create_app(settings):
         logger.debug(f"  external_proxy_url: {settings.external_proxy_url}")
         logger.debug(f"  atlassian_url: {settings.atlassian_url}")
 
-        # Prepend cluster extra_paths to PATH so scheduler commands
-        # (bsub, bjobs, bkill) are findable without relying on the
-        # system service's default PATH.
-        if settings.cluster.extra_paths:
-            extra = os.pathsep.join(settings.cluster.extra_paths)
+        # Prepend extra_paths to PATH so commands (e.g. bsub, bjobs,
+        # bkill) are findable without relying on the system service's
+        # default PATH.
+        if settings.extra_paths:
+            extra = os.pathsep.join(settings.extra_paths)
             os.environ["PATH"] = extra + os.pathsep + os.environ.get("PATH", "")
-            logger.debug(f"  cluster.extra_paths prepended to PATH: {extra}")
+            logger.debug(f"extra_paths prepended to PATH: {extra}")
 
-        # Set extra environment variables needed by scheduler commands
-        # (e.g., LSF_ENVDIR for bsub to find lsf.conf). Pixi strips
-        # inherited env vars, so they must be set inside the process.
-        if settings.cluster.extra_env:
-            for key, value in settings.cluster.extra_env.items():
+        # Set extra environment variables at startup.
+        if settings.extra_env:
+            for key, value in settings.extra_env.items():
                 os.environ[key] = value
-                logger.debug(f"  cluster.extra_env set: {key}={value}")
+                logger.debug(f"extra_env set: {key}={value}")
 
         # Initialize database (run migrations once at startup)
         db.initialize_database(settings.db_url)

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -271,7 +271,7 @@ def create_app(settings):
         # in a bash subshell and captures the resulting environment,
         # applying any new/changed vars to this process. Pixi strips
         # inherited env vars, so they must be set inside the process.
-        # Runs before extra_paths/extra_env so those can override.
+        #
         if settings.env_source_script:
             import subprocess as _sp
             script = settings.env_source_script
@@ -297,20 +297,6 @@ def create_app(settings):
                     )
             except Exception as e:
                 logger.warning(f"env_source_script error: {e}")
-
-        # Prepend extra_paths to PATH so commands (e.g. bsub, bjobs,
-        # bkill) are findable without relying on the system service's
-        # default PATH.
-        if settings.extra_paths:
-            extra = os.pathsep.join(settings.extra_paths)
-            os.environ["PATH"] = extra + os.pathsep + os.environ.get("PATH", "")
-            logger.debug(f"extra_paths prepended to PATH: {extra}")
-
-        # Set extra environment variables at startup.
-        if settings.extra_env:
-            for key, value in settings.extra_env.items():
-                os.environ[key] = value
-                logger.debug(f"extra_env set: {key}={value}")
 
         # Initialize database (run migrations once at startup)
         db.initialize_database(settings.db_url)

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -266,6 +266,38 @@ def create_app(settings):
         logger.debug(f"  external_proxy_url: {settings.external_proxy_url}")
         logger.debug(f"  atlassian_url: {settings.atlassian_url}")
 
+        # Source a shell script to import environment variables
+        # (e.g., /misc/lsf/conf/profile.lsf). This runs the script
+        # in a bash subshell and captures the resulting environment,
+        # applying any new/changed vars to this process. Pixi strips
+        # inherited env vars, so they must be set inside the process.
+        # Runs before extra_paths/extra_env so those can override.
+        if settings.env_source_script:
+            import subprocess as _sp
+            script = settings.env_source_script
+            try:
+                result = _sp.run(
+                    ["bash", "-c", f". {script} && env -0"],
+                    capture_output=True, text=True, timeout=10,
+                )
+                if result.returncode == 0:
+                    sourced_env = dict(
+                        line.split("=", 1)
+                        for line in result.stdout.split("\0")
+                        if "=" in line
+                    )
+                    for key, value in sourced_env.items():
+                        if os.environ.get(key) != value:
+                            os.environ[key] = value
+                            logger.debug(f"  env_source_script set: {key}={value}")
+                else:
+                    logger.warning(
+                        f"env_source_script failed (rc={result.returncode}): "
+                        f"{result.stderr.strip()}"
+                    )
+            except Exception as e:
+                logger.warning(f"env_source_script error: {e}")
+
         # Prepend extra_paths to PATH so commands (e.g. bsub, bjobs,
         # bkill) are findable without relying on the system service's
         # default PATH.

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -266,6 +266,14 @@ def create_app(settings):
         logger.debug(f"  external_proxy_url: {settings.external_proxy_url}")
         logger.debug(f"  atlassian_url: {settings.atlassian_url}")
 
+        # Prepend cluster extra_paths to PATH so scheduler commands
+        # (bsub, bjobs, bkill) are findable without relying on the
+        # system service's default PATH.
+        if settings.cluster.extra_paths:
+            extra = os.pathsep.join(settings.cluster.extra_paths)
+            os.environ["PATH"] = extra + os.pathsep + os.environ.get("PATH", "")
+            logger.debug(f"  cluster.extra_paths prepended to PATH: {extra}")
+
         # Initialize database (run migrations once at startup)
         db.initialize_database(settings.db_url)
 

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -1700,11 +1700,12 @@ def create_app(settings):
     async def validate_paths(body: PathValidationRequest,
                              username: str = Depends(get_current_user)):
         errors = {}
-        with db.get_db_session(settings.db_url) as session:
-            for param_key, path_value in body.paths.items():
-                error = apps_module.validate_path_in_filestore(path_value, session)
-                if error:
-                    errors[param_key] = error
+        with _get_user_context(username):
+            with db.get_db_session(settings.db_url) as session:
+                for param_key, path_value in body.paths.items():
+                    error = apps_module.validate_path_in_filestore(path_value, session)
+                    if error:
+                        errors[param_key] = error
         return PathValidationResponse(errors=errors)
 
     @app.get("/api/cluster-defaults",
@@ -1738,7 +1739,8 @@ def create_app(settings):
                 container=body.container,
                 container_args=body.container_args,
             )
-            return _convert_job(db_job)
+            with _get_user_context(username):
+                return _convert_job(db_job)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
         except Exception as e:

--- a/fileglancer/settings.py
+++ b/fileglancer/settings.py
@@ -14,8 +14,6 @@ from pydantic_settings import (
 class ClusterSettings(BaseModel):
     """Cluster configuration matching py-cluster-api's ClusterConfig."""
     executor: str = 'local'
-    extra_paths: List[str] = []
-    extra_env: Dict[str, str] = {}
     cpus: Optional[int] = None
     gpus: Optional[int] = None
     memory: Optional[str] = None
@@ -96,6 +94,12 @@ class Settings(BaseSettings):
 
     # CLI mode - enables auto-login endpoint for standalone CLI usage
     cli_mode: bool = False
+    # Directories prepended to the server's PATH at startup.
+    extra_paths: List[str] = []
+
+    # Extra environment variables set at startup.
+    extra_env: Dict[str, str] = {}
+
     # Cluster / Apps settings (mirrors py-cluster-api ClusterConfig)
     cluster: ClusterSettings = ClusterSettings()
 

--- a/fileglancer/settings.py
+++ b/fileglancer/settings.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import List, Optional
 from functools import cache
 import sys
 
@@ -98,12 +98,6 @@ class Settings(BaseSettings):
     # Shell script sourced at startup to import environment variables.
     # Useful for setting up scheduler env (e.g., /misc/lsf/conf/profile.lsf).
     env_source_script: Optional[str] = None
-
-    # Directories prepended to the server's PATH at startup.
-    extra_paths: List[str] = []
-
-    # Extra environment variables set at startup.
-    extra_env: Dict[str, str] = {}
 
     # Cluster / Apps settings (mirrors py-cluster-api ClusterConfig)
     cluster: ClusterSettings = ClusterSettings()

--- a/fileglancer/settings.py
+++ b/fileglancer/settings.py
@@ -14,6 +14,7 @@ from pydantic_settings import (
 class ClusterSettings(BaseModel):
     """Cluster configuration matching py-cluster-api's ClusterConfig."""
     executor: str = 'local'
+    extra_paths: List[str] = []
     cpus: Optional[int] = None
     gpus: Optional[int] = None
     memory: Optional[str] = None

--- a/fileglancer/settings.py
+++ b/fileglancer/settings.py
@@ -32,6 +32,7 @@ class ClusterSettings(BaseModel):
     completed_retention_minutes: float = 10.0
     command_timeout: float = 100.0
     suppress_job_email: bool = True
+    poll_all_users: bool = False
 
 
 class AppsSettings(BaseModel):

--- a/fileglancer/settings.py
+++ b/fileglancer/settings.py
@@ -94,6 +94,11 @@ class Settings(BaseSettings):
 
     # CLI mode - enables auto-login endpoint for standalone CLI usage
     cli_mode: bool = False
+
+    # Shell script sourced at startup to import environment variables.
+    # Useful for setting up scheduler env (e.g., /misc/lsf/conf/profile.lsf).
+    env_source_script: Optional[str] = None
+
     # Directories prepended to the server's PATH at startup.
     extra_paths: List[str] = []
 

--- a/fileglancer/settings.py
+++ b/fileglancer/settings.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 from functools import cache
 import sys
 
@@ -15,6 +15,7 @@ class ClusterSettings(BaseModel):
     """Cluster configuration matching py-cluster-api's ClusterConfig."""
     executor: str = 'local'
     extra_paths: List[str] = []
+    extra_env: Dict[str, str] = {}
     cpus: Optional[int] = None
     gpus: Optional[int] = None
     memory: Optional[str] = None

--- a/fileglancer/user_context.py
+++ b/fileglancer/user_context.py
@@ -43,7 +43,10 @@ class EffectiveUserContext(UserContext):
         self._user = None
 
     def __enter__(self):
-        logger.trace(f"Entering user context for {self.username}")
+        logger.debug(
+            f"EffectiveUserContext entering for {self.username} "
+            f"(current euid={os.geteuid()} egid={os.getegid()})"
+        )
         user = pwd.getpwnam(self.username)
 
         uid = user.pw_uid
@@ -106,11 +109,18 @@ class EffectiveUserContext(UserContext):
             raise e
 
         self._user = user
+        logger.debug(
+            f"EffectiveUserContext now running as {self.username} "
+            f"(euid={os.geteuid()} egid={os.getegid()})"
+        )
 
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        logger.trace(f"Exiting user context for {self.username}")
+        logger.debug(
+            f"EffectiveUserContext exiting for {self.username} "
+            f"(restoring euid={self._uid} egid={self._gid})"
+        )
         os.seteuid(self._uid)
         os.setegid(self._gid)
         if len(self._gids) > os.sysconf("SC_NGROUPS_MAX"):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a10",
+    "version": "2.7.0-a11",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a10",
+            "version": "2.7.0-a11",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a16",
+    "version": "2.7.0-a17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a16",
+            "version": "2.7.0-a17",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a14",
+    "version": "2.7.0-a15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a14",
+            "version": "2.7.0-a15",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a13",
+    "version": "2.7.0-a14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a13",
+            "version": "2.7.0-a14",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a15",
+    "version": "2.7.0-a16",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a15",
+            "version": "2.7.0-a16",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a4",
+    "version": "2.7.0-a6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a4",
+            "version": "2.7.0-a6",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a6",
+    "version": "2.7.0-a7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a6",
+            "version": "2.7.0-a7",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a9",
+    "version": "2.7.0-a10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a9",
+            "version": "2.7.0-a10",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a7",
+    "version": "2.7.0-a8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a7",
+            "version": "2.7.0-a8",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a11",
+    "version": "2.7.0-a12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a11",
+            "version": "2.7.0-a12",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a12",
+    "version": "2.7.0-a13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a12",
+            "version": "2.7.0-a13",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0-a8",
+    "version": "2.7.0-a9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0-a8",
+            "version": "2.7.0-a9",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a11",
+    "version": "2.7.0-a12",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a16",
+    "version": "2.7.0-a17",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a7",
+    "version": "2.7.0-a8",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a6",
+    "version": "2.7.0-a7",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a9",
+    "version": "2.7.0-a10",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a4",
+    "version": "2.7.0-a6",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a13",
+    "version": "2.7.0-a14",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a15",
+    "version": "2.7.0-a16",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a12",
+    "version": "2.7.0-a13",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a8",
+    "version": "2.7.0-a9",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a10",
+    "version": "2.7.0-a11",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0-a14",
+    "version": "2.7.0-a15",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/src/components/AppLaunch.tsx
+++ b/frontend/src/components/AppLaunch.tsx
@@ -104,7 +104,7 @@ export default function AppLaunch() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [manifest]);
 
-  const handleSubmit = async (
+  const handleSubmit = (
     parameters: Record<string, unknown>,
     resources?: AppResourceDefaults,
     extraArgs?: string,
@@ -118,8 +118,9 @@ export default function AppLaunch() {
     if (!selectedEntryPoint) {
       return;
     }
-    try {
-      await submitJobMutation.mutateAsync({
+    submitJobMutation.reset();
+    submitJobMutation.mutate(
+      {
         app_url: appUrl,
         manifest_path: manifestPath,
         entry_point_id: selectedEntryPoint.id,
@@ -132,14 +133,14 @@ export default function AppLaunch() {
         post_run: postRun,
         container,
         container_args: containerArgs
-      });
-      toast.success('Job submitted');
-      navigate('/apps/jobs');
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Failed to submit job';
-      toast.error(message);
-    }
+      },
+      {
+        onSuccess: () => {
+          toast.success('Job submitted');
+          navigate('/apps/jobs');
+        }
+      }
+    );
   };
 
   const handleInstall = async () => {
@@ -227,6 +228,7 @@ export default function AppLaunch() {
           initialValues={relaunchParameters}
           manifest={manifest}
           onSubmit={handleSubmit}
+          submitError={submitJobMutation.error?.message}
           submitting={submitJobMutation.isPending}
         />
       ) : manifest ? (

--- a/frontend/src/components/ui/AppsPage/AppLaunchForm.tsx
+++ b/frontend/src/components/ui/AppsPage/AppLaunchForm.tsx
@@ -37,8 +37,9 @@ interface AppLaunchFormProps {
     postRun?: string,
     container?: string,
     containerArgs?: string
-  ) => Promise<void>;
+  ) => void;
   readonly submitting: boolean;
+  readonly submitError?: string;
   readonly initialValues?: Record<string, unknown>;
   readonly initialResources?: AppResourceDefaults;
   readonly initialExtraArgs?: string;
@@ -661,6 +662,7 @@ export default function AppLaunchForm({
   entryPoint,
   onSubmit,
   submitting,
+  submitError,
   initialValues: externalValues,
   initialResources,
   initialExtraArgs: externalExtraArgs,
@@ -934,7 +936,7 @@ export default function AppLaunchForm({
     }
     const hasEnv = Object.keys(envRecord).length > 0;
 
-    await onSubmit(
+    onSubmit(
       params,
       hasResourceOverrides ? resources : undefined,
       extraArgs.trim() || undefined,
@@ -1220,6 +1222,13 @@ export default function AppLaunchForm({
       {Object.keys(errors).length > 0 ? (
         <div className="mt-6 mb-4 p-3 bg-error/10 rounded text-error text-sm">
           Please fix the errors above before submitting.
+        </div>
+      ) : null}
+
+      {/* Submission error */}
+      {submitError ? (
+        <div className="mt-6 mb-4 p-3 bg-error/10 rounded text-error text-sm">
+          {submitError}
         </div>
       ) : null}
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -170,7 +170,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/4b/5079831d1b4f37caa13a994f50a9f9d943eef44ea04aa2a2f53d49abbd32/x2s3-1.1.1-py3-none-any.whl
@@ -335,7 +335,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/4b/5079831d1b4f37caa13a994f50a9f9d943eef44ea04aa2a2f53d49abbd32/x2s3-1.1.1-py3-none-any.whl
@@ -497,7 +497,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/9b/03b04e7d82a5f54fb16113d839f5ea1ede58a61e90edf515f6577c66fa8f/propcache-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/4b/5079831d1b4f37caa13a994f50a9f9d943eef44ea04aa2a2f53d49abbd32/x2s3-1.1.1-py3-none-any.whl
@@ -659,7 +659,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/4b/5079831d1b4f37caa13a994f50a9f9d943eef44ea04aa2a2f53d49abbd32/x2s3-1.1.1-py3-none-any.whl
@@ -878,7 +878,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/4b/5079831d1b4f37caa13a994f50a9f9d943eef44ea04aa2a2f53d49abbd32/x2s3-1.1.1-py3-none-any.whl
@@ -1086,7 +1086,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/4b/5079831d1b4f37caa13a994f50a9f9d943eef44ea04aa2a2f53d49abbd32/x2s3-1.1.1-py3-none-any.whl
@@ -1286,7 +1286,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/9b/03b04e7d82a5f54fb16113d839f5ea1ede58a61e90edf515f6577c66fa8f/propcache-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/4b/5079831d1b4f37caa13a994f50a9f9d943eef44ea04aa2a2f53d49abbd32/x2s3-1.1.1-py3-none-any.whl
@@ -1486,7 +1486,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/4b/5079831d1b4f37caa13a994f50a9f9d943eef44ea04aa2a2f53d49abbd32/x2s3-1.1.1-py3-none-any.whl
@@ -1740,7 +1740,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl
@@ -1986,7 +1986,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl
@@ -2232,7 +2232,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/65/9b/03b04e7d82a5f54fb16113d839f5ea1ede58a61e90edf515f6577c66fa8f/propcache-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl
@@ -2478,7 +2478,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl
@@ -2736,7 +2736,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/46/4b/3aae6835b8e5f44ea6a68348ad90f78134047b503765087be2f9912140ea/propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl
@@ -2986,7 +2986,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/9e/d3/6c7ee328b39a81ee877c962469f1e795f9db87f925251efeb0545e0020d0/propcache-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl
@@ -3232,7 +3232,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/76/47/8ccf75935f51448ba9a16a71b783eb7ef6b9ee60f5d14c7f8a8a79fbeed7/propcache-0.4.1-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl
@@ -3478,7 +3478,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0a/b6/5c9a0e42df4d00bfb4a3cbbe5cf9f54260300c88a0e9af1f47ca5ce17ac0/propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl
@@ -5340,8 +5340,8 @@ packages:
   timestamp: 1760972937564
 - pypi: ./
   name: fileglancer
-  version: 2.6.0
-  sha256: 89ade90344f06c7ac1f650cd3a3dd73f5b04b80bd4fc710845f52f853e09b165
+  version: 2.7.0a13
+  sha256: 7518f993abbc4253cb1b37407b7368c799e58f2fb6dd4cae2927a8025dc1a8a6
   requires_dist:
   - alembic>=1.17.0
   - atlassian-python-api>=4.0.7
@@ -5355,7 +5355,7 @@ packages:
   - loguru>=0.7.3
   - pandas>=2.3.3
   - psycopg2>=2.9.10,<3
-  - py-cluster-api>=0.3.0
+  - py-cluster-api>=0.4.0
   - pydantic-settings>=2.11.0
   - pydantic>=2.10.6
   - python-jose>=3.5.0,<4
@@ -9851,10 +9851,10 @@ packages:
   - pkg:pypi/pure-eval?source=hash-mapping
   size: 16668
   timestamp: 1733569518868
-- pypi: https://files.pythonhosted.org/packages/69/88/4d20dbaf2af1bb2bfdc774b1b32b80d52cc459acad44abb900d2139ba4ef/py_cluster_api-0.3.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/7a/66/efd63582a7e5be53f7c6a6154e46507e24bc6cc99ef5066fd710f0298f8c/py_cluster_api-0.4.0-py3-none-any.whl
   name: py-cluster-api
-  version: 0.3.0
-  sha256: c2501e95310a1115e155229bc93495ab01750e65879bf0e339489aec5f0bcf31
+  version: 0.4.0
+  sha256: c8e8cee915247b80e047708e649a70836d690e3f4a44aeae80809bcf187de0aa
   requires_dist:
   - pyyaml
   - build ; extra == 'release'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "sqlalchemy >=2.0.44",
     "uvicorn >=0.38.0",
     "x2s3 >=1.1.1",
-    "py-cluster-api >=0.3.0"
+    "py-cluster-api >=0.4.0"
 ]
 
 [project.scripts]

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -3,6 +3,7 @@
 import asyncio
 import fcntl
 import multiprocessing
+import time
 from datetime import datetime, UTC
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, call
@@ -148,6 +149,9 @@ def _try_poll_with_lock(counter, sync_barrier):
             try:
                 with counter.get_lock():
                     counter.value += 1
+                # Hold lock long enough for the other process to attempt
+                # acquisition and fail with LOCK_NB
+                time.sleep(0.5)
             finally:
                 fcntl.flock(f, fcntl.LOCK_UN)
     except OSError:

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,0 +1,243 @@
+"""Tests for the job poll loop: file-lock election and status-update logic."""
+
+import asyncio
+import fcntl
+import multiprocessing
+from datetime import datetime, UTC
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock, call
+
+from fileglancer.apps.core import _poll_jobs, _POLL_LOCK_PATH
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_settings(**overrides):
+    """Return a minimal Settings-like object for poll tests."""
+    cluster = SimpleNamespace(
+        poll_interval=0.05,
+        zombie_timeout_minutes=30.0,
+        **{k: v for k, v in {
+            "executor": "local",
+        }.items()},
+    )
+    cluster.model_dump = lambda exclude_none=False: {"executor": "local"}
+    settings = SimpleNamespace(
+        cluster=cluster,
+        db_url="sqlite:///unused",
+    )
+    return settings
+
+
+def _make_db_job(job_id, cluster_job_id, status, username="alice",
+                 created_at=None):
+    """Return a mock DB job row."""
+    job = SimpleNamespace(
+        id=job_id,
+        cluster_job_id=cluster_job_id,
+        status=status,
+        username=username,
+        created_at=created_at or datetime.now(UTC),
+    )
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Test: poll skips same-status (no spurious DB writes)
+# ---------------------------------------------------------------------------
+
+class TestPollSkipsSameStatus:
+    """When the worker returns the same status already in the DB,
+    _poll_jobs must NOT call update_job_status.  This was the bug that
+    caused 'RUNNING -> RUNNING' log spam with multiple workers."""
+
+    @patch("fileglancer.apps.core._run_as_user")
+    @patch("fileglancer.apps.core.db")
+    def test_same_status_not_written(self, mock_db, mock_run):
+        settings = _make_settings()
+
+        job = _make_db_job(1, "1001", "RUNNING")
+        mock_session = MagicMock()
+        mock_db.get_db_session.return_value.__enter__ = lambda _: mock_session
+        mock_db.get_db_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_db.get_active_jobs.return_value = [job]
+
+        # Worker returns RUNNING (lowercase from cluster_api) — same as DB
+        mock_run.return_value = {
+            "jobs": {
+                "1001": {
+                    "status": "running",
+                    "exit_code": None,
+                    "exec_host": None,
+                    "start_time": None,
+                    "finish_time": None,
+                },
+            },
+        }
+
+        _poll_jobs(settings)
+
+        mock_db.update_job_status.assert_not_called()
+
+    @patch("fileglancer.apps.core._run_as_user")
+    @patch("fileglancer.apps.core.db")
+    def test_changed_status_is_written(self, mock_db, mock_run):
+        settings = _make_settings()
+
+        job = _make_db_job(1, "1001", "RUNNING")
+        mock_session = MagicMock()
+        mock_db.get_db_session.return_value.__enter__ = lambda _: mock_session
+        mock_db.get_db_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_db.get_active_jobs.return_value = [job]
+
+        # Worker returns DONE — different from DB's RUNNING
+        mock_run.return_value = {
+            "jobs": {
+                "1001": {
+                    "status": "done",
+                    "exit_code": 0,
+                    "exec_host": "node01",
+                    "start_time": "2026-03-26T10:00:00",
+                    "finish_time": "2026-03-26T10:05:00",
+                },
+            },
+        }
+
+        _poll_jobs(settings)
+
+        mock_db.update_job_status.assert_called_once()
+        args, kwargs = mock_db.update_job_status.call_args
+        assert args == (mock_session, 1, "DONE")
+
+    @patch("fileglancer.apps.core._run_as_user")
+    @patch("fileglancer.apps.core.db")
+    def test_job_statuses_passed_to_worker(self, mock_db, mock_run):
+        """The poll request must include job_statuses so the worker seeds
+        stubs with the correct status instead of defaulting to PENDING."""
+        settings = _make_settings()
+
+        jobs = [
+            _make_db_job(1, "1001", "RUNNING"),
+            _make_db_job(2, "1002", "PENDING"),
+        ]
+        mock_session = MagicMock()
+        mock_db.get_db_session.return_value.__enter__ = lambda _: mock_session
+        mock_db.get_db_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_db.get_active_jobs.return_value = jobs
+
+        mock_run.return_value = {"jobs": {}}
+
+        _poll_jobs(settings)
+
+        request = mock_run.call_args[0][1]
+        assert request["job_statuses"] == {"1001": "RUNNING", "1002": "PENDING"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers for multiprocessing lock test (must be module-level for pickling)
+# ---------------------------------------------------------------------------
+
+def _try_poll_with_lock(counter, sync_barrier):
+    """Attempt to acquire the poll lock and increment a shared counter."""
+    sync_barrier.wait()
+    try:
+        with open(_POLL_LOCK_PATH, "w") as f:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                with counter.get_lock():
+                    counter.value += 1
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Test: file lock ensures only one poll per cycle
+# ---------------------------------------------------------------------------
+
+class TestPollLockElection:
+    """Only one concurrent caller should execute _poll_jobs per cycle.
+    Uses the real file lock to test actual OS-level mutual exclusion."""
+
+    def test_only_one_caller_polls(self, tmp_path):
+        """Hold the lock externally, then run _poll_loop for one iteration.
+        The loop should skip polling because it can't acquire the lock."""
+        settings = _make_settings()
+        poll_called = False
+
+        def fake_poll_jobs(s):
+            nonlocal poll_called
+            poll_called = True
+
+        # Hold the lock from this thread
+        lock_file = open(_POLL_LOCK_PATH, "w")
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        try:
+            # Run one iteration of the poll loop with a short sleep
+            # The loop should fail to acquire the lock and skip
+            async def run_one_iteration():
+                with patch("fileglancer.apps.core._poll_jobs", fake_poll_jobs):
+                    # Run the poll loop body once (not the infinite loop)
+                    try:
+                        with open(_POLL_LOCK_PATH, "w") as f:
+                            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                            try:
+                                fake_poll_jobs(settings)
+                            finally:
+                                fcntl.flock(f, fcntl.LOCK_UN)
+                    except OSError:
+                        pass  # Lock held — should skip
+
+            asyncio.run(run_one_iteration())
+            assert not poll_called, "_poll_jobs should not run when lock is held"
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+            lock_file.close()
+
+    def test_poll_runs_when_lock_available(self):
+        """When no one holds the lock, _poll_jobs should execute."""
+        settings = _make_settings()
+        poll_called = False
+
+        def fake_poll_jobs(s):
+            nonlocal poll_called
+            poll_called = True
+
+        # Ensure lock file is not held
+        async def run_one_iteration():
+            try:
+                with open(_POLL_LOCK_PATH, "w") as f:
+                    fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    try:
+                        fake_poll_jobs(settings)
+                    finally:
+                        fcntl.flock(f, fcntl.LOCK_UN)
+            except OSError:
+                pass
+
+        asyncio.run(run_one_iteration())
+        assert poll_called, "_poll_jobs should run when lock is available"
+
+    def test_concurrent_processes_only_one_wins(self):
+        """Simulate two worker processes racing for the lock — only one should poll.
+
+        fcntl.flock is per-process (not per-thread), so we must use
+        multiprocessing to test real mutual exclusion — matching how
+        uvicorn workers are separate OS processes.
+        """
+        ctx = multiprocessing.get_context("fork")
+        won_count = ctx.Value("i", 0)
+        barrier = ctx.Barrier(2, timeout=5)
+
+        p1 = ctx.Process(target=_try_poll_with_lock, args=(won_count, barrier))
+        p2 = ctx.Process(target=_try_poll_with_lock, args=(won_count, barrier))
+        p1.start()
+        p2.start()
+        p1.join(timeout=5)
+        p2.join(timeout=5)
+
+        assert won_count.value == 1, f"Expected 1 poll winner, got {won_count.value}"


### PR DESCRIPTION
This PR troubleshoots submitting jobs to the Janelia cluster when running the Fileglancer server as root.

**Changes so far:**
1. [Work directory fix](https://github.com/JaneliaSciComp/fileglancer/commit/543d9cb7fd17b28a61e93bb138b1cada2ec8fd1e) - Resolved ~ to the actual user's home (~username), not root's home.
2. [seteuid job submission](https://github.com/JaneliaSciComp/fileglancer/commit/3a016beaeefa7aac0d648872d26e56850611b0ea) - Wrapped work dir creation, symlink, and executor.submit() in the EffectiveUserContext so filesystem operations happen as the user.
3. [Stale symlink fix](https://github.com/JaneliaSciComp/fileglancer/commit/95742f461e1b9caf36bb24405c2729de96f629a5) - Unlink existing repo symlink before creating a new one (caused an issue when a job failed - the symlink wasn't removed).
4. [bsub -U username flag](https://github.com/JaneliaSciComp/fileglancer/commit/99fda28323be5d6b59e25e9945e3bd996168f740) — Because bsub uses getuid() (real UID = root) not geteuid(), we pass -U username to tell LSF to run the job as the actual user. Note: unsure whether this is actually needed after adding the missing FGC_CLUSTER__EXECUTOR=lsf to the fileglancer-hub .env file — should test removing it once everything else is fixed
5. [cluster.extra_paths config option](https://github.com/JaneliaSciComp/fileglancer/commit/95b301ff269e68823639bda63cf1116d8378f95b) — Prepends directories to os.environ["PATH"] at server startup so bsub/bjobs/bkill are findable. Needed because systemd services have minimal PATH. Documented in config.yaml.template.

**Where we are now** (as of release 2.7.0a7, commit eff3c098a1ed08614fedaa4a74ba68cd0333c273)
- bsub is found on PATH (no more FileNotFoundError), but it fails because LSF can't find its configuration

@krokicki 
