### PR TITLE
style: compact within-row json spacing in file viewer

### DIFF
--- a/frontend/src/components/ui/BrowsePage/FileViewer.tsx
+++ b/frontend/src/components/ui/BrowsePage/FileViewer.tsx
@@ -172,6 +172,7 @@ export default function FileViewer({ file }: FileViewerProps) {
         const parsed = JSON.parse(content);
         const formatter = new Formatter();
         formatter.Options.IndentSpaces = 2;
+        formatter.Options.MaxTableRowComplexity = 1;
         displayContent = formatter.Serialize(parsed);
       } catch {
         // If JSON parsing fails, show original content

--- a/frontend/src/components/ui/BrowsePage/FileViewer.tsx
+++ b/frontend/src/components/ui/BrowsePage/FileViewer.tsx
@@ -173,7 +173,7 @@ export default function FileViewer({ file }: FileViewerProps) {
         const formatter = new Formatter();
         formatter.Options.IndentSpaces = 2;
         formatter.Options.MaxTableRowComplexity = 1;
-        displayContent = formatter.Serialize(parsed);
+        displayContent = formatter.Serialize(parsed) ?? content;
       } catch {
         // If JSON parsing fails, show original content
         displayContent = content;


### PR DESCRIPTION
Clickup id: 86agx68ec

This PR changes the within-row complexity option in the FracturedJson package to prevent table-aligned spacing of variables between multiple rows of JSON (effectively, enabling a compact within-row spacing). 

This PR also fixes a type error by falling back to the non-formatted JSON content.

To test: 
- `pixi run dev-install` and `pixi run dev-launch` from this branch, from a machine with access to the file system
- Navigate to `/nrs/tavakoli/data_internal/mouseLICONN_different_z/20260406_ExPID71_2ndgel_BAC_Cortex_600nm_A_Atto488_40XW001.zarr/raw/zarr.json`
- Compare JSON appearance to https://fileglancer.int.janelia.org/browse/nrs_tavakoli/data_internal/mouseLICONN_different_z/20260406_ExPID71_2ndgel_BAC_Cortex_600nm_A_Atto488_40XW001.zarr/raw/zarr.json. In the dev version, there should not be table-aligned spacing between variables within a single row of JSON

@krokicki @dchen116