### PR TITLE
fix: reflect request origin in CORS responses instead of wildcard

### DIFF
--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -460,11 +460,15 @@ def create_app(settings):
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        # Use allow_origin_regex instead of allow_origins=["*"] so Starlette
+        # reflects the specific request origin rather than returning "*".
+        # This is required because allow_credentials=True + "Access-Control-Allow-Origin: *"
+        # causes browsers to block responses even for non-credentialed requests.
+        allow_origin_regex=r".*",
         allow_credentials=True,
         allow_methods=["GET","HEAD","POST","PUT","PATCH","DELETE"],
         allow_headers=["*"],
-        expose_headers=["Range", "Content-Range"],
+        expose_headers=["Range", "Content-Range", "Accept-Ranges", "Content-Length"],
     )
 
 


### PR DESCRIPTION
## Summary

- Replace `allow_origins=["*"]` with `allow_origin_regex=r".*"` in the Starlette `CORSMiddleware` so the server reflects the specific request origin instead of returning `*`
- Add `Accept-Ranges` and `Content-Length` to `expose_headers`

## Problem

Starlette 0.48 sends `Access-Control-Allow-Origin: *` combined with `Access-Control-Allow-Credentials: true` when `allow_origins=["*"]` is configured. Browsers reject this combination even for non-credentialed requests (e.g. HTTP Range reads from a cross-origin viewer).

This means any client served from a different origin — such as [zipglancer](https://github.com/JaneliaSciComp/zipglancer), a companion viewer for ZIP/OME-Zarr archives — cannot make range requests to fileglancer's `/files/` shared path endpoint.

## Fix

`allow_origin_regex=r".*"` causes Starlette to reflect the actual request origin in `Access-Control-Allow-Origin`, which is valid alongside `Allow-Credentials: true` and accepted by all browsers.

The additional exposed headers (`Accept-Ranges`, `Content-Length`) allow cross-origin clients to read range-request metadata directly without workarounds.

## Test plan

- [ ] Run `pixi run node-install && pixi run node-eslint-check` — passes (0 errors)
- [ ] Open fileglancer and create a data link to a `.zip` or `.ozx` file
- [ ] Open the data link URL from a cross-origin client (e.g. zipglancer at `https://janeliascicomp.github.io/zipglancer/`) and confirm the archive loads without CORS errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)