### PR TITLE
chore: add fileglancer-specific domains to allowed domains in devcontainer

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -84,6 +84,10 @@ ALLOWED_DOMAINS=(
     "conda-mapping.prefix.dev"
     "prefix.dev"
     "repo.prefix.dev"
+    # Fileglancer
+    "fileglancer.int.janelia.org"
+    "s3.janelia.org"
+    "neuroglancer-demo.appspot.com"
 )
 
 for domain in "${ALLOWED_DOMAINS[@]}"; do


### PR DESCRIPTION
This is for convenience when running Claude Code for debugging in the devcontainer.
@krokicki 