### PR TITLE
fix: map loguru log levels to stdlib equivalents in worker subprocess

### DIFF
--- a/fileglancer/apps/worker.py
+++ b/fileglancer/apps/worker.py
@@ -215,6 +215,9 @@ def main():
     # Configure cluster_api logging so debug output reaches the parent
     # process via stderr.  The parent captures stderr separately.
     log_level = os.environ.get("FGC_LOG_LEVEL", "INFO").upper()
+    # Map loguru-specific levels to their nearest stdlib equivalents
+    _LOGURU_TO_STDLIB = {"TRACE": "DEBUG", "SUCCESS": "INFO"}
+    log_level = _LOGURU_TO_STDLIB.get(log_level, log_level)
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(logging.Formatter(
         "%(levelname)s | %(name)s:%(funcName)s:%(lineno)d - %(message)s"


### PR DESCRIPTION
The parent process passes FGC_LOG_LEVEL (a loguru level) to the worker subprocess, which uses stdlib logging. Loguru-specific levels like TRACE (used in my local dev mode, which is where I discovered the bug) crash the worker with "Unknown level" ValueError, preventing app manifest fetches from completing.
@krokicki 