### PR TITLE
fix: use latest zarrita release with bug fix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,7 @@
                 "react-syntax-highlighter": "^16.1.0",
                 "shepherd.js": "^14.5.1",
                 "tailwindcss": "^3.4.17",
-                "zarrita": "^0.5.1"
+                "zarrita": "^0.7.3"
             },
             "devDependencies": {
                 "@eslint/css": "^0.8.1",
@@ -2440,13 +2440,13 @@
             }
         },
         "node_modules/@zarrita/storage": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.3.tgz",
-            "integrity": "sha512-ZyCMYN3LuCNtKxro9876r/KyHyXV+ie2Bhk1qYsJR4Jp+sAjoVRRNNSJPsJxk64ZgFFezayO5S2hCu88/1Odwg==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
+            "integrity": "sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==",
             "license": "MIT",
             "dependencies": {
                 "reference-spec-reader": "^0.2.0",
-                "unzipit": "^1.4.3"
+                "unzipit": "2.0.0"
             }
         },
         "node_modules/acorn": {
@@ -8073,6 +8073,38 @@
                 "zarrita": "^0.5.0"
             }
         },
+        "node_modules/ome-zarr.js/node_modules/@zarrita/storage": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.4.tgz",
+            "integrity": "sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==",
+            "license": "MIT",
+            "dependencies": {
+                "reference-spec-reader": "^0.2.0",
+                "unzipit": "1.4.3"
+            }
+        },
+        "node_modules/ome-zarr.js/node_modules/unzipit": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+            "license": "MIT",
+            "dependencies": {
+                "uzip-module": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/ome-zarr.js/node_modules/zarrita": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.4.tgz",
+            "integrity": "sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==",
+            "license": "MIT",
+            "dependencies": {
+                "@zarrita/storage": "^0.1.3",
+                "numcodecs": "^0.3.2"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10540,15 +10572,12 @@
             }
         },
         "node_modules/unzipit": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
-            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
+            "integrity": "sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==",
             "license": "MIT",
-            "dependencies": {
-                "uzip-module": "^1.0.2"
-            },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -11265,12 +11294,12 @@
             }
         },
         "node_modules/zarrita": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.4.tgz",
-            "integrity": "sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.3.tgz",
+            "integrity": "sha512-wChTQ1Ox75INoQCzKAfLWAfB70JJ4KjdW8Sz5x4ZWrFB4Dw+YZdnxHTL0xSdsrB9EmKSeK7fS1Y+I2ibhfGbkw==",
             "license": "MIT",
             "dependencies": {
-                "@zarrita/storage": "^0.1.3",
+                "@zarrita/storage": "^0.2.0",
                 "numcodecs": "^0.3.2"
             }
         },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.8.1-a0",
+    "version": "2.8.1-a1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.8.1-a0",
+            "version": "2.8.1-a1",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.8.0",
+    "version": "2.8.1-a0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.8.0",
+            "version": "2.8.1-a0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@material-tailwind/react": "^3.0.0-beta.24",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8073,38 +8073,6 @@
                 "zarrita": "^0.5.0"
             }
         },
-        "node_modules/ome-zarr.js/node_modules/@zarrita/storage": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.4.tgz",
-            "integrity": "sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==",
-            "license": "MIT",
-            "dependencies": {
-                "reference-spec-reader": "^0.2.0",
-                "unzipit": "1.4.3"
-            }
-        },
-        "node_modules/ome-zarr.js/node_modules/unzipit": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
-            "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
-            "license": "MIT",
-            "dependencies": {
-                "uzip-module": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/ome-zarr.js/node_modules/zarrita": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.4.tgz",
-            "integrity": "sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==",
-            "license": "MIT",
-            "dependencies": {
-                "@zarrita/storage": "^0.1.3",
-                "numcodecs": "^0.3.2"
-            }
-        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10668,12 +10636,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "license": "MIT"
-        },
-        "node_modules/uzip-module": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
-            "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==",
             "license": "MIT"
         },
         "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
         "react-syntax-highlighter": "^16.1.0",
         "shepherd.js": "^14.5.1",
         "tailwindcss": "^3.4.17",
-        "zarrita": "^0.5.1"
+        "zarrita": "^0.7.3"
     },
     "devDependencies": {
         "@eslint/css": "^0.8.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.8.0",
+    "version": "2.8.1-a0",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.8.1-a0",
+    "version": "2.8.1-a1",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,8 @@
     },
     "overrides": {
         "qs": ">=6.14.1",
-        "vite": "npm:rolldown-vite@latest"
+        "vite": "npm:rolldown-vite@latest",
+        "zarrita": "^0.7.3"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
This PR bumps the zarrita dependency to 0.7.3 or higher. The [0.7.3 release](https://github.com/manzt/zarrita.js/releases/tag/zarrita%400.7.3) fixed a [bug](https://github.com/manzt/zarrita.js/issues/424) where a checksum byte length of 4 was hardcoded into the zarrita sharding codec, resulting in unreadable data when a sharded array's `index_codecs` did not include a checksum.
@krokicki 