### PR TITLE
feat: add download button to FileViewer header

### DIFF
--- a/frontend/src/components/ui/BrowsePage/FileViewer.tsx
+++ b/frontend/src/components/ui/BrowsePage/FileViewer.tsx
@@ -5,10 +5,11 @@ import {
   materialDark,
   coy
 } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { HiOutlineDownload } from 'react-icons/hi';
 import { Formatter } from 'fracturedjsonjs';
 
 import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
-import { formatFileSize, formatUnixTimestamp } from '@/utils';
+import { formatFileSize, formatUnixTimestamp, getFileURL } from '@/utils';
 import type { FileOrFolder } from '@/shared.types';
 import {
   useFileContentQuery,
@@ -199,6 +200,8 @@ export default function FileViewer({ file }: FileViewerProps) {
   const showJsonToggle =
     isJsonFile && metadataQuery.isSuccess && !metadataQuery.data.isBinary;
 
+  const downloadUrl = fspName ? getFileURL(fspName, file.path) : null;
+
   return (
     <div className="flex flex-col h-full w-full overflow-hidden">
       {/* File info header */}
@@ -212,17 +215,24 @@ export default function FileViewer({ file }: FileViewerProps) {
             {formatUnixTimestamp(file.last_modified)}
           </Typography>
         </div>
-        {showJsonToggle ? (
-          <div className="flex items-center gap-2 shrink-0">
-            <Typography className="text-foreground text-sm whitespace-nowrap">
-              Format JSON
-            </Typography>
-            <Switch
-              checked={formatJson}
-              onChange={() => setFormatJson(!formatJson)}
-            />
-          </div>
-        ) : null}
+        <div className="flex items-center gap-3 shrink-0">
+          {showJsonToggle ? (
+            <div className="flex items-center gap-2">
+              <Typography className="text-foreground text-sm whitespace-nowrap">
+                Format JSON
+              </Typography>
+              <Switch
+                checked={formatJson}
+                onChange={() => setFormatJson(!formatJson)}
+              />
+            </div>
+          ) : null}
+          {downloadUrl ? (
+            <a download={file.name} href={downloadUrl} title="Download file">
+              <HiOutlineDownload className="text-foreground hover:text-primary text-xl" />
+            </a>
+          ) : null}
+        </div>
       </div>
 
       {/* File content viewer */}


### PR DESCRIPTION
## Summary

Adds a download icon button to the `FileViewer` header for all files. Clicking it triggers a browser download with the correct filename via the HTML `download` attribute.

- Uses `getFileURL(fspName, file.path)` to construct the content URL
- Uses `HiOutlineDownload` from `react-icons/hi` for the icon
- Wraps the existing JSON format toggle and new download button in a shared flex container so they align consistently

## Test plan

- [x] Open any file in the file browser and confirm the download button appears in the header
- [x] Click the download button and confirm the file downloads with the correct filename
- [x] Confirm the JSON format toggle still appears for JSON files alongside the download button
- [x] `pixi run node-check` — no TypeScript errors
- [x] `pixi run node-eslint-check` — no ESLint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)