### PR TITLE
feat: add preference to show Apps and Jobs pages

### DIFF
--- a/frontend/src/components/Preferences.tsx
+++ b/frontend/src/components/Preferences.tsx
@@ -7,6 +7,7 @@ import DataLinkOptions from '@/components/ui/PreferencesPage/DataLinkOptions';
 import DisplayOptions from '@/components/ui/PreferencesPage/DisplayOptions';
 import JobOptions from '@/components/ui/PreferencesPage/JobOptions';
 import NeuroglancerOptions from '@/components/ui/PreferencesPage/NeuroglancerOptions';
+import ExperimentalOptions from '@/components/ui/PreferencesPage/ExperimentalOptions';
 
 export default function Preferences() {
   const { pathPreference, handlePathPreferenceSubmit } =
@@ -124,6 +125,7 @@ export default function Preferences() {
           <DataLinkOptions />
           <NeuroglancerOptions />
           <JobOptions />
+          <ExperimentalOptions />
         </Card.Body>
       </Card>
     </>

--- a/frontend/src/components/ui/Navbar/Navbar.tsx
+++ b/frontend/src/components/ui/Navbar/Navbar.tsx
@@ -27,6 +27,7 @@ import { FaRunning } from 'react-icons/fa';
 import ProfileMenu from '@/components/ui/Navbar/ProfileMenu';
 import FgTooltip from '@/components/ui/widgets/FgTooltip';
 import useTheme from '@/hooks/useTheme';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
 import { trackEvent } from '@/utils/fathom';
 
 const LINKS = [
@@ -101,10 +102,20 @@ function LogoSvg() {
 
 // Links list component
 function NavList() {
+  const { showAppsAndJobsPages } = usePreferencesContext();
   const tasksEnabled = import.meta.env.VITE_ENABLE_TASKS === 'true';
-  const filteredLinks = tasksEnabled
-    ? LINKS
-    : LINKS.filter(link => link.href !== '/jobs');
+  const filteredLinks = LINKS.filter(link => {
+    if (link.href === '/apps' && !showAppsAndJobsPages) {
+      return false;
+    }
+    if (link.href === '/apps/jobs' && !showAppsAndJobsPages) {
+      return false;
+    }
+    if (link.href === '/jobs' && !tasksEnabled) {
+      return false;
+    }
+    return true;
+  });
 
   return (
     <>

--- a/frontend/src/components/ui/PreferencesPage/ExperimentalOptions.tsx
+++ b/frontend/src/components/ui/PreferencesPage/ExperimentalOptions.tsx
@@ -1,0 +1,34 @@
+import toast from 'react-hot-toast';
+
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
+import OptionsSection from '@/components/ui/PreferencesPage/OptionsSection';
+
+export default function ExperimentalOptions() {
+  const { showAppsAndJobsPages, toggleShowAppsAndJobsPages } =
+    usePreferencesContext();
+
+  return (
+    <OptionsSection
+      header="Experimental Features"
+      options={[
+        {
+          checked: showAppsAndJobsPages,
+          id: 'show_apps_and_jobs_pages',
+          label: 'Show Apps and Jobs pages',
+          onChange: async () => {
+            const result = await toggleShowAppsAndJobsPages();
+            if (result.success) {
+              toast.success(
+                showAppsAndJobsPages
+                  ? 'Apps and Jobs pages are now hidden'
+                  : 'Apps and Jobs pages are now visible'
+              );
+            } else {
+              toast.error(result.error);
+            }
+          }
+        }
+      ]}
+    />
+  );
+}

--- a/frontend/src/contexts/PreferencesContext.tsx
+++ b/frontend/src/contexts/PreferencesContext.tsx
@@ -53,6 +53,7 @@ type PreferencesContextType = {
   useLegacyMultichannelApproach: boolean;
   isFilteredByGroups: boolean;
   showTutorial: boolean;
+  showAppsAndJobsPages: boolean;
   defaultExtraArgs: string;
   apptainerCacheDir: string;
 
@@ -82,6 +83,7 @@ type PreferencesContextType = {
   toggleUseLegacyMultichannelApproach: () => Promise<Result<void>>;
   toggleFilterByGroups: () => Promise<Result<void>>;
   toggleShowTutorial: () => Promise<Result<void>>;
+  toggleShowAppsAndJobsPages: () => Promise<Result<void>>;
   updateDefaultExtraArgs: (args: string) => Promise<Result<void>>;
   updateApptainerCacheDir: (dir: string) => Promise<Result<void>>;
   handleFavoriteChange: (
@@ -243,6 +245,13 @@ export const PreferencesProvider = ({
     return togglePreference(
       'showTutorial',
       preferencesQuery.data?.showTutorial ?? true
+    );
+  };
+
+  const toggleShowAppsAndJobsPages = async (): Promise<Result<void>> => {
+    return togglePreference(
+      'showAppsAndJobsPages',
+      preferencesQuery.data?.showAppsAndJobsPages || false
     );
   };
 
@@ -532,6 +541,7 @@ export const PreferencesProvider = ({
       preferencesQuery.data?.useLegacyMultichannelApproach || false,
     isFilteredByGroups: preferencesQuery.data?.isFilteredByGroups ?? true,
     showTutorial: preferencesQuery.data?.showTutorial ?? true,
+    showAppsAndJobsPages: preferencesQuery.data?.showAppsAndJobsPages || false,
     defaultExtraArgs: preferencesQuery.data?.defaultExtraArgs || '',
     apptainerCacheDir: preferencesQuery.data?.apptainerCacheDir || '',
 
@@ -560,6 +570,7 @@ export const PreferencesProvider = ({
     toggleUseLegacyMultichannelApproach,
     toggleFilterByGroups,
     toggleShowTutorial,
+    toggleShowAppsAndJobsPages,
     updateDefaultExtraArgs,
     updateApptainerCacheDir,
     handleFavoriteChange,

--- a/frontend/src/queries/preferencesQueries.ts
+++ b/frontend/src/queries/preferencesQueries.ts
@@ -38,6 +38,7 @@ type PreferencesApiResponse = {
   useLegacyMultichannelApproach?: { value: boolean };
   isFilteredByGroups?: { value: boolean };
   showTutorial?: { value: boolean };
+  showAppsAndJobsPages?: { value: boolean };
   defaultExtraArgs?: { value: string };
   apptainerCacheDir?: { value: string };
   zone?: { value: ZonePreference[] };
@@ -70,6 +71,7 @@ export type PreferencesQueryData = {
   useLegacyMultichannelApproach: boolean;
   isFilteredByGroups: boolean;
   showTutorial: boolean;
+  showAppsAndJobsPages: boolean;
   defaultExtraArgs: string;
   apptainerCacheDir: string;
 };
@@ -237,6 +239,7 @@ const createTransformPreferences = (
         rawData.useLegacyMultichannelApproach?.value || false,
       isFilteredByGroups: rawData.isFilteredByGroups?.value ?? true,
       showTutorial: rawData.showTutorial?.value ?? true,
+      showAppsAndJobsPages: rawData.showAppsAndJobsPages?.value || false,
       defaultExtraArgs: rawData.defaultExtraArgs?.value || '',
       apptainerCacheDir: rawData.apptainerCacheDir?.value || ''
     };


### PR DESCRIPTION
Clickup id: 86agrdyba

This PR adds an "Experimental features" section to the /preferences page. Currently, the only option there is to show the Apps and Jobs page, which is set to `false` by default.

@krokicki @neomorphic 