### PR TITLE
feat: allow changing execute permission

### DIFF
--- a/fileglancer/filestore.py
+++ b/fileglancer/filestore.py
@@ -748,17 +748,23 @@ class Filestore:
             raise ValueError("Permissions must be a string of length 10")
         full_path = self._check_path_in_root(path)
         # Convert permission string (like '-rw-r--r--') to octal mode
+        # Execute positions (3, 6, 9) can contain special characters:
+        #   'x' = execute, 's'/'S' = setuid/setgid, 't'/'T' = sticky bit
+        #   Lowercase = execute set, uppercase = execute not set
         mode = 0
         # Owner permissions (positions 1-3)
         if permissions[1] == 'r': mode |= stat.S_IRUSR
         if permissions[2] == 'w': mode |= stat.S_IWUSR
-        if permissions[3] == 'x': mode |= stat.S_IXUSR
+        if permissions[3] in ('x', 's'): mode |= stat.S_IXUSR
+        if permissions[3] in ('s', 'S'): mode |= stat.S_ISUID
         # Group permissions (positions 4-6)
         if permissions[4] == 'r': mode |= stat.S_IRGRP
         if permissions[5] == 'w': mode |= stat.S_IWGRP
-        if permissions[6] == 'x': mode |= stat.S_IXGRP
+        if permissions[6] in ('x', 's'): mode |= stat.S_IXGRP
+        if permissions[6] in ('s', 'S'): mode |= stat.S_ISGID
         # Other permissions (positions 7-9)
         if permissions[7] == 'r': mode |= stat.S_IROTH
         if permissions[8] == 'w': mode |= stat.S_IWOTH
-        if permissions[9] == 'x': mode |= stat.S_IXOTH
+        if permissions[9] in ('x', 't'): mode |= stat.S_IXOTH
+        if permissions[9] in ('t', 'T'): mode |= stat.S_ISVTX
         os.chmod(full_path, mode)

--- a/frontend/src/__tests__/componentTests/ChangePermissions.test.tsx
+++ b/frontend/src/__tests__/componentTests/ChangePermissions.test.tsx
@@ -73,7 +73,7 @@ describe('Change Permissions dialog', () => {
     expect(submitButton).toBeDisabled();
   });
 
