### PR TITLE
feat: jobs notification badge

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.7.0",
+    "version": "2.8.0-a0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.7.0",
+            "version": "2.8.0-a0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.7.0",
+    "version": "2.8.0-a0",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/src/__tests__/componentTests/NavbarBadge.test.tsx
+++ b/frontend/src/__tests__/componentTests/NavbarBadge.test.tsx
@@ -1,0 +1,100 @@
+import { describe, test, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import FileglancerNavbar from '@/components/ui/Navbar/Navbar';
+
+vi.mock('@/hooks/useActiveJobCount', () => ({
+  useActiveJobCount: vi.fn(() => 0)
+}));
+
+vi.mock('@/contexts/PreferencesContext', () => ({
+  usePreferencesContext: vi.fn(() => ({
+    showAppsAndJobsPages: true
+  }))
+}));
+
+vi.mock('@/hooks/useTheme', () => ({
+  default: vi.fn(() => ({
+    toggleTheme: vi.fn(),
+    isLightTheme: true,
+    setIsLightTheme: vi.fn()
+  }))
+}));
+
+vi.mock('@/utils/fathom', () => ({
+  trackEvent: vi.fn()
+}));
+
+vi.mock('@/components/ui/Navbar/ProfileMenu', () => ({
+  default: () => <div data-testid="profile-menu" />
+}));
+
+vi.mock('@/components/ui/widgets/FgTooltip', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}));
+
+import { useActiveJobCount } from '@/hooks/useActiveJobCount';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
+
+const mockedUseActiveJobCount = vi.mocked(useActiveJobCount);
+const mockedUsePreferencesContext = vi.mocked(usePreferencesContext);
+
+function renderNavbar() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/browse']}>
+        <FileglancerNavbar />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('Navbar badge', () => {
+  test('badge is not visible when active job count is 0', () => {
+    mockedUseActiveJobCount.mockReturnValue(0);
+
+    renderNavbar();
+
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+    expect(screen.getByText('Jobs')).toBeInTheDocument();
+  });
+
+  test('badge shows correct count when active jobs exist', () => {
+    mockedUseActiveJobCount.mockReturnValue(3);
+
+    renderNavbar();
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  test('badge shows "9+" when count exceeds 9', () => {
+    mockedUseActiveJobCount.mockReturnValue(15);
+
+    renderNavbar();
+
+    expect(screen.getByText('9+')).toBeInTheDocument();
+  });
+
+  test('badge is not visible when Jobs link is hidden', () => {
+    mockedUseActiveJobCount.mockReturnValue(5);
+    mockedUsePreferencesContext.mockReturnValue({
+      showAppsAndJobsPages: false
+    } as ReturnType<typeof usePreferencesContext>);
+
+    renderNavbar();
+
+    expect(screen.queryByText('Jobs')).not.toBeInTheDocument();
+    expect(screen.queryByText('5')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/Navbar/Navbar.tsx
+++ b/frontend/src/components/ui/Navbar/Navbar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
+  Badge,
   IconButton,
   Typography,
   Collapse,
@@ -7,6 +8,7 @@ import {
   List
 } from '@material-tailwind/react';
 import { Link } from 'react-router-dom';
+import type { IconType } from 'react-icons';
 import {
   HiOutlineInformationCircle,
   HiOutlineMoon,
@@ -27,46 +29,16 @@ import { FaRunning } from 'react-icons/fa';
 import ProfileMenu from '@/components/ui/Navbar/ProfileMenu';
 import FgTooltip from '@/components/ui/widgets/FgTooltip';
 import useTheme from '@/hooks/useTheme';
+import { useActiveJobCount } from '@/hooks/useActiveJobCount';
 import { usePreferencesContext } from '@/contexts/PreferencesContext';
 import { trackEvent } from '@/utils/fathom';
 
-const LINKS = [
-  {
-    icon: HiOutlineFolder,
-    title: 'Browse Files',
-    href: '/browse'
-  },
-  {
-    icon: HiOutlineShare,
-    title: 'Data Links',
-    href: '/links'
-  },
-  {
-    icon: HiOutlineEye,
-    title: 'NG Links',
-    href: '/nglinks'
-  },
-  {
-    icon: HiOutlineRocketLaunch,
-    title: 'Apps',
-    href: '/apps'
-  },
-  {
-    icon: FaRunning,
-    title: 'Jobs',
-    href: '/apps/jobs'
-  },
-  {
-    icon: HiOutlineBriefcase,
-    title: 'Tasks',
-    href: '/jobs'
-  },
-  {
-    icon: HiOutlineInformationCircle,
-    title: 'Help',
-    href: '/help'
-  }
-];
+type NavLink = {
+  icon: IconType;
+  title: string;
+  href: string;
+  badge?: number;
+};
 
 // Logo SVG component to reduce JSX nesting depth
 function LogoSvg() {
@@ -104,7 +76,24 @@ function LogoSvg() {
 function NavList() {
   const { showAppsAndJobsPages } = usePreferencesContext();
   const tasksEnabled = import.meta.env.VITE_ENABLE_TASKS === 'true';
-  const filteredLinks = LINKS.filter(link => {
+  const activeJobCount = useActiveJobCount();
+
+  const links: NavLink[] = [
+    { icon: HiOutlineFolder, title: 'Browse Files', href: '/browse' },
+    { icon: HiOutlineShare, title: 'Data Links', href: '/links' },
+    { icon: HiOutlineEye, title: 'NG Links', href: '/nglinks' },
+    { icon: HiOutlineRocketLaunch, title: 'Apps', href: '/apps' },
+    {
+      icon: FaRunning,
+      title: 'Jobs',
+      href: '/apps/jobs',
+      badge: activeJobCount
+    },
+    { icon: HiOutlineBriefcase, title: 'Tasks', href: '/jobs' },
+    { icon: HiOutlineInformationCircle, title: 'Help', href: '/help' }
+  ];
+
+  const filteredLinks = links.filter(link => {
     if (link.href === '/apps' && !showAppsAndJobsPages) {
       return false;
     }
@@ -119,26 +108,46 @@ function NavList() {
 
   return (
     <>
-      {filteredLinks.map(({ icon: Icon, title, href }) => (
-        <List.Item
-          as={Link}
-          className="flex items-center dark:!text-foreground hover:bg-hover-gradient hover:dark:bg-hover-gradient-dark focus:bg-hover-gradient focus:dark:bg-hover-gradient-dark hover:!text-foreground focus:!text-foreground"
-          key={title}
-          onClick={() =>
-            trackEvent({
-              eventId: `navbar_${title.toLowerCase().replace(' ', '_')}_click`
-            })
-          }
-          to={href}
-        >
-          <List.ItemStart className="flex items-center mr-1.5">
-            <Icon className="stroke-2 icon-default short:icon-xsmall" />
-          </List.ItemStart>
-          <Typography className="short:text-xs" type="small">
-            {title}
-          </Typography>
-        </List.Item>
-      ))}
+      {filteredLinks.map(({ icon: Icon, title, href, badge }) => {
+        const listItem = (
+          <List.Item
+            as={Link}
+            className="flex items-center dark:!text-foreground hover:bg-hover-gradient hover:dark:bg-hover-gradient-dark focus:bg-hover-gradient focus:dark:bg-hover-gradient-dark hover:!text-foreground focus:!text-foreground"
+            key={title}
+            onClick={() =>
+              trackEvent({
+                eventId: `navbar_${title.toLowerCase().replace(' ', '_')}_click`
+              })
+            }
+            to={href}
+          >
+            <List.ItemStart className="flex items-center mr-1.5">
+              <Icon className="stroke-2 icon-default short:icon-xsmall" />
+            </List.ItemStart>
+            <Typography className="short:text-xs" type="small">
+              {title}
+            </Typography>
+          </List.Item>
+        );
+
+        if (badge !== undefined && badge > 0) {
+          return (
+            <Badge
+              color="info"
+              key={title}
+              overlap="square"
+              placement="top-end"
+            >
+              <Badge.Content>{listItem}</Badge.Content>
+              <Badge.Indicator className="p-0 pointer-events-none text-[10px] min-w-4 min-h-4">
+                {badge > 9 ? '9+' : badge}
+              </Badge.Indicator>
+            </Badge>
+          );
+        }
+
+        return listItem;
+      })}
     </>
   );
 }

--- a/frontend/src/components/ui/Navbar/Navbar.tsx
+++ b/frontend/src/components/ui/Navbar/Navbar.tsx
@@ -133,7 +133,7 @@ function NavList() {
         if (badge !== undefined && badge > 0) {
           return (
             <Badge
-              color="info"
+              color="secondary"
               key={title}
               overlap="square"
               placement="top-end"

--- a/frontend/src/hooks/useActiveJobCount.ts
+++ b/frontend/src/hooks/useActiveJobCount.ts
@@ -1,0 +1,10 @@
+import { useJobsQuery } from '@/queries/jobsQueries';
+
+export function useActiveJobCount(): number {
+  const { data: jobs } = useJobsQuery();
+  if (!jobs) {
+    return 0;
+  }
+  return jobs.filter(j => j.status === 'PENDING' || j.status === 'RUNNING')
+    .length;
+}


### PR DESCRIPTION
Clickup id: 86ag89ucu

This PR adds a notification-style badge to the Jobs tab in the navbar (or the Jobs link in the hamburger menu drop-down) when there are any "pending" or "running" jobs for the user.

You can test out the PR on fileglancer-dev.int.janelia.org, where I have a test build from this branch installed. Start some jobs and you will see the badge appear, and the number change based on the number of active jobs.

@krokicki 