### PR TITLE
feat: show hint when zone search results are hidden by group filter

### DIFF
--- a/frontend/src/components/ui/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/ui/Sidebar/Sidebar.tsx
@@ -14,7 +14,8 @@ export default function Sidebar() {
     filteredZonesMap,
     filteredZoneFavorites,
     filteredFileSharePathFavorites,
-    filteredFolderFavorites
+    filteredFolderFavorites,
+    hasResultsOutsideGroups
   } = useFilteredZonesAndFavorites();
 
   return (
@@ -54,6 +55,7 @@ export default function Sidebar() {
         />
         <ZonesBrowser
           filteredZonesMap={filteredZonesMap}
+          hasResultsOutsideGroups={hasResultsOutsideGroups}
           searchQuery={searchQuery}
         />
       </div>

--- a/frontend/src/components/ui/Sidebar/ZonesBrowser.tsx
+++ b/frontend/src/components/ui/Sidebar/ZonesBrowser.tsx
@@ -1,6 +1,7 @@
 import { Collapse, Typography, List } from '@material-tailwind/react';
 import { HiChevronRight } from 'react-icons/hi';
 import { HiSquares2X2 } from 'react-icons/hi2';
+import toast from 'react-hot-toast';
 
 import { ZonesAndFileSharePathsMap } from '@/shared.types';
 import { useZoneAndFspMapContext } from '@/contexts/ZonesAndFspMapContext';
@@ -12,13 +13,15 @@ import { Link } from 'react-router';
 
 export default function ZonesBrowser({
   searchQuery,
-  filteredZonesMap
+  filteredZonesMap,
+  hasResultsOutsideGroups
 }: {
   readonly searchQuery: string;
   readonly filteredZonesMap: ZonesAndFileSharePathsMap;
+  readonly hasResultsOutsideGroups: boolean;
 }) {
   const { zonesAndFspQuery } = useZoneAndFspMapContext();
-  const { isFilteredByGroups } = usePreferencesContext();
+  const { isFilteredByGroups, toggleFilterByGroups } = usePreferencesContext();
   const { openZones, toggleOpenZones } = useOpenZones();
 
   const displayZones: ZonesAndFileSharePathsMap =
@@ -65,11 +68,45 @@ export default function ZonesBrowser({
             Object.keys(displayZones).length === 0 ? (
               <div className="px-4 py-6 text-center">
                 <Typography className="text-sm text-foreground/60">
-                  No zones match your filter '{searchQuery}'
+                  No zones match your filter &apos;{searchQuery}&apos;
                 </Typography>
-                <Typography className="text-xs text-foreground/60 mt-1">
-                  Try broadening your search to see more results
-                </Typography>
+                {hasResultsOutsideGroups ? (
+                  <div className="mt-3 px-2 py-3 bg-surface rounded-md text-left">
+                    <Typography className="text-xs text-foreground/70">
+                      Results exist in Zones outside your groups.
+                    </Typography>
+                    <Typography className="text-xs text-foreground mt-2">
+                      Change your zone display preferences to view:
+                    </Typography>
+                    <div className="flex items-center gap-2 mt-2">
+                      <input
+                        checked={isFilteredByGroups}
+                        className="icon-small checked:accent-secondary-light dark:checked:accent-secondary"
+                        id="sidebar_is_filtered_by_groups"
+                        onChange={async () => {
+                          const result = await toggleFilterByGroups();
+                          if (result.success) {
+                            toast.success('All Zones are now visible');
+                          } else {
+                            toast.error(result.error);
+                          }
+                        }}
+                        type="checkbox"
+                      />
+                      <Typography
+                        as="label"
+                        className="text-xs text-foreground"
+                        htmlFor="sidebar_is_filtered_by_groups"
+                      >
+                        Display Zones for your groups only
+                      </Typography>
+                    </div>
+                  </div>
+                ) : (
+                  <Typography className="text-xs text-foreground/60 mt-1">
+                    Try broadening your search to see more results
+                  </Typography>
+                )}
               </div>
             ) : (
               Object.entries(displayZones).map(([key, value]) => {

--- a/frontend/src/hooks/useFilteredZonesAndFavorites.ts
+++ b/frontend/src/hooks/useFilteredZonesAndFavorites.ts
@@ -35,11 +35,14 @@ export default function useSearchFilter() {
   const [filteredFolderFavorites, setFilteredFolderFavorites] = useState<
     FolderFavorite[]
   >([]);
+  const [hasResultsOutsideGroups, setHasResultsOutsideGroups] =
+    useState<boolean>(false);
 
   const filterZonesMap = useCallback(
     (query: string) => {
       if (!zonesAndFspQuery.isSuccess) {
         setFilteredZonesMap({});
+        setHasResultsOutsideGroups(false);
         return;
       }
 
@@ -92,7 +95,28 @@ export default function useSearchFilter() {
         })
         .filter(Boolean); // Remove null entries
 
-      setFilteredZonesMap(Object.fromEntries(matches as [string, Zone][]));
+      const filteredResult = Object.fromEntries(matches as [string, Zone][]);
+      setFilteredZonesMap(filteredResult);
+
+      // Check if there would be results without group filtering
+      if (isFilteredByGroups && Object.keys(filteredResult).length === 0) {
+        const unfilteredMatches = Object.entries(zonesAndFspQuery.data).some(
+          ([key, value]) => {
+            if (key.startsWith('zone')) {
+              const zone = value as Zone;
+              const zoneNameMatches = zone.name.toLowerCase().includes(query);
+              const hasMatchingFsps = zone.fileSharePaths.some(fsp =>
+                fsp.name.toLowerCase().includes(query)
+              );
+              return zoneNameMatches || hasMatchingFsps;
+            }
+            return false;
+          }
+        );
+        setHasResultsOutsideGroups(unfilteredMatches);
+      } else {
+        setHasResultsOutsideGroups(false);
+      }
     },
     [zonesAndFspQuery, isFilteredByGroups, profile]
   );
@@ -147,6 +171,7 @@ export default function useSearchFilter() {
       filterAllFavorites(searchQuery);
     } else if (searchQuery === '' && isFilteredByGroups && profile?.groups) {
       // When search query is empty but group filtering is enabled, apply group filter
+      setHasResultsOutsideGroups(false);
       if (!zonesAndFspQuery.isSuccess) {
         setFilteredZonesMap({});
         setFilteredZoneFavorites([]);
@@ -189,6 +214,7 @@ export default function useSearchFilter() {
       setFilteredZoneFavorites([]);
       setFilteredFileSharePathFavorites([]);
       setFilteredFolderFavorites([]);
+      setHasResultsOutsideGroups(false);
     }
   }, [
     searchQuery,
@@ -208,6 +234,7 @@ export default function useSearchFilter() {
     filteredZoneFavorites,
     filteredFileSharePathFavorites,
     filteredFolderFavorites,
+    hasResultsOutsideGroups,
     handleSearchChange,
     clearSearch
   };


### PR DESCRIPTION
Clickup id: 86ae0w708

This PR adds a hint to the sidebar that appears when: 1. the user has the "display only Zones in your groups" preference turned on and 2. they enter a search value that has no results for Zones in their groups but it _does_ have results for Zones outside their groups. The hint indicates this, and also provides the option to toggle their display preferences directly from the sidebar. If they do this, the Zone results from outside their groups become immediately visible in the sidebar.

Screenshot:

<img width="380" height="551" alt="Screenshot 2026-04-30 at 1 17 30 PM" src="https://github.com/user-attachments/assets/fa7ff2b3-7c5f-4479-9862-05873b1575b5" />