-  it('should update local permissions when input is checked', async () => {
+  it('should update local permissions when write input is checked', async () => {
     const user = userEvent.setup();
     const checkbox = screen.getByRole('checkbox', { name: 'w_8' });
 
@@ -83,6 +83,38 @@ describe('Change Permissions dialog', () => {
     // Checkboxes are updated based on the local permissions state
     // Initial mock target state is 'drwxrwxr-x', it should now be 'drwxrwxrwx'
     expect(checkbox).toBeChecked();
+  });
+
+  it('should update local permissions when execute input is toggled', async () => {
+    const user = userEvent.setup();
+    // Owner execute is at position 3 - initial 'drwxrwxr-x' has 'x' at position 3
+    const checkbox = screen.getByRole('checkbox', { name: 'x_3' });
+
+    expect(checkbox).toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('should show sticky bit checkbox for directories', () => {
+    const stickyCheckbox = screen.getByRole('checkbox', { name: 't_9' });
+    expect(stickyCheckbox).toBeInTheDocument();
+    // Initial 'drwxrwxr-x' does not have sticky bit
+    expect(stickyCheckbox).not.toBeChecked();
+  });
+
+  it('should toggle sticky bit while preserving execute', async () => {
+    const user = userEvent.setup();
+    const stickyCheckbox = screen.getByRole('checkbox', { name: 't_9' });
+    const executeCheckbox = screen.getByRole('checkbox', { name: 'x_9' });
+
+    // Initial 'drwxrwxr-x' has execute at position 9
+    expect(executeCheckbox).toBeChecked();
+    expect(stickyCheckbox).not.toBeChecked();
+
+    // Enable sticky bit - should change 'x' to 't' (sticky + execute)
+    await user.click(stickyCheckbox);
+    expect(stickyCheckbox).toBeChecked();
+    expect(executeCheckbox).toBeChecked(); // execute preserved
   });
 
   it('calls toast.success for an ok HTTP response', async () => {

--- a/frontend/src/__tests__/componentTests/ChangePermissions.test.tsx
+++ b/frontend/src/__tests__/componentTests/ChangePermissions.test.tsx
@@ -117,6 +117,28 @@ describe('Change Permissions dialog', () => {
     expect(executeCheckbox).toBeChecked(); // execute preserved
   });
 
+  it('should show setgid checkbox for directories', () => {
+    const setgidCheckbox = screen.getByRole('checkbox', { name: 's_6' });
+    expect(setgidCheckbox).toBeInTheDocument();
+    // Initial 'drwxrwxr-x' does not have setgid
+    expect(setgidCheckbox).not.toBeChecked();
+  });
+
+  it('should toggle setgid while preserving group execute', async () => {
+    const user = userEvent.setup();
+    const setgidCheckbox = screen.getByRole('checkbox', { name: 's_6' });
+    const groupExecuteCheckbox = screen.getByRole('checkbox', { name: 'x_6' });
+
+    // Initial 'drwxrwxr-x' has group execute at position 6
+    expect(groupExecuteCheckbox).toBeChecked();
+    expect(setgidCheckbox).not.toBeChecked();
+
+    // Enable setgid - should change 'x' to 's' (setgid + execute)
+    await user.click(setgidCheckbox);
+    expect(setgidCheckbox).toBeChecked();
+    expect(groupExecuteCheckbox).toBeChecked(); // execute preserved
+  });
+
   it('calls toast.success for an ok HTTP response', async () => {
     const user = userEvent.setup();
     const checkbox = screen.getByRole('checkbox', { name: 'w_8' });

--- a/frontend/src/components/ui/Dialogs/ChangePermissions.tsx
+++ b/frontend/src/components/ui/Dialogs/ChangePermissions.tsx
@@ -64,6 +64,7 @@ export default function ChangePermissions({
                 </th>
                 <th className="px-3 py-2 text-left font-medium">Read</th>
                 <th className="px-3 py-2 text-left font-medium">Write</th>
+                <th className="px-3 py-2 text-left font-medium">Execute</th>
               </tr>
             </thead>
 
@@ -73,7 +74,7 @@ export default function ChangePermissions({
                   <td className="p-3 font-medium">
                     Owner: {fileBrowserState.propertiesTarget.owner}
                   </td>
-                  {/* Owner read/write */}
+                  {/* Owner read/write/execute */}
                   <td className="p-3">
                     <input
                       aria-label="r_1"
@@ -93,13 +94,26 @@ export default function ChangePermissions({
                       type="checkbox"
                     />
                   </td>
+                  <td className="p-3">
+                    <input
+                      aria-label="x_3"
+                      checked={
+                        localPermissions[3] === 'x' ||
+                        localPermissions[3] === 's'
+                      }
+                      className="accent-secondary-light hover:cursor-pointer"
+                      name="x_3"
+                      onChange={event => handleLocalPermissionChange(event)}
+                      type="checkbox"
+                    />
+                  </td>
                 </tr>
 
                 <tr className="border-b border-surface dark:border-surface-light">
                   <td className="p-3 font-medium">
                     Group: {fileBrowserState.propertiesTarget.group}
                   </td>
-                  {/* Group read/write */}
+                  {/* Group read/write/execute */}
                   <td className="p-3">
                     <input
                       aria-label="r_4"
@@ -120,11 +134,24 @@ export default function ChangePermissions({
                       type="checkbox"
                     />
                   </td>
+                  <td className="p-3">
+                    <input
+                      aria-label="x_6"
+                      checked={
+                        localPermissions[6] === 'x' ||
+                        localPermissions[6] === 's'
+                      }
+                      className="accent-secondary-light hover:cursor-pointer"
+                      name="x_6"
+                      onChange={event => handleLocalPermissionChange(event)}
+                      type="checkbox"
+                    />
+                  </td>
                 </tr>
 
                 <tr>
                   <td className="p-3 font-medium">Everyone else</td>
-                  {/* Everyone else read/write */}
+                  {/* Everyone else read/write/execute */}
                   <td className="p-3">
                     <input
                       aria-label="r_7"
@@ -145,10 +172,39 @@ export default function ChangePermissions({
                       type="checkbox"
                     />
                   </td>
+                  <td className="p-3">
+                    <input
+                      aria-label="x_9"
+                      checked={
+                        localPermissions[9] === 'x' ||
+                        localPermissions[9] === 't'
+                      }
+                      className="accent-secondary-light hover:cursor-pointer"
+                      name="x_9"
+                      onChange={event => handleLocalPermissionChange(event)}
+                      type="checkbox"
+                    />
+                  </td>
                 </tr>
               </tbody>
             ) : null}
           </table>
+
+          {fileBrowserState.propertiesTarget.is_dir && localPermissions ? (
+            <label className="flex items-center gap-2 my-4 text-sm text-foreground">
+              <input
+                aria-label="t_9"
+                checked={
+                  localPermissions[9] === 't' || localPermissions[9] === 'T'
+                }
+                className="accent-secondary-light hover:cursor-pointer"
+                name="t_9"
+                onChange={event => handleLocalPermissionChange(event)}
+                type="checkbox"
+              />
+              Only owner can delete and rename files in this directory
+            </label>
+          ) : null}
           <Button
             className="!rounded-md"
             disabled={Boolean(

--- a/frontend/src/components/ui/Dialogs/ChangePermissions.tsx
+++ b/frontend/src/components/ui/Dialogs/ChangePermissions.tsx
@@ -206,7 +206,7 @@ export default function ChangePermissions({
                 <span>
                   New files created in this directory belong to group{' '}
                   <em>{fileBrowserState.propertiesTarget.group}</em>, regardless
-                  of creator's primary group
+                  of the file creator's primary group
                 </span>
               </label>
               <label className="flex items-center gap-2 my-4 text-sm text-foreground">

--- a/frontend/src/components/ui/Dialogs/ChangePermissions.tsx
+++ b/frontend/src/components/ui/Dialogs/ChangePermissions.tsx
@@ -191,19 +191,38 @@ export default function ChangePermissions({
           </table>
 
           {fileBrowserState.propertiesTarget.is_dir && localPermissions ? (
-            <label className="flex items-center gap-2 my-4 text-sm text-foreground">
-              <input
-                aria-label="t_9"
-                checked={
-                  localPermissions[9] === 't' || localPermissions[9] === 'T'
-                }
-                className="accent-secondary-light hover:cursor-pointer"
-                name="t_9"
-                onChange={event => handleLocalPermissionChange(event)}
-                type="checkbox"
-              />
-              Only owner can delete and rename files in this directory
-            </label>
+            <>
+              <label className="flex items-start gap-2 my-4 text-sm text-foreground">
+                <input
+                  aria-label="s_6"
+                  checked={
+                    localPermissions[6] === 's' || localPermissions[6] === 'S'
+                  }
+                  className="accent-secondary-light hover:cursor-pointer mt-0.5"
+                  name="s_6"
+                  onChange={event => handleLocalPermissionChange(event)}
+                  type="checkbox"
+                />
+                <span>
+                  New files created in this directory belong to group{' '}
+                  <em>{fileBrowserState.propertiesTarget.group}</em>, regardless
+                  of creator's primary group
+                </span>
+              </label>
+              <label className="flex items-center gap-2 my-4 text-sm text-foreground">
+                <input
+                  aria-label="t_9"
+                  checked={
+                    localPermissions[9] === 't' || localPermissions[9] === 'T'
+                  }
+                  className="accent-secondary-light hover:cursor-pointer"
+                  name="t_9"
+                  onChange={event => handleLocalPermissionChange(event)}
+                  type="checkbox"
+                />
+                Only owner can delete and rename files in this directory
+              </label>
+            </>
           ) : null}
           <Button
             className="!rounded-md"

--- a/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
+++ b/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
@@ -18,9 +18,9 @@ function PermissionIcon({
 export default function PermissionsTable({
   file
 }: {
-  readonly file: FileOrFolder | null;
+  readonly file: FileOrFolder;
 }) {
-  const permissions = file ? parsePermissions(file.permissions) : null;
+  const permissions = parsePermissions(file.permissions);
 
   return (
     <div className="w-full min-w-max overflow-hidden rounded-lg border border-surface mt-4">
@@ -32,6 +32,7 @@ export default function PermissionsTable({
             </th>
             <th className="px-3 py-2 text-center font-medium">Read</th>
             <th className="px-3 py-2 text-center font-medium">Write</th>
+            <th className="px-3 py-2 text-center font-medium">Execute</th>
           </tr>
         </thead>
         <tbody className="text-sm">
@@ -49,6 +50,11 @@ export default function PermissionsTable({
                 <PermissionIcon hasPermission={permissions.owner.write} />
               ) : null}
             </td>
+            <td className="p-3">
+              {permissions ? (
+                <PermissionIcon hasPermission={permissions.owner.execute} />
+              ) : null}
+            </td>
           </tr>
           <tr className="border-b border-surface">
             <td className="p-3 font-medium">
@@ -64,6 +70,11 @@ export default function PermissionsTable({
                 <PermissionIcon hasPermission={permissions.group.write} />
               ) : null}
             </td>
+            <td className="p-3">
+              {permissions ? (
+                <PermissionIcon hasPermission={permissions.group.execute} />
+              ) : null}
+            </td>
           </tr>
           <tr>
             <td className="p-3 font-medium">Everyone else</td>
@@ -77,9 +88,17 @@ export default function PermissionsTable({
                 <PermissionIcon hasPermission={permissions.others.write} />
               ) : null}
             </td>
+            <td className="p-3">
+              <PermissionIcon hasPermission={permissions.others.execute} />
+            </td>
           </tr>
         </tbody>
       </table>
+      {file.is_dir && permissions.stickyBit ? (
+        <p className="mt-2 text-sm text-foreground/70">
+          Sticky bit set: only owner can delete and rename files
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
+++ b/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
@@ -96,27 +96,31 @@ export default function PermissionsTable({
           </tbody>
         </table>
       </div>
-      <div className="w-full min-w-[333px] overflow-hidden rounded-lg border border-surface my-2">
-        <table className="w-full">
-          <thead className="border-b border-surface bg-surface-dark text-sm">
-            <tr>
-              <th className="px-3 py-2 text-start font-medium" colspan="2">
-                Additional permissions
-              </th>
-            </tr>
-          </thead>
-          <tbody className="text-sm">
-            <tr>
-              <td className="p-3">Only owner can delete or rename files?</td>
-              <td className="p-3">
-                {permissions ? (
-                  <PermissionIcon hasPermission={permissions.stickyBit} />
-                ) : null}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      {file.is_dir ? (
+        <div className="w-full min-w-[333px] overflow-hidden rounded-lg border border-surface my-2">
+          <table className="w-full">
+            <thead className="border-b border-surface bg-surface-dark text-sm">
+              <tr>
+                <th className="px-3 py-2 text-start font-medium" colspan="2">
+                  Additional permissions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="text-sm">
+              <tr>
+                <td className="p-3">
+                  Only owner can delete and rename files in this directory
+                </td>
+                <td className="p-3">
+                  {permissions ? (
+                    <PermissionIcon hasPermission={permissions.stickyBit} />
+                  ) : null}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
+++ b/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
@@ -98,6 +98,13 @@ export default function PermissionsTable({
       </div>
       <div className="w-full min-w-[333px] overflow-hidden rounded-lg border border-surface my-2">
         <table className="w-full">
+          <thead className="border-b border-surface bg-surface-dark text-sm">
+            <tr>
+              <th className="px-3 py-2 text-start font-medium" colspan="2">
+                Additional permissions
+              </th>
+            </tr>
+          </thead>
           <tbody className="text-sm">
             <tr>
               <td className="p-3">Only owner can delete or rename files?</td>

--- a/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
+++ b/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
@@ -23,82 +23,93 @@ export default function PermissionsTable({
   const permissions = parsePermissions(file.permissions);
 
   return (
-    <div className="w-full min-w-max overflow-hidden rounded-lg border border-surface mt-4">
-      <table className="w-full min-w-max">
-        <thead className="border-b border-surface bg-surface-dark text-sm font-medium">
-          <tr>
-            <th className="px-3 py-2 text-start font-medium">
-              Who can view or edit this data?
-            </th>
-            <th className="px-3 py-2 text-center font-medium">Read</th>
-            <th className="px-3 py-2 text-center font-medium">Write</th>
-            <th className="px-3 py-2 text-center font-medium">Execute</th>
-          </tr>
-        </thead>
-        <tbody className="text-sm">
-          <tr className="border-b border-surface">
-            <td className="p-3 font-medium">
-              Owner: {file ? file.owner : null}
-            </td>
-            <td className="p-3">
-              {permissions ? (
-                <PermissionIcon hasPermission={permissions.owner.read} />
-              ) : null}
-            </td>
-            <td className="p-3">
-              {permissions ? (
-                <PermissionIcon hasPermission={permissions.owner.write} />
-              ) : null}
-            </td>
-            <td className="p-3">
-              {permissions ? (
-                <PermissionIcon hasPermission={permissions.owner.execute} />
-              ) : null}
-            </td>
-          </tr>
-          <tr className="border-b border-surface">
-            <td className="p-3 font-medium">
-              Group: {file ? file.group : null}
-            </td>
-            <td className="p-3">
-              {permissions ? (
-                <PermissionIcon hasPermission={permissions.group.read} />
-              ) : null}
-            </td>
-            <td className="p-3">
-              {permissions ? (
-                <PermissionIcon hasPermission={permissions.group.write} />
-              ) : null}
-            </td>
-            <td className="p-3">
-              {permissions ? (
-                <PermissionIcon hasPermission={permissions.group.execute} />
-              ) : null}
-            </td>
-          </tr>
-          <tr>
-            <td className="p-3 font-medium">Everyone else</td>
-            <td className="p-3">
-              {permissions ? (
-                <PermissionIcon hasPermission={permissions.others.read} />
-              ) : null}
-            </td>
-            <td className="p-3">
-              {permissions ? (
-                <PermissionIcon hasPermission={permissions.others.write} />
-              ) : null}
-            </td>
-            <td className="p-3">
-              <PermissionIcon hasPermission={permissions.others.execute} />
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      {file.is_dir && permissions.stickyBit ? (
-        <p className="mt-2 text-sm text-foreground/70">
-          Sticky bit set: only owner can delete and rename files
-        </p>
-      ) : null}
-    </div>
+    <>
+      <div className="w-full min-w-[333px] overflow-hidden rounded-lg border border-surface mt-4">
+        <table className="w-full">
+          <thead className="border-b border-surface bg-surface-dark text-sm">
+            <tr>
+              <th className="px-3 py-2 text-start font-medium">Who</th>
+              <th className="px-3 py-2 text-start font-medium">Read</th>
+              <th className="px-3 py-2 text-start font-medium">Write</th>
+              <th className="px-3 py-2 text-start font-medium">Execute</th>
+            </tr>
+          </thead>
+          <tbody className="text-sm">
+            <tr className="border-b border-surface">
+              <td className="p-3 font-medium">
+                Owner: {file ? file.owner : null}
+              </td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.owner.read} />
+                ) : null}
+              </td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.owner.write} />
+                ) : null}
+              </td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.owner.execute} />
+                ) : null}
+              </td>
+            </tr>
+            <tr className="border-b border-surface">
+              <td className="p-3 font-medium">
+                Group: {file ? file.group : null}
+              </td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.group.read} />
+                ) : null}
+              </td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.group.write} />
+                ) : null}
+              </td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.group.execute} />
+                ) : null}
+              </td>
+            </tr>
+            <tr>
+              <td className="p-3 font-medium">Everyone else</td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.others.read} />
+                ) : null}
+              </td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.others.write} />
+                ) : null}
+              </td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.others.execute} />
+                ) : null}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div className="w-full min-w-[333px] overflow-hidden rounded-lg border border-surface my-2">
+        <table className="w-full">
+          <tbody className="text-sm">
+            <tr>
+              <td className="p-3">Only owner can delete or rename files?</td>
+              <td className="p-3">
+                {permissions ? (
+                  <PermissionIcon hasPermission={permissions.stickyBit} />
+                ) : null}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </>
   );
 }

--- a/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
+++ b/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
@@ -107,6 +107,17 @@ export default function PermissionsTable({
               </tr>
             </thead>
             <tbody className="text-sm">
+              <tr className="border-b border-surface">
+                <td className="p-3">
+                  New files created in this directory belong to group{' '}
+                  <em>{file.group}</em>, regardless of creator's primary group
+                </td>
+                <td className="p-3">
+                  {permissions ? (
+                    <PermissionIcon hasPermission={permissions.setgid} />
+                  ) : null}
+                </td>
+              </tr>
               <tr>
                 <td className="p-3">
                   Only owner can delete and rename files in this directory

--- a/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
+++ b/frontend/src/components/ui/PropertiesDrawer/PermissionsTable.tsx
@@ -110,7 +110,8 @@ export default function PermissionsTable({
               <tr className="border-b border-surface">
                 <td className="p-3">
                   New files created in this directory belong to group{' '}
-                  <em>{file.group}</em>, regardless of creator's primary group
+                  <em>{file.group}</em>, regardless of the file creator's
+                  primary group
                 </td>
                 <td className="p-3">
                   {permissions ? (

--- a/frontend/src/hooks/usePermissionsDialog.ts
+++ b/frontend/src/hooks/usePermissionsDialog.ts
@@ -15,6 +15,41 @@ export default function usePermissionsDialog() {
   );
 
   /**
+   * For execute positions (3, 6, 9), determine the correct character based on
+   * whether execute is set and whether a special bit (sticky) is active.
+   * Position 9 uses 't'/'T' for sticky bit; positions 3 and 6 use 's'/'S' for setuid/setgid.
+   */
+  function getExecuteChar(
+    position: number,
+    execute: boolean,
+    currentChar: string
+  ): string {
+    const hasSpecial =
+      position === 9
+        ? currentChar === 't' || currentChar === 'T'
+        : currentChar === 's' || currentChar === 'S';
+
+    if (hasSpecial) {
+      // Special bit is set - use lowercase (with execute) or uppercase (without)
+      const specialChar = position === 9 ? 't' : 's';
+      return execute ? specialChar : specialChar.toUpperCase();
+    }
+    return execute ? 'x' : '-';
+  }
+
+  /**
+   * For the sticky bit toggle at position 9, determine the correct character
+   * based on whether sticky is set and whether execute is also set.
+   */
+  function getStickyChar(sticky: boolean, currentChar: string): string {
+    const hasExecute = currentChar === 'x' || currentChar === 't';
+    if (sticky) {
+      return hasExecute ? 't' : 'T';
+    }
+    return hasExecute ? 'x' : '-';
+  }
+
+  /**
    * Handles local permission state changes based on user input to the form.
    * This local state is necessary to track the user's changes before the form is submitted,
    * which causes the state in the fileglancer db to update.
@@ -25,26 +60,34 @@ export default function usePermissionsDialog() {
     if (!localPermissions) {
       return null; // If the local permissions are not set, this means the fileBrowserState is not set, return null
     }
-    // Extract the value (w - write or r - read) and position in the UNIX permission string
-    // (1 - 8) from the input name
+    // Extract the value (r, w, x, or t for sticky) and position in the UNIX permission string
+    // from the input name
     const { name, checked } = event.target;
     const [value, position] = name.split('_');
+    const pos = parseInt(position);
 
     setLocalPermissions(prev => {
       if (!prev) {
         return prev; // If the prev local permission string is null, that means the fileBrowserState isn't set yet, so return null
       }
-      // Split the previous local permission string at every character in the string
       const splitPermissions = prev.split('');
-      // If the event checked the input, set that value (r/w) at that position in the string
-      if (checked) {
-        splitPermissions.splice(parseInt(position), 1, value);
+      const currentChar = splitPermissions[pos];
+
+      if (value === 'x') {
+        // Execute toggle - must account for sticky/setuid/setgid special bits
+        splitPermissions[pos] = getExecuteChar(pos, checked, currentChar);
+      } else if (value === 't') {
+        // Sticky bit toggle at position 9
+        splitPermissions[pos] = getStickyChar(checked, currentChar);
+      } else if (checked) {
+        // Read or write - set the value at that position
+        splitPermissions[pos] = value;
       } else {
-        // If the event unchecked the input, set the value to "-" at that posiiton in the string
-        splitPermissions.splice(parseInt(position), 1, '-');
+        // Unchecked read or write - set to '-'
+        splitPermissions[pos] = '-';
       }
-      const newPermissions = splitPermissions.join('');
-      return newPermissions;
+
+      return splitPermissions.join('');
     });
   }
 

--- a/frontend/src/hooks/usePermissionsDialog.ts
+++ b/frontend/src/hooks/usePermissionsDialog.ts
@@ -18,6 +18,13 @@ export default function usePermissionsDialog() {
    * For execute positions (3, 6, 9), determine the correct character based on
    * whether execute is set and whether a special bit (sticky) is active.
    * Position 9 uses 't'/'T' for sticky bit; positions 3 and 6 use 's'/'S' for setuid/setgid.
+   *
+   * Note on setuid/setgid: this dialog has no toggle for setuid (position 3) or
+   * setgid (position 6), so users cannot set or clear them here. However, those
+   * bits round-trip safely: if the file already has them set, toggling the
+   * Execute checkbox preserves the special bit (lowercase when execute is on,
+   * uppercase when off), and the backend in filestore.py honors 's'/'S' in the
+   * incoming permission string.
    */
   function getExecuteChar(
     position: number,

--- a/frontend/src/hooks/usePermissionsDialog.ts
+++ b/frontend/src/hooks/usePermissionsDialog.ts
@@ -16,15 +16,14 @@ export default function usePermissionsDialog() {
 
   /**
    * For execute positions (3, 6, 9), determine the correct character based on
-   * whether execute is set and whether a special bit (sticky) is active.
+   * whether execute is set and whether a special bit (sticky/setgid) is active.
    * Position 9 uses 't'/'T' for sticky bit; positions 3 and 6 use 's'/'S' for setuid/setgid.
    *
-   * Note on setuid/setgid: this dialog has no toggle for setuid (position 3) or
-   * setgid (position 6), so users cannot set or clear them here. However, those
-   * bits round-trip safely: if the file already has them set, toggling the
-   * Execute checkbox preserves the special bit (lowercase when execute is on,
-   * uppercase when off), and the backend in filestore.py honors 's'/'S' in the
-   * incoming permission string.
+   * Note on setuid: this dialog has no toggle for setuid (position 3), so users
+   * cannot set or clear it here. However, the bit round-trips safely: if the
+   * file already has it set, toggling the Execute checkbox preserves the
+   * special bit (lowercase when execute is on, uppercase when off), and the
+   * backend in filestore.py honors 's'/'S' in the incoming permission string.
    */
   function getExecuteChar(
     position: number,
@@ -57,6 +56,18 @@ export default function usePermissionsDialog() {
   }
 
   /**
+   * For the setgid toggle at position 6, determine the correct character
+   * based on whether setgid is set and whether group execute is also set.
+   */
+  function getSetgidChar(setgid: boolean, currentChar: string): string {
+    const hasExecute = currentChar === 'x' || currentChar === 's';
+    if (setgid) {
+      return hasExecute ? 's' : 'S';
+    }
+    return hasExecute ? 'x' : '-';
+  }
+
+  /**
    * Handles local permission state changes based on user input to the form.
    * This local state is necessary to track the user's changes before the form is submitted,
    * which causes the state in the fileglancer db to update.
@@ -67,8 +78,8 @@ export default function usePermissionsDialog() {
     if (!localPermissions) {
       return null; // If the local permissions are not set, this means the fileBrowserState is not set, return null
     }
-    // Extract the value (r, w, x, or t for sticky) and position in the UNIX permission string
-    // from the input name
+    // Extract the value (r, w, x, s for setgid, or t for sticky) and position
+    // in the UNIX permission string from the input name
     const { name, checked } = event.target;
     const [value, position] = name.split('_');
     const pos = parseInt(position);
@@ -86,6 +97,9 @@ export default function usePermissionsDialog() {
       } else if (value === 't') {
         // Sticky bit toggle at position 9
         splitPermissions[pos] = getStickyChar(checked, currentChar);
+      } else if (value === 's') {
+        // Setgid toggle at position 6
+        splitPermissions[pos] = getSetgidChar(checked, currentChar);
       } else if (checked) {
         // Read or write - set the value at that position
         splitPermissions[pos] = value;

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -216,23 +216,41 @@ async function sendFetchRequest(
 }
 
 // Parse the Unix-style permissions string (e.g., "drwxr-xr-x")
+// Execute positions (3, 6, 9) can contain:
+//   'x' = execute only
+//   's'/'S' = setuid/setgid (positions 3, 6)
+//   't'/'T' = sticky bit (position 9)
+// Lowercase means execute is also set; uppercase means execute is not set.
 const parsePermissions = (permissionString: string) => {
   // Owner permissions (positions 1-3)
   const ownerRead = permissionString[1] === 'r';
   const ownerWrite = permissionString[2] === 'w';
+  const ownerExecute = 'xsS'.includes(permissionString[3])
+    ? permissionString[3] === 'x' || permissionString[3] === 's'
+    : false;
 
   // Group permissions (positions 4-6)
   const groupRead = permissionString[4] === 'r';
   const groupWrite = permissionString[5] === 'w';
+  const groupExecute = 'xsS'.includes(permissionString[6])
+    ? permissionString[6] === 'x' || permissionString[6] === 's'
+    : false;
 
   // Others/everyone permissions (positions 7-9)
   const othersRead = permissionString[7] === 'r';
   const othersWrite = permissionString[8] === 'w';
+  const othersExecute = 'xtT'.includes(permissionString[9])
+    ? permissionString[9] === 'x' || permissionString[9] === 't'
+    : false;
+
+  // Sticky bit is shown at position 9 as 't' (with execute) or 'T' (without execute)
+  const stickyBit = permissionString[9] === 't' || permissionString[9] === 'T';
 
   return {
-    owner: { read: ownerRead, write: ownerWrite },
-    group: { read: groupRead, write: groupWrite },
-    others: { read: othersRead, write: othersWrite }
+    owner: { read: ownerRead, write: ownerWrite, execute: ownerExecute },
+    group: { read: groupRead, write: groupWrite, execute: groupExecute },
+    others: { read: othersRead, write: othersWrite, execute: othersExecute },
+    stickyBit
   };
 };
 

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -243,6 +243,9 @@ const parsePermissions = (permissionString: string) => {
     ? permissionString[9] === 'x' || permissionString[9] === 't'
     : false;
 
+  // Setgid is shown at position 6 as 's' (with execute) or 'S' (without execute)
+  const setgid = permissionString[6] === 's' || permissionString[6] === 'S';
+
   // Sticky bit is shown at position 9 as 't' (with execute) or 'T' (without execute)
   const stickyBit = permissionString[9] === 't' || permissionString[9] === 'T';
 
@@ -250,6 +253,7 @@ const parsePermissions = (permissionString: string) => {
     owner: { read: ownerRead, write: ownerWrite, execute: ownerExecute },
     group: { read: groupRead, write: groupWrite, execute: groupExecute },
     others: { read: othersRead, write: othersWrite, execute: othersExecute },
+    setgid,
     stickyBit
   };
 };

--- a/tests/test_filestore.py
+++ b/tests/test_filestore.py
@@ -200,6 +200,26 @@ def test_change_file_permissions(filestore, test_dir):
     assert stat.S_IMODE(os.stat(fullpath).st_mode) == 0o644
 
 
+def test_change_file_permissions_with_execute(filestore, test_dir):
+    filestore.change_file_permissions("test.txt", "-rwxr-xr-x")
+    fullpath = os.path.join(test_dir, "test.txt")
+    assert stat.S_IMODE(os.stat(fullpath).st_mode) == 0o755
+
+
+def test_change_dir_permissions_with_sticky_bit(filestore, test_dir):
+    subdir = os.path.join(test_dir, "sticky_dir")
+    os.makedirs(subdir, exist_ok=True)
+    filestore.change_file_permissions("sticky_dir", "drwxrwxrwt")
+    assert stat.S_IMODE(os.stat(subdir).st_mode) == 0o1777
+
+
+def test_change_dir_permissions_sticky_without_execute(filestore, test_dir):
+    subdir = os.path.join(test_dir, "sticky_dir2")
+    os.makedirs(subdir, exist_ok=True)
+    filestore.change_file_permissions("sticky_dir2", "drwxrwxrwT")
+    assert stat.S_IMODE(os.stat(subdir).st_mode) == 0o1776
+
+
 def test_change_file_permissions_invalid_permissions(filestore):
     with pytest.raises(ValueError):
         filestore.change_file_permissions("test.txt", "invalid")


### PR DESCRIPTION
Clickup id: 86ah03cn7

This PR allows the user to change the execute permissions on files and folders from the properties drawer. It also adds the ability to change the "sticky bit" permission - whether only the owner can rename or delete files in a directory. The latter is displayed in a new table under the main permissions table in the properties drawer and can be changed via a new checkbox in the ChangePermissions dialog, for directories only.

@krokicki 