### PR TITLE
Pyright-driven cleanup

### DIFF
--- a/fileglancer/alembic/env.py
+++ b/fileglancer/alembic/env.py
@@ -84,7 +84,7 @@ def run_migrations_online() -> None:
 
     """
     # Override the sqlalchemy.url from the alembic.ini file
-    configuration = config.get_section(config.config_ini_section)
+    configuration = config.get_section(config.config_ini_section) or {}
     configuration['sqlalchemy.url'] = get_database_url()
 
     connectable = engine_from_config(

--- a/fileglancer/apps/adapters.py
+++ b/fileglancer/apps/adapters.py
@@ -9,8 +9,8 @@ To add a new adapter:
   3. Register it by adding an instance to the MANIFEST_ADAPTERS list below
 """
 
-from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Protocol
 
 from fileglancer.model import AppManifest
 
@@ -18,19 +18,19 @@ from fileglancer.apps.nextflow import NextflowAdapter
 from fileglancer.apps.pixi import PixiAdapter
 
 
-class ManifestAdapter(ABC):
+class ManifestAdapter(Protocol):
     """Base class for converting project-specific config files into an AppManifest."""
 
-    @abstractmethod
     def can_handle(self, directory: Path) -> bool:
         """Return True if this adapter can generate a manifest for the given directory."""
+        ...
 
-    @abstractmethod
     def convert(self, directory: Path) -> AppManifest:
         """Convert the project config in the given directory to an AppManifest.
 
         Only called when can_handle() returned True.
         """
+        ...
 
 
 # ---------------------------------------------------------------------------

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -764,7 +764,7 @@ def build_command(entry_point: AppEntryPoint, parameters: dict, session=None) ->
         validated = _validate_parameter_value(p, value, session=session)
         if p.type == "boolean":
             if value is True:
-                parts.append(param.flag)
+                parts.append(p.flag)
         else:
             parts.append(f"{p.flag} {shlex.quote(validated)}")
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -25,6 +25,7 @@ from fileglancer.platform_compat import (
     FileLockUnavailable,
     effective_uid,
     effective_user_home,
+    process_is_alive,
     user_home,
 )
 from fileglancer.settings import get_settings
@@ -1077,9 +1078,7 @@ def _poll_local_jobs(session, jobs_to_poll: list) -> bool:
             continue
 
         old_status = db_job.status
-        try:
-            os.kill(pid, 0)
-            # Process is still alive
+        if process_is_alive(pid):
             still_active = True
             if old_status == "PENDING":
                 db.update_job_status(
@@ -1089,7 +1088,7 @@ def _poll_local_jobs(session, jobs_to_poll: list) -> bool:
                     started_at=datetime.now(UTC),
                 )
                 logger.info(f"Job {db_job.id} status updated: PENDING -> RUNNING")
-        except ProcessLookupError:
+        else:
             # Process has exited — read exit code from the trap file
             exit_code = _read_exit_code(work_dir)
             new_status = "DONE" if exit_code == 0 else "FAILED"
@@ -1103,17 +1102,6 @@ def _poll_local_jobs(session, jobs_to_poll: list) -> bool:
                 started_at=now if old_status == "PENDING" else None,
             )
             logger.info(f"Job {db_job.id} status updated: {old_status} -> {new_status}")
-        except PermissionError:
-            # Process exists but owned by another user — still running
-            still_active = True
-            if old_status == "PENDING":
-                db.update_job_status(
-                    session,
-                    db_job.id,
-                    "RUNNING",
-                    started_at=datetime.now(UTC),
-                )
-                logger.info(f"Job {db_job.id} status updated: PENDING -> RUNNING")
 
     return still_active
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -1,36 +1,33 @@
 """Apps module for fetching manifests, building commands, and managing cluster jobs."""
 
 import asyncio
-try:
-    import fcntl
-except ImportError:
-    fcntl = None  # type: ignore[assignment]
-try:
-    import pwd
-except ImportError:
-    pwd = None  # type: ignore[assignment]
 import os
 import re
 import shlex
 import shutil
 import subprocess
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
-from datetime import datetime, UTC
-from typing import Optional
+from typing import Any, Optional
 
 import yaml
+from cluster_api import ResourceSpec
 from loguru import logger
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from cluster_api import ResourceSpec
-
 from fileglancer import database as db
 from fileglancer.apps.adapters import try_adapt
-from fileglancer.model import AppManifest, AppEntryPoint, AppParameter
+from fileglancer.model import AppEntryPoint, AppManifest, AppParameter
+from fileglancer.platform_compat import (
+    FileLock,
+    FileLockUnavailable,
+    effective_uid,
+    effective_user_home,
+    user_home,
+)
 from fileglancer.settings import get_settings
-
 
 # Registered by server.py at startup. Dispatches an action to the per-user
 # persistent worker (or in-process in dev mode). Signature mirrors
@@ -54,13 +51,12 @@ async def _dispatch(username: str, action: str, **kwargs) -> dict:
 
 _MANIFEST_FILENAME = "runnables.yaml"
 
+
 def _repo_cache_base(username: str | None = None) -> Path:
     """Return the repo cache base directory, optionally for a specific user."""
-    if username:
-        home = os.path.expanduser(f"~{username}")
-    else:
-        home = os.path.expanduser("~")
-    return Path(home) / ".fileglancer" / "apps"
+    return Path(user_home(username)) / ".fileglancer" / "apps"
+
+
 _repo_locks: dict[str, asyncio.Lock] = {}
 
 
@@ -135,7 +131,11 @@ async def _resolve_default_branch(clone_url: str) -> str:
     try:
         proc = await asyncio.wait_for(
             asyncio.create_subprocess_exec(
-                "git", "ls-remote", "--symref", clone_url, "HEAD",
+                "git",
+                "ls-remote",
+                "--symref",
+                clone_url,
+                "HEAD",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
@@ -154,8 +154,9 @@ async def _resolve_default_branch(clone_url: str) -> str:
     return "main"
 
 
-async def _ensure_repo_cache(url: str, pull: bool = False,
-                             username: str | None = None) -> Path:
+async def _ensure_repo_cache(
+    url: str, pull: bool = False, username: str | None = None
+) -> Path:
     """Clone or update the GitHub repo in per-user cache. Returns repo path.
 
     Cache is keyed by owner/repo/branch to avoid checkout races between branches.
@@ -179,7 +180,7 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
             return Path(result["repo_dir"])
 
     # Running as the current user (worker subprocess or dev mode)
-    logger.debug(f"ensure_repo running in-process as euid={os.geteuid()}")
+    logger.debug(f"ensure_repo running in-process as euid={effective_uid()}")
     cache_base = _repo_cache_base()
     repo_dir = (cache_base / owner / repo / branch).resolve()
     repo_dir.relative_to(cache_base.resolve())
@@ -191,7 +192,9 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
             if pull:
                 logger.info(f"Pulling latest for {owner}/{repo} ({branch})")
                 await _run_git(["git", "-C", str(repo_dir), "fetch", "origin", branch])
-                await _run_git(["git", "-C", str(repo_dir), "reset", "--hard", f"origin/{branch}"])
+                await _run_git(
+                    ["git", "-C", str(repo_dir), "reset", "--hard", f"origin/{branch}"]
+                )
         else:
             logger.info(f"Cloning {owner}/{repo} ({branch}) into {repo_dir}")
             repo_dir.parent.mkdir(parents=True, exist_ok=True)
@@ -203,7 +206,7 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
     return repo_dir
 
 
-_SKIP_DIRS = {'.git', 'node_modules', '__pycache__', '.pixi', '.venv', 'venv'}
+_SKIP_DIRS = {".git", "node_modules", "__pycache__", ".pixi", ".venv", "venv"}
 
 
 def _read_manifest_file(manifest_dir: Path) -> AppManifest:
@@ -278,8 +281,9 @@ def _find_manifests_in_repo(repo_dir: Path) -> list[tuple[str, AppManifest]]:
 MANIFEST_FILENAME = _MANIFEST_FILENAME
 
 
-async def discover_app_manifests(url: str,
-                                 username: str | None = None) -> list[tuple[str, AppManifest]]:
+async def discover_app_manifests(
+    url: str, username: str | None = None
+) -> list[tuple[str, AppManifest]]:
     """Clone/pull a GitHub repo and discover all manifest files.
 
     Returns a list of (relative_dir_path, AppManifest) tuples.
@@ -299,8 +303,9 @@ async def discover_app_manifests(url: str,
     return _find_manifests_in_repo(repo_dir)
 
 
-async def fetch_app_manifest(url: str, manifest_path: str = "",
-                             username: str | None = None) -> AppManifest:
+async def fetch_app_manifest(
+    url: str, manifest_path: str = "", username: str | None = None
+) -> AppManifest:
     """Fetch and validate an app manifest from a cloned repo.
 
     Clones the repo if needed, then reads the manifest from disk.
@@ -309,7 +314,9 @@ async def fetch_app_manifest(url: str, manifest_path: str = "",
     running as the target user.
     """
     if username:
-        result = await _dispatch(username, "read_manifest", url=url, manifest_path=manifest_path)
+        result = await _dispatch(
+            username, "read_manifest", url=url, manifest_path=manifest_path
+        )
         return AppManifest(**result["manifest"])
 
     repo_dir = await _ensure_repo_cache(url)
@@ -317,8 +324,9 @@ async def fetch_app_manifest(url: str, manifest_path: str = "",
     return _read_manifest_file(target_dir)
 
 
-async def get_or_load_manifest(username: str, url: str,
-                                manifest_path: str = "") -> AppManifest:
+async def get_or_load_manifest(
+    username: str, url: str, manifest_path: str = ""
+) -> AppManifest:
     """Return the manifest for an app, preferring the DB cache.
 
     Hot path: a single SELECT plus model_validate — no disk I/O,
@@ -353,9 +361,12 @@ async def get_or_load_manifest(username: str, url: str,
         branch = await get_app_branch(url)
         with db.get_db_session(settings.db_url) as session:
             db.upsert_user_app(
-                session, username,
-                url=url, manifest_path=manifest_path,
-                name=manifest.name, description=manifest.description,
+                session,
+                username,
+                url=url,
+                manifest_path=manifest_path,
+                name=manifest.name,
+                description=manifest.description,
                 branch=branch,
                 manifest=manifest.model_dump(mode="json"),
                 bump_updated_at=False,
@@ -364,10 +375,9 @@ async def get_or_load_manifest(username: str, url: str,
     return manifest
 
 
-async def refresh_cached_manifest(username: str, url: str,
-                                   manifest_path: str = "",
-                                   bump_updated_at: bool = False
-                                   ) -> tuple[AppManifest, str]:
+async def refresh_cached_manifest(
+    username: str, url: str, manifest_path: str = "", bump_updated_at: bool = False
+) -> tuple[AppManifest, str]:
     """Re-read the manifest from disk and sync the cache.
 
     Call this after any operation that mutates the on-disk YAML
@@ -386,9 +396,12 @@ async def refresh_cached_manifest(username: str, url: str,
     with db.get_db_session(settings.db_url) as session:
         if db.get_user_app(session, username, url, manifest_path) is not None:
             db.upsert_user_app(
-                session, username,
-                url=url, manifest_path=manifest_path,
-                name=manifest.name, description=manifest.description,
+                session,
+                username,
+                url=url,
+                manifest_path=manifest_path,
+                name=manifest.name,
+                description=manifest.description,
                 branch=branch,
                 manifest=manifest.model_dump(mode="json"),
                 bump_updated_at=bump_updated_at,
@@ -471,8 +484,10 @@ def merge_requirements(
 
     # Keep manifest requirements that aren't overridden by entry-point
     merged = [
-        req for req in manifest_requirements
-        if _REQ_PATTERN.match(req.strip()) and _REQ_PATTERN.match(req.strip()).group(1) not in ep_tools
+        req
+        for req in manifest_requirements
+        if (m := _REQ_PATTERN.match(req.strip())) is not None
+        and m.group(1) not in ep_tools
     ]
     merged.extend(entry_point_requirements)
     return merged
@@ -515,13 +530,17 @@ def verify_requirements(requirements: list[str]):
         if version_spec:
             registry_entry = _TOOL_REGISTRY.get(tool)
             if not registry_entry:
-                errors.append(f"Cannot check version for '{tool}': no version command configured")
+                errors.append(
+                    f"Cannot check version for '{tool}': no version command configured"
+                )
                 continue
 
             try:
                 result = subprocess.run(
                     registry_entry["version_args"],
-                    capture_output=True, text=True, timeout=10,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
                     env=env,
                 )
                 output = result.stdout.strip() or result.stderr.strip()
@@ -550,8 +569,8 @@ def verify_requirements(requirements: list[str]):
 # --- Path Validation ---
 
 # Characters that are dangerous in shell commands
-_SHELL_METACHAR_PATTERN = re.compile(r'[;&|`$(){}!<>\n\r]')
-_WINDOWS_DRIVE_PATTERN = re.compile(r'^[a-zA-Z]:/')
+_SHELL_METACHAR_PATTERN = re.compile(r"[;&|`$(){}!<>\n\r]")
+_WINDOWS_DRIVE_PATTERN = re.compile(r"^[a-zA-Z]:/")
 
 
 def validate_path_for_shell(path_value: str) -> str | None:
@@ -573,8 +592,12 @@ def validate_path_for_shell(path_value: str) -> str | None:
     if ".." in normalized:
         return "Path must not contain '..'"
 
-    if not (normalized.startswith("/") or normalized.startswith("~") or normalized.startswith("./")
-            or _WINDOWS_DRIVE_PATTERN.match(normalized)):
+    if not (
+        normalized.startswith("/")
+        or normalized.startswith("~")
+        or normalized.startswith("./")
+        or _WINDOWS_DRIVE_PATTERN.match(normalized)
+    ):
         return "Must be an absolute or relative path (starting with /, ~, or ./)"
 
     return None
@@ -596,13 +619,16 @@ def validate_path_in_filestore(path_value: str, fsps: list) -> str | None:
 
     # Relative paths and cloud storage URIs are not local filesystem paths;
     # skip filestore validation.
-    if normalized.startswith("./") or normalized.startswith(("s3://", "gs://", "https://")):
+    if normalized.startswith("./") or normalized.startswith(
+        ("s3://", "gs://", "https://")
+    ):
         return None
 
     expanded = os.path.expanduser(normalized)
 
     # Resolve to a file share path
     from fileglancer.database import find_fsp_in_paths
+
     result = find_fsp_in_paths(fsps, expanded)
     if result is None:
         return "Path is not within an allowed file share"
@@ -610,6 +636,7 @@ def validate_path_in_filestore(path_value: str, fsps: list) -> str | None:
     fsp, subpath = result
 
     from fileglancer.filestore import Filestore
+
     filestore = Filestore(fsp)
     return filestore.validate_path(subpath)
 
@@ -617,7 +644,7 @@ def validate_path_in_filestore(path_value: str, fsps: list) -> str | None:
 # --- Command Building ---
 
 # Valid environment variable name
-_ENV_VAR_NAME_PATTERN = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+_ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _validate_parameter_value(param: AppParameter, value, session=None) -> str:
@@ -671,10 +698,7 @@ def _validate_parameter_value(param: AppParameter, value, session=None) -> str:
         # where the shell would not perform tilde expansion.
         # Use euid so this works when the server runs as root with seteuid.
         if str_val.startswith("~/") or str_val == "~":
-            try:
-                home = pwd.getpwuid(os.geteuid()).pw_dir
-            except (AttributeError, KeyError):
-                home = os.path.expanduser("~")
+            home = effective_user_home()
             home = home.replace("\\", "/")
             str_val = home + str_val[1:]
         if session is not None:
@@ -687,7 +711,9 @@ def _validate_parameter_value(param: AppParameter, value, session=None) -> str:
 
     if param.type == "string" and param.pattern:
         if not re.fullmatch(param.pattern, str_val):
-            raise ValueError(f"Parameter '{param.name}' does not match required pattern")
+            raise ValueError(
+                f"Parameter '{param.name}' does not match required pattern"
+            )
 
     return str_val
 
@@ -718,7 +744,7 @@ def build_command(entry_point: AppEntryPoint, parameters: dict, session=None) ->
             raise ValueError(f"Unknown parameter '{param_key}'")
 
     # Compute effective values: user-provided merged with defaults
-    effective: dict[str, tuple[AppParameter, any]] = {}
+    effective: dict[str, tuple[AppParameter, Any]] = {}
     for param in flat_params:
         if param.key in parameters:
             effective[param.key] = (param, parameters[param.key])
@@ -738,7 +764,7 @@ def build_command(entry_point: AppEntryPoint, parameters: dict, session=None) ->
         validated = _validate_parameter_value(p, value, session=session)
         if p.type == "boolean":
             if value is True:
-                parts.append(p.flag)
+                parts.append(param.flag)
         else:
             parts.append(f"{p.flag} {shlex.quote(validated)}")
 
@@ -789,12 +815,10 @@ async def start_job_monitor():
 
     # Only one worker should reconnect at startup — use the same lock.
     try:
-        with open(_POLL_LOCK_PATH, "w") as f:
-            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with FileLock(_POLL_LOCK_PATH):
             await _reconnect_as_any_user(settings)
-            fcntl.flock(f, fcntl.LOCK_UN)
         logger.info("Job monitor started (reconnected existing jobs)")
-    except OSError:
+    except FileLockUnavailable:
         logger.info("Job monitor started (reconnect handled by another worker)")
 
     # Only start the poll loop if there are already active jobs
@@ -880,9 +904,13 @@ async def _reconnect_as_any_user(settings):
             new_status = info["status"].upper()
             if new_status != db_job.status:
                 is_terminal = new_status in ("DONE", "FAILED", "KILLED")
-                finished_at = _parse_iso_dt(info.get("finish_time")) if is_terminal else None
+                finished_at = (
+                    _parse_iso_dt(info.get("finish_time")) if is_terminal else None
+                )
                 db.update_job_status(
-                    session, db_job.id, new_status,
+                    session,
+                    db_job.id,
+                    new_status,
                     exit_code=info.get("exit_code"),
                     started_at=_parse_iso_dt(info.get("start_time")),
                     finished_at=finished_at,
@@ -904,29 +932,23 @@ async def _poll_loop(settings):
     global _poll_task
 
     while True:
-        lock_fd = None
         try:
-            lock_fd = open(_POLL_LOCK_PATH, "w")
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            try:
-                has_jobs = await _poll_jobs(settings)
-            except Exception:
-                logger.exception("Error in job poll loop")
-                has_jobs = True  # keep polling on error
-            # Hold lock through the sleep so no other worker polls
-            # until this interval is over
-            await asyncio.sleep(settings.cluster.poll_interval)
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            lock_fd.close()
+            with FileLock(_POLL_LOCK_PATH):
+                try:
+                    has_jobs = await _poll_jobs(settings)
+                except Exception:
+                    logger.exception("Error in job poll loop")
+                    has_jobs = True  # keep polling on error
+                # Hold lock through the sleep so no other worker polls
+                # until this interval is over
+                await asyncio.sleep(settings.cluster.poll_interval)
 
             if not has_jobs:
                 logger.info("No active jobs — poll loop stopping")
                 _poll_task = None
                 return
-        except OSError:
+        except FileLockUnavailable:
             # Another worker is polling this cycle — skip and retry
-            if lock_fd:
-                lock_fd.close()
             await asyncio.sleep(settings.cluster.poll_interval)
 
 
@@ -946,10 +968,18 @@ async def _poll_jobs(settings):
         jobs_to_poll = []
         for db_job in active_jobs:
             if not db_job.cluster_job_id:
-                created = db_job.created_at.replace(tzinfo=None) if db_job.created_at.tzinfo else db_job.created_at
-                age_minutes = (datetime.now(UTC).replace(tzinfo=None) - created).total_seconds() / 60
+                created = (
+                    db_job.created_at.replace(tzinfo=None)
+                    if db_job.created_at.tzinfo
+                    else db_job.created_at
+                )
+                age_minutes = (
+                    datetime.now(UTC).replace(tzinfo=None) - created
+                ).total_seconds() / 60
                 if age_minutes > settings.cluster.zombie_timeout_minutes:
-                    db.update_job_status(session, db_job.id, "FAILED", finished_at=datetime.now(UTC))
+                    db.update_job_status(
+                        session, db_job.id, "FAILED", finished_at=datetime.now(UTC)
+                    )
                     logger.warning(
                         f"Job {db_job.id} has no cluster_job_id after "
                         f"{age_minutes:.0f} minutes, marked FAILED"
@@ -973,14 +1003,13 @@ async def _poll_jobs(settings):
         # Pass current known statuses so stubs are seeded correctly.
         # Without this, stubs default to PENDING and jobs whose status
         # bjobs doesn't return would revert to PENDING in the DB.
-        job_statuses = {
-            j.cluster_job_id: j.status for j in jobs_to_poll
-        }
+        job_statuses = {j.cluster_job_id: j.status for j in jobs_to_poll}
 
         cluster_config = settings.cluster.model_dump(exclude_none=True)
         try:
             result = await _dispatch(
-                poll_username, "poll",
+                poll_username,
+                "poll",
                 cluster_config=cluster_config,
                 cluster_job_ids=list(job_statuses.keys()),
                 job_statuses=job_statuses,
@@ -1001,9 +1030,13 @@ async def _poll_jobs(settings):
             if new_status == old_status:
                 continue
             is_terminal = new_status in ("DONE", "FAILED", "KILLED")
-            finished_at = _parse_iso_dt(info.get("finish_time")) if is_terminal else None
+            finished_at = (
+                _parse_iso_dt(info.get("finish_time")) if is_terminal else None
+            )
             db.update_job_status(
-                session, db_job.id, new_status,
+                session,
+                db_job.id,
+                new_status,
                 exit_code=info.get("exit_code") if is_terminal else None,
                 started_at=_parse_iso_dt(info.get("start_time")),
                 finished_at=finished_at,
@@ -1048,7 +1081,9 @@ def _poll_local_jobs(session, jobs_to_poll: list) -> bool:
             still_active = True
             if old_status == "PENDING":
                 db.update_job_status(
-                    session, db_job.id, "RUNNING",
+                    session,
+                    db_job.id,
+                    "RUNNING",
                     started_at=datetime.now(UTC),
                 )
                 logger.info(f"Job {db_job.id} status updated: PENDING -> RUNNING")
@@ -1058,7 +1093,9 @@ def _poll_local_jobs(session, jobs_to_poll: list) -> bool:
             new_status = "DONE" if exit_code == 0 else "FAILED"
             now = datetime.now(UTC)
             db.update_job_status(
-                session, db_job.id, new_status,
+                session,
+                db_job.id,
+                new_status,
                 exit_code=exit_code,
                 finished_at=now,
                 started_at=now if old_status == "PENDING" else None,
@@ -1069,7 +1106,9 @@ def _poll_local_jobs(session, jobs_to_poll: list) -> bool:
             still_active = True
             if old_status == "PENDING":
                 db.update_job_status(
-                    session, db_job.id, "RUNNING",
+                    session,
+                    db_job.id,
+                    "RUNNING",
                     started_at=datetime.now(UTC),
                 )
                 logger.info(f"Job {db_job.id} status updated: PENDING -> RUNNING")
@@ -1100,18 +1139,19 @@ def _parse_iso_dt(s: str | None) -> datetime | None:
 
 # --- Job Submission ---
 
+
 def _sanitize_for_path(s: str) -> str:
     """Sanitize a string for use in a directory name."""
-    return re.sub(r'[^a-zA-Z0-9._-]', '_', s)
+    return re.sub(r"[^a-zA-Z0-9._-]", "_", s)
 
 
-_CONTAINER_SIF_SAFE = re.compile(r'[^a-zA-Z0-9._-]')
+_CONTAINER_SIF_SAFE = re.compile(r"[^a-zA-Z0-9._-]")
 
 
 def _container_sif_name(container_url: str) -> str:
     """Derive a safe SIF filename from a container URL."""
     url = container_url.removeprefix("docker://")
-    return _CONTAINER_SIF_SAFE.sub('_', url) + ".sif"
+    return _CONTAINER_SIF_SAFE.sub("_", url) + ".sif"
 
 
 _DEFAULT_CONTAINER_CACHE_DIR = "$HOME/.fileglancer/apptainer_cache"
@@ -1127,7 +1167,11 @@ def _build_container_script(
 ) -> str:
     """Build shell script for running a command inside an Apptainer container."""
     sif_name = _container_sif_name(container_url)
-    docker_url = container_url if container_url.startswith("docker://") else f"docker://{container_url}"
+    docker_url = (
+        container_url
+        if container_url.startswith("docker://")
+        else f"docker://{container_url}"
+    )
 
     # Deduplicate and sort bind paths
     all_binds = sorted(set([work_dir] + bind_paths))
@@ -1139,21 +1183,25 @@ def _build_container_script(
 
     lines = [
         "# Apptainer container setup",
-        f'APPTAINER_CACHE_DIR={resolved_dir}',
+        f"APPTAINER_CACHE_DIR={resolved_dir}",
         'mkdir -p "$APPTAINER_CACHE_DIR"',
         f'SIF_PATH="$APPTAINER_CACHE_DIR/{sif_name}"',
         'if [ ! -f "$SIF_PATH" ]; then',
         f'  apptainer pull "$SIF_PATH" {shlex.quote(docker_url)}',
-        'fi',
+        "fi",
         f'apptainer exec {bind_flags}{extra} "$SIF_PATH" \\',
-        f'  {command}',
+        f"  {command}",
     ]
     return "\n".join(lines)
 
 
-def _build_work_dir(job_id: int, app_name: str, entry_point_id: str,
-                    job_name_prefix: Optional[str] = None,
-                    username: Optional[str] = None) -> Path:
+def _build_work_dir(
+    job_id: int,
+    app_name: str,
+    entry_point_id: str,
+    job_name_prefix: Optional[str] = None,
+    username: Optional[str] = None,
+) -> Path:
     """Build a working directory path under ~/.fileglancer/jobs/.
 
     When username is provided, expands ~username to the user's home directory
@@ -1221,10 +1269,20 @@ async def submit_job(
     merged_env = dict(entry_point.env or {})
     if env:
         merged_env.update(env)
-    effective_pre_run = pre_run if pre_run is not None else (entry_point.pre_run or None)
-    effective_post_run = post_run if post_run is not None else (entry_point.post_run or None)
-    effective_container = container if container is not None else (entry_point.container or None)
-    effective_container_args = container_args if container_args is not None else (entry_point.container_args or None)
+    effective_pre_run = (
+        pre_run if pre_run is not None else (entry_point.pre_run or None)
+    )
+    effective_post_run = (
+        post_run if post_run is not None else (entry_point.post_run or None)
+    )
+    effective_container = (
+        container if container is not None else (entry_point.container or None)
+    )
+    effective_container_args = (
+        container_args
+        if container_args is not None
+        else (entry_point.container_args or None)
+    )
 
     # Create DB record first to get job ID for the work directory
     resources_dict = None
@@ -1234,7 +1292,9 @@ async def submit_job(
             "memory": resource_spec.memory,
             "walltime": resource_spec.walltime,
             "queue": resource_spec.queue,
-            "extra_args": " ".join(resource_spec.extra_args) if resource_spec.extra_args else None,
+            "extra_args": " ".join(resource_spec.extra_args)
+            if resource_spec.extra_args
+            else None,
         }
 
     with db.get_db_session(settings.db_url) as session:
@@ -1263,21 +1323,27 @@ async def submit_job(
         job_id = db_job.id
 
         # Compute and persist work_dir now that we have the job ID
-        work_dir = _build_work_dir(job_id, manifest.name, entry_point.id,
-                                   job_name_prefix=settings.cluster.job_name_prefix,
-                                   username=username)
+        work_dir = _build_work_dir(
+            job_id,
+            manifest.name,
+            entry_point.id,
+            job_name_prefix=settings.cluster.job_name_prefix,
+            username=username,
+        )
         db_job.work_dir = str(work_dir)
         session.commit()
 
     # Clone/pull repo into the user's cache (~username/.fileglancer/apps).
     if manifest.repo_url and manifest.repo_url != app_url:
-        cached_repo_dir = await _ensure_repo_cache(manifest.repo_url, pull=pull_latest,
-                                                   username=username)
+        cached_repo_dir = await _ensure_repo_cache(
+            manifest.repo_url, pull=pull_latest, username=username
+        )
         cd_suffix = "repo"
         pulled_manifest_repo = False
     else:
-        cached_repo_dir = await _ensure_repo_cache(app_url, pull=pull_latest,
-                                                   username=username)
+        cached_repo_dir = await _ensure_repo_cache(
+            app_url, pull=pull_latest, username=username
+        )
         cd_suffix = f"repo/{manifest_path}" if manifest_path else "repo"
         pulled_manifest_repo = pull_latest
 
@@ -1310,9 +1376,7 @@ async def submit_job(
     # For local executor, trap EXIT to write the exit code to a file so
     # PID-based polling can determine the final status after the process exits.
     if settings.cluster.executor == "local":
-        preamble_lines.append(
-            'trap \'echo $? > "$FG_WORK_DIR/exit_code"\' EXIT'
-        )
+        preamble_lines.append("trap 'echo $? > \"$FG_WORK_DIR/exit_code\"' EXIT")
     if settings.apps.extra_paths:
         path_suffix = os.pathsep.join(shlex.quote(p) for p in settings.apps.extra_paths)
         preamble_lines.append(f"export PATH=$PATH:{path_suffix}")
@@ -1325,7 +1389,7 @@ async def submit_job(
     if entry_point.conda_env:
         conda_activation = (
             'eval "$(conda shell.bash hook)"\n'
-            f'conda activate {shlex.quote(entry_point.conda_env)}'
+            f"conda activate {shlex.quote(entry_point.conda_env)}"
         )
         script_parts.append(conda_activation)
 
@@ -1373,7 +1437,8 @@ async def submit_job(
     cluster_config = settings.cluster.model_dump(exclude_none=True)
     try:
         worker_result = await _dispatch(
-            username, "submit",
+            username,
+            "submit",
             cluster_config=cluster_config,
             command=full_command,
             job_name=job_name,
@@ -1404,10 +1469,14 @@ async def submit_job(
     # Update DB with cluster job ID — the poll loop will track status from here
     with db.get_db_session(settings.db_url) as session:
         db.update_job_status(
-            session, job_id, "PENDING",
+            session,
+            job_id,
+            "PENDING",
             cluster_job_id=cluster_job_id,
         )
         db_job = db.get_job(session, job_id, username)
+        if db_job is None:
+            raise RuntimeError(f"Job {job_id} not found after submission")
         session.expunge(db_job)
 
     ensure_poll_loop()
@@ -1415,7 +1484,9 @@ async def submit_job(
     return db_job
 
 
-def _build_resource_spec(entry_point: AppEntryPoint, overrides: Optional[dict], settings) -> ResourceSpec:
+def _build_resource_spec(
+    entry_point: AppEntryPoint, overrides: Optional[dict], settings
+) -> ResourceSpec:
     """Build a ResourceSpec from entry point defaults, user overrides, and global defaults."""
     cpus = settings.cluster.cpus
     memory = settings.cluster.memory
@@ -1435,7 +1506,9 @@ def _build_resource_spec(entry_point: AppEntryPoint, overrides: Optional[dict], 
 
     # Apply user overrides
     # extra_args default to config values; user overrides replace them entirely
-    extra_args = list(settings.cluster.extra_args) if settings.cluster.extra_args else None
+    extra_args = (
+        list(settings.cluster.extra_args) if settings.cluster.extra_args else None
+    )
     if overrides:
         if overrides.get("cpus") is not None:
             cpus = overrides["cpus"]
@@ -1466,13 +1539,16 @@ async def cancel_job(job_id: int, username: str) -> db.JobDB:
         if db_job is None:
             raise ValueError(f"Job {job_id} not found")
         if db_job.status not in ("PENDING", "RUNNING"):
-            raise ValueError(f"Job {job_id} is not cancellable (status: {db_job.status})")
+            raise ValueError(
+                f"Job {job_id} is not cancellable (status: {db_job.status})"
+            )
 
         # Cancel on cluster as the target user
         if db_job.cluster_job_id:
             cluster_config = settings.cluster.model_dump(exclude_none=True)
             await _dispatch(
-                username, "cancel",
+                username,
+                "cancel",
                 cluster_config=cluster_config,
                 job_id=db_job.cluster_job_id,
             )
@@ -1481,6 +1557,8 @@ async def cancel_job(job_id: int, username: str) -> db.JobDB:
         now = datetime.now(UTC)
         db.update_job_status(session, db_job.id, "KILLED", finished_at=now)
         db_job = db.get_job(session, db_job.id, username)
+        if db_job is None:
+            raise RuntimeError(f"Job {job_id} not found after cancellation")
         session.expunge(db_job)
 
     logger.info(f"Job {job_id} cancelled by user {username}")
@@ -1489,6 +1567,7 @@ async def cancel_job(job_id: int, username: str) -> db.JobDB:
 
 # --- Job File Access ---
 
+
 def _resolve_work_dir(db_job: db.JobDB) -> Path:
     """Resolve a job's work directory to an absolute path."""
     if db_job.work_dir:
@@ -1496,7 +1575,9 @@ def _resolve_work_dir(db_job: db.JobDB) -> Path:
     return _build_work_dir(db_job.id, db_job.app_name, db_job.entry_point_id)
 
 
-def _resolve_browse_path(abs_path: str, fsps: Optional[list] = None) -> tuple[str | None, str | None]:
+def _resolve_browse_path(
+    abs_path: str, fsps: Optional[list] = None
+) -> tuple[str | None, str | None]:
     """Resolve an absolute path to an FSP name and subpath for browse links.
 
     If *fsps* is None, queries the database directly. Pass a pre-fetched list
@@ -1516,7 +1597,9 @@ def _resolve_browse_path(abs_path: str, fsps: Optional[list] = None) -> tuple[st
 
 def _make_file_info(file_path: str, exists: bool, fsps: Optional[list] = None) -> dict:
     """Create a file info dict with browse link resolution."""
-    fsp_name, subpath = _resolve_browse_path(file_path, fsps) if exists else (None, None)
+    fsp_name, subpath = (
+        _resolve_browse_path(file_path, fsps) if exists else (None, None)
+    )
     return {
         "path": file_path,
         "exists": exists,
@@ -1532,9 +1615,9 @@ def get_service_url(db_job: db.JobDB) -> Optional[str]:
     The service writes its URL to a plain text file named 'service_url' in the
     job's work directory.
     """
-    if getattr(db_job, 'entry_point_type', 'job') != 'service':
+    if getattr(db_job, "entry_point_type", "job") != "service":
         return None
-    if db_job.status != 'RUNNING':
+    if db_job.status != "RUNNING":
         return None
 
     work_dir = _resolve_work_dir(db_job)
@@ -1554,7 +1637,9 @@ def get_service_url(db_job: db.JobDB) -> Optional[str]:
     return url
 
 
-def get_job_file_paths(db_job: db.JobDB, fsps: Optional[list] = None) -> dict[str, dict]:
+def get_job_file_paths(
+    db_job: db.JobDB, fsps: Optional[list] = None
+) -> dict[str, dict]:
     """Return file path info for a job's files (script, stdout, stderr, service_url).
 
     Returns a dict keyed by file type with path and existence info. Pass *fsps*
@@ -1576,9 +1661,11 @@ def get_job_file_paths(db_job: db.JobDB, fsps: Optional[list] = None) -> dict[st
     }
 
     # Include service_url file info for service-type jobs
-    if getattr(db_job, 'entry_point_type', 'job') == 'service':
+    if getattr(db_job, "entry_point_type", "job") == "service":
         service_url_path = work_dir / "service_url"
-        files["service_url"] = _make_file_info(str(service_url_path), service_url_path.is_file(), fsps)
+        files["service_url"] = _make_file_info(
+            str(service_url_path), service_url_path.is_file(), fsps
+        )
 
     return files
 

--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -764,7 +764,9 @@ def build_command(entry_point: AppEntryPoint, parameters: dict, session=None) ->
         validated = _validate_parameter_value(p, value, session=session)
         if p.type == "boolean":
             if value is True:
-                parts.append(p.flag)
+                # Use param.flag (not p.flag): the `if param.flag is None`
+                # guard above narrows it to str, satisfying list.append.
+                parts.append(param.flag)
         else:
             parts.append(f"{p.flag} {shlex.quote(validated)}")
 

--- a/fileglancer/apps/nextflow.py
+++ b/fileglancer/apps/nextflow.py
@@ -11,6 +11,7 @@ from fileglancer.model import (
     AppEntryPoint,
     AppManifest,
     AppParameter,
+    AppParameterItem,
     AppParameterSection,
 )
 
@@ -106,7 +107,7 @@ class NextflowAdapter:
         if not ordered_def_keys:
             ordered_def_keys = list(definitions.keys())
 
-        parameters = []
+        parameters: list[AppParameterItem] = []
         for def_key in ordered_def_keys:
             defn = definitions.get(def_key)
             if not defn:
@@ -137,7 +138,7 @@ class NextflowAdapter:
             )
             parameters.append(section)
 
-        env_parameters = [
+        env_parameters: list[AppParameterItem] = [
             AppParameterSection(
                 section="Nextflow",
                 parameters=[

--- a/fileglancer/apps/pixi.py
+++ b/fileglancer/apps/pixi.py
@@ -6,6 +6,7 @@ converting pixi tasks into runnables.
 
 import subprocess
 from pathlib import Path
+from typing import Any
 
 try:
     import tomllib
@@ -16,13 +17,14 @@ from fileglancer.model import (
     AppEntryPoint,
     AppManifest,
     AppParameter,
+    AppParameterItem,
 )
 
 _PIXI_TOML = "pixi.toml"
 _PYPROJECT_TOML = "pyproject.toml"
 
 
-def _read_pixi_config(directory: Path) -> dict | None:
+def _read_pixi_config(directory: Path) -> dict[str, Any] | None:
     """Read pixi configuration from pixi.toml or pyproject.toml.
 
     Returns the pixi config dict (equivalent to the [tool.pixi] section),
@@ -41,15 +43,18 @@ def _read_pixi_config(directory: Path) -> dict | None:
     pyproject_path = directory / _PYPROJECT_TOML
     if pyproject_path.is_file():
         data = tomllib.loads(pyproject_path.read_text())
-        pixi_config = data.get("tool", {}).get("pixi")
-        if pixi_config and "tasks" in pixi_config:
+        tool_config = data.get("tool", {})
+        pixi_config = tool_config.get("pixi") if isinstance(tool_config, dict) else None
+        if isinstance(pixi_config, dict) and "tasks" in pixi_config:
             # Merge top-level [project] metadata into pixi config.
             # [tool.pixi.project] may only have channels/platforms,
             # so fill in missing fields (name, description, version)
             # from the top-level [project] section.
             top_project = data.get("project", {})
-            if top_project:
+            if isinstance(top_project, dict) and top_project:
                 pixi_project = pixi_config.get("project", {})
+                if not isinstance(pixi_project, dict):
+                    pixi_project = {}
                 for key in ("name", "description", "version"):
                     if key not in pixi_project and key in top_project:
                         pixi_project[key] = top_project[key]
@@ -60,27 +65,37 @@ def _read_pixi_config(directory: Path) -> dict | None:
     return None
 
 
-def _collect_tasks(config: dict) -> dict[str, dict]:
+def _collect_tasks(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Collect all tasks from a pixi config, including feature tasks.
 
     Returns a dict of task_name -> task_definition (normalized to dict form).
     """
-    tasks: dict[str, dict] = {}
+    tasks: dict[str, dict[str, Any]] = {}
 
     # Top-level tasks
-    for name, defn in config.get("tasks", {}).items():
-        tasks[name] = _normalize_task(defn)
+    task_config = config.get("tasks", {})
+    if isinstance(task_config, dict):
+        for name, defn in task_config.items():
+            tasks[str(name)] = _normalize_task(defn)
 
     # Feature tasks (e.g. [tool.pixi.feature.test.tasks])
-    for feature_name, feature in config.get("feature", {}).items():
-        for name, defn in feature.get("tasks", {}).items():
-            if name not in tasks:
-                tasks[name] = _normalize_task(defn)
+    feature_config = config.get("feature", {})
+    if isinstance(feature_config, dict):
+        for feature in feature_config.values():
+            if not isinstance(feature, dict):
+                continue
+            feature_tasks = feature.get("tasks", {})
+            if not isinstance(feature_tasks, dict):
+                continue
+            for name, defn in feature_tasks.items():
+                task_name = str(name)
+                if task_name not in tasks:
+                    tasks[task_name] = _normalize_task(defn)
 
     return tasks
 
 
-def _normalize_task(defn) -> dict:
+def _normalize_task(defn: Any) -> dict[str, Any]:
     """Normalize a task definition to dict form.
 
     Tasks can be defined as:
@@ -89,10 +104,12 @@ def _normalize_task(defn) -> dict:
     """
     if isinstance(defn, str):
         return {"cmd": defn}
-    return dict(defn)
+    if isinstance(defn, dict):
+        return dict(defn)
+    return {}
 
 
-def _convert_task_arg(arg) -> AppParameter:
+def _convert_task_arg(arg: Any) -> AppParameter:
     """Convert a pixi task argument to an AppParameter."""
     if isinstance(arg, str):
         # Simple required argument
@@ -103,7 +120,7 @@ def _convert_task_arg(arg) -> AppParameter:
         )
 
     # Dict form with optional default and choices
-    arg_name = arg["arg"]
+    arg_name = str(arg["arg"])
     param_type = "enum" if "choices" in arg else "string"
     kwargs: dict = {
         "name": arg_name.replace("_", " ").title(),
@@ -118,7 +135,7 @@ def _convert_task_arg(arg) -> AppParameter:
     return AppParameter(**kwargs)
 
 
-def _task_to_entry_point(name: str, task: dict) -> AppEntryPoint | None:
+def _task_to_entry_point(name: str, task: dict[str, Any]) -> AppEntryPoint | None:
     """Convert a pixi task dict to an AppEntryPoint.
 
     Returns None for tasks without a command (dependency-only tasks with no
@@ -144,7 +161,7 @@ def _task_to_entry_point(name: str, task: dict) -> AppEntryPoint | None:
     description = task.get("description")
 
     # Convert task arguments to parameters
-    parameters = []
+    parameters: list[AppParameterItem] = []
     args = task.get("args")
     if args:
         for arg in args:
@@ -211,9 +228,12 @@ class PixiAdapter:
 
     def convert(self, directory: Path) -> AppManifest:
         config = _read_pixi_config(directory)
+        if config is None:
+            raise ValueError("No pixi configuration found")
 
         # Extract project metadata
-        project = config.get("project", config.get("workspace", {}))
+        project_config = config.get("project") or config.get("workspace") or {}
+        project = project_config if isinstance(project_config, dict) else {}
         description = project.get("description")
         version = project.get("version")
 

--- a/fileglancer/auth.py
+++ b/fileglancer/auth.py
@@ -52,6 +52,7 @@ def verify_id_token(id_token: str, settings: Settings) -> dict:
         # But we decode to extract claims
         decoded = jwt.decode(
             id_token,
+            key="",
             options={"verify_signature": False}  # authlib already verified it
         )
         return decoded
@@ -87,6 +88,10 @@ def get_session_from_cookie(request: Request, settings: Settings) -> Optional[db
 
         # Check if session secret key has changed (if hash is stored)
         if user_session.session_secret_key_hash:
+            if settings.session_secret_key is None:
+                logger.warning(f"Missing session secret key, revoking session for user {user_session.username}")
+                db.delete_session(session, session_id)
+                return None
             current_key_hash = _hash_session_secret_key(settings.session_secret_key)
             if user_session.session_secret_key_hash != current_key_hash:
                 logger.warning(f"Session secret key changed, revoking session for user {user_session.username}")

--- a/fileglancer/cli.py
+++ b/fileglancer/cli.py
@@ -33,7 +33,7 @@ def run_server_with_interrupt_handler(config, url, cleanup_callback=None):
     def run_server():
         """Run server in thread - this disables signal handlers in the thread"""
         # Disable signal handlers in this thread - they'll be handled in main thread
-        server.install_signal_handlers = lambda: None
+        server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
         server.run()
 
     def handle_interrupt(signum, frame):
@@ -173,7 +173,6 @@ def start(host, port, reload, workers, ssl_keyfile, ssl_certfile,
 
     # Find available port if auto_port is enabled
     if auto_port:
-        import socket
         original_port = port
         max_attempts = 100
         for attempt in range(max_attempts):

--- a/fileglancer/database.py
+++ b/fileglancer/database.py
@@ -5,10 +5,10 @@ import os
 from functools import lru_cache
 
 from sqlalchemy import create_engine, Column, String, Integer, Boolean, DateTime, JSON, UniqueConstraint
-from sqlalchemy.orm import sessionmaker, declarative_base, Session
+from sqlalchemy.orm import Session, DeclarativeBase, Mapped, mapped_column, sessionmaker
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.pool import StaticPool
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Any
 from loguru import logger
 from cachetools import LRUCache
 
@@ -37,7 +37,10 @@ def _get_sharing_key_cache():
         _sharing_key_cache = LRUCache(maxsize=settings.sharing_key_cache_size)
     return _sharing_key_cache
 
-Base = declarative_base()
+class Base(DeclarativeBase):
+    pass
+
+
 class FileSharePathDB(Base):
     """Database model for storing file share paths"""
     __tablename__ = 'file_share_paths'
@@ -141,45 +144,45 @@ class JobDB(Base):
     """Database model for storing cluster jobs"""
     __tablename__ = 'jobs'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    username = Column(String, nullable=False, index=True)
-    cluster_job_id = Column(String, nullable=True, index=True)
-    app_url = Column(String, nullable=False)
-    app_name = Column(String, nullable=False)
-    manifest_path = Column(String, nullable=False, server_default="")
-    entry_point_id = Column(String, nullable=False)
-    entry_point_name = Column(String, nullable=False)
-    entry_point_type = Column(String, nullable=False, server_default="job")
-    parameters = Column(JSON, nullable=False)
-    status = Column(String, nullable=False, default="PENDING")
-    exit_code = Column(Integer, nullable=True)
-    resources = Column(JSON, nullable=True)
-    env = Column(JSON, nullable=True)
-    pre_run = Column(String, nullable=True)
-    post_run = Column(String, nullable=True)
-    container = Column(String, nullable=True)
-    container_args = Column(String, nullable=True)
-    work_dir = Column(String, nullable=True)
-    pull_latest = Column(Boolean, nullable=False, default=False)
-    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
-    started_at = Column(DateTime, nullable=True)
-    finished_at = Column(DateTime, nullable=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    username: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    cluster_job_id: Mapped[Optional[str]] = mapped_column(String, nullable=True, index=True)
+    app_url: Mapped[str] = mapped_column(String, nullable=False)
+    app_name: Mapped[str] = mapped_column(String, nullable=False)
+    manifest_path: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    entry_point_id: Mapped[str] = mapped_column(String, nullable=False)
+    entry_point_name: Mapped[str] = mapped_column(String, nullable=False)
+    entry_point_type: Mapped[str] = mapped_column(String, nullable=False, server_default="job")
+    parameters: Mapped[Any] = mapped_column(JSON, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="PENDING")
+    exit_code: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    resources: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+    env: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+    pre_run: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    post_run: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    container: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    container_args: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    work_dir: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    pull_latest: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    started_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
 
 class UserAppDB(Base):
     """Database model for a user's installed apps with cached manifests."""
     __tablename__ = 'user_apps'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    username = Column(String, nullable=False, index=True)
-    url = Column(String, nullable=False)
-    manifest_path = Column(String, nullable=False, server_default="")
-    name = Column(String, nullable=False)
-    description = Column(String, nullable=True)
-    branch = Column(String, nullable=True)
-    manifest = Column(JSON, nullable=True)
-    added_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
-    updated_at = Column(DateTime, nullable=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    username: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    url: Mapped[str] = mapped_column(String, nullable=False)
+    manifest_path: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    branch: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    manifest: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
+    added_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    updated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     __table_args__ = (
         UniqueConstraint('username', 'url', 'manifest_path', name='uq_user_app'),

--- a/fileglancer/database.py
+++ b/fileglancer/database.py
@@ -4,11 +4,11 @@ from datetime import datetime, timedelta, UTC
 import os
 from functools import lru_cache
 
-from sqlalchemy import create_engine, Column, String, Integer, Boolean, DateTime, JSON, UniqueConstraint
+from sqlalchemy import create_engine, String, Integer, Boolean, DateTime, JSON, UniqueConstraint
 from sqlalchemy.orm import Session, DeclarativeBase, Mapped, mapped_column, sessionmaker
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.pool import StaticPool
-from typing import Optional, Dict, List, Any
+from typing import Callable, Optional, Dict, List, Any, Sequence
 from loguru import logger
 from cachetools import LRUCache
 
@@ -44,44 +44,47 @@ class Base(DeclarativeBase):
 class FileSharePathDB(Base):
     """Database model for storing file share paths"""
     __tablename__ = 'file_share_paths'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String, index=True, unique=True)
-    zone = Column(String)
-    group = Column(String)
-    storage = Column(String)
-    mount_path = Column(String)
-    mac_path = Column(String)
-    windows_path = Column(String)
-    linux_path = Column(String)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String, index=True, unique=True)
+    zone: Mapped[str] = mapped_column(String)
+    group: Mapped[Optional[str]] = mapped_column(String)
+    storage: Mapped[Optional[str]] = mapped_column(String)
+    mount_path: Mapped[str] = mapped_column(String)
+    mac_path: Mapped[Optional[str]] = mapped_column(String)
+    windows_path: Mapped[Optional[str]] = mapped_column(String)
+    linux_path: Mapped[Optional[str]] = mapped_column(String)
 
 
 class ExternalBucketDB(Base):
     """Database model for storing external buckets"""
     __tablename__ = 'external_buckets'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    full_path = Column(String)
-    external_url = Column(String)
-    fsp_name = Column(String, nullable=False)
-    relative_path = Column(String)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    full_path: Mapped[str] = mapped_column(String)
+    external_url: Mapped[str] = mapped_column(String)
+    fsp_name: Mapped[str] = mapped_column(String, nullable=False)
+    relative_path: Mapped[Optional[str]] = mapped_column(String)
 
 
 class LastRefreshDB(Base):
     """Database model for storing the last refresh time of tables"""
     __tablename__ = 'last_refresh'
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    table_name = Column(String, nullable=False, index=True)
-    source_last_updated = Column(DateTime, nullable=False)
-    db_last_updated = Column(DateTime, nullable=False)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    table_name: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    source_last_updated: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    db_last_updated: Mapped[datetime] = mapped_column(DateTime, nullable=False)
 
 
 class UserPreferenceDB(Base):
     """Database model for storing user preferences"""
     __tablename__ = 'user_preferences'
 
-    id = Column(Integer, primary_key=True)
-    username = Column(String, nullable=False)
-    key = Column(String, nullable=False)
-    value = Column(JSON, nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    username: Mapped[str] = mapped_column(String, nullable=False)
+    key: Mapped[str] = mapped_column(String, nullable=False)
+    value: Mapped[Dict] = mapped_column(JSON, nullable=False)
 
     __table_args__ = (
         UniqueConstraint('username', 'key', name='uq_user_pref'),
@@ -92,15 +95,15 @@ class ProxiedPathDB(Base):
     """Database model for storing proxied paths"""
     __tablename__ = 'proxied_paths'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    username = Column(String, nullable=False)
-    sharing_key = Column(String, nullable=False, unique=True)
-    sharing_name = Column(String, nullable=False)
-    fsp_name = Column(String, nullable=False)
-    path = Column(String, nullable=False)
-    url_prefix = Column(String, nullable=False, server_default="")
-    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
-    updated_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    username: Mapped[str] = mapped_column(String, nullable=False)
+    sharing_key: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    sharing_name: Mapped[str] = mapped_column(String, nullable=False)
+    fsp_name: Mapped[str] = mapped_column(String, nullable=False)
+    path: Mapped[str] = mapped_column(String, nullable=False)
+    url_prefix: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
 
     __table_args__ = (
         UniqueConstraint('username', 'fsp_name', 'path', name='uq_proxied_path'),
@@ -111,27 +114,27 @@ class NeuroglancerStateDB(Base):
     """Database model for storing Neuroglancer states"""
     __tablename__ = 'neuroglancer_states'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    short_key = Column(String, nullable=False, unique=True, index=True)
-    short_name = Column(String, nullable=True)
-    username = Column(String, nullable=False)
-    url_base = Column(String, nullable=False)
-    state = Column(JSON, nullable=False)
-    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
-    updated_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    short_key: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    short_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    username: Mapped[str] = mapped_column(String, nullable=False)
+    url_base: Mapped[str] = mapped_column(String, nullable=False)
+    state: Mapped[Dict] = mapped_column(JSON, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
 
 
 class TicketDB(Base):
     """Database model for storing proxied paths"""
     __tablename__ = 'tickets'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    username = Column(String, nullable=False)
-    fsp_name = Column(String, nullable=False)
-    path = Column(String, nullable=False)
-    ticket_key = Column(String, nullable=False, unique=True)
-    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
-    updated_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    username: Mapped[str] = mapped_column(String, nullable=False)
+    fsp_name: Mapped[str] = mapped_column(String, nullable=False)
+    path: Mapped[str] = mapped_column(String, nullable=False)
+    ticket_key: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
 
     # TODO: Do we want to only allow one ticket per path?
     # Commented out now for testing purposes
@@ -193,16 +196,16 @@ class SessionDB(Base):
     """Database model for storing user sessions"""
     __tablename__ = 'sessions'
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    session_id = Column(String, nullable=False, unique=True, index=True)
-    username = Column(String, nullable=False, index=True)
-    email = Column(String, nullable=True)
-    okta_access_token = Column(String, nullable=True)
-    okta_id_token = Column(String, nullable=True)
-    session_secret_key_hash = Column(String, nullable=True)
-    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
-    expires_at = Column(DateTime, nullable=False)
-    last_accessed_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    session_id: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+    username: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    email: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    okta_access_token: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    okta_id_token: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    session_secret_key_hash: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    last_accessed_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
 
 
 def run_alembic_upgrade(db_url):
@@ -498,7 +501,7 @@ def get_all_user_preferences(session: Session, username: str) -> Dict[str, Dict]
     return {pref.key: pref.value for pref in prefs}
 
 
-def get_proxied_paths(session: Session, username: str, fsp_name: str = None, path: str = None) -> List[ProxiedPathDB]:
+def get_proxied_paths(session: Session, username: str, fsp_name: Optional[str] = None, path: Optional[str] = None) -> List[ProxiedPathDB]:
     """Get proxied paths for a user, optionally filtered by fsp_name and path"""
     logger.info(f"Getting proxied paths for {username} with fsp_name={fsp_name} and path={path}")
     query = session.query(ProxiedPathDB).filter_by(username=username)
@@ -553,7 +556,7 @@ def _clear_sharing_key_cache():
 def _find_best_fsp_match(
     fsps: list[FileSharePath],
     normalized_input: str,
-    get_candidates: callable,
+    get_candidates: Callable[[FileSharePath], Sequence[str | None]],
     separator: str = "/",
 ) -> Optional[tuple[FileSharePath, str]]:
     """Find the FSP whose candidate path is the longest prefix of *normalized_input*.
@@ -821,7 +824,7 @@ def delete_neuroglancer_state(session: Session, username: str, short_key: str) -
     return deleted
 
 
-def get_tickets(session: Session, username: str, fsp_name: str = None, path: str = None) -> List[TicketDB]:
+def get_tickets(session: Session, username: str, fsp_name: Optional[str] = None, path: Optional[str] = None) -> List[TicketDB]:
     """Get tickets for a user, optionally filtered by fsp_name and path"""
     logger.info(f"Getting tickets for {username} with fsp_name={fsp_name} and path={path}")
     query = session.query(TicketDB).filter_by(username=username)

--- a/fileglancer/filestore.py
+++ b/fileglancer/filestore.py
@@ -14,10 +14,11 @@ from loguru import logger
 
 from .database import find_fsp_in_paths
 from .model import FileSharePath
-from .platform_compat import optional_module
-
-pwd = optional_module("pwd")
-grp = optional_module("grp")
+from .platform_compat import (
+    group_names_for_user,
+    groupname_for_gid,
+    username_for_uid,
+)
 
 # Default buffer size for streaming file contents
 DEFAULT_BUFFER_SIZE = 8192
@@ -159,15 +160,8 @@ class FileInfo(BaseModel):
         permissions = stat.filemode(stat_result.st_mode)
         last_modified = stat_result.st_mtime
 
-        try:
-            owner = pwd.getpwuid(stat_result.st_uid).pw_name
-        except (KeyError, AttributeError):
-            owner = str(stat_result.st_uid)
-
-        try:
-            group = grp.getgrgid(stat_result.st_gid).gr_name
-        except (KeyError, AttributeError):
-            group = str(stat_result.st_gid)
+        owner = username_for_uid(stat_result.st_uid)
+        group = groupname_for_gid(stat_result.st_gid)
 
         # Calculate read/write permissions for current user
         hasRead = None
@@ -197,20 +191,7 @@ class FileInfo(BaseModel):
     @staticmethod
     def _get_user_groups(username: str) -> set[str]:
         """Compute all groups a user belongs to. Call once per listing, not per file."""
-        groups: set[str] = set()
-        try:
-            for g in grp.getgrall():
-                if username in g.gr_mem:
-                    groups.add(g.gr_name)
-        except (KeyError, OSError, AttributeError):
-            pass
-        try:
-            primary_gid = pwd.getpwnam(username).pw_gid
-            primary_group = grp.getgrgid(primary_gid).gr_name
-            groups.add(primary_group)
-        except (KeyError, OSError, AttributeError):
-            pass
-        return groups
+        return group_names_for_user(username)
 
     @staticmethod
     def _check_permissions(stat_result: os.stat_result, current_user: str,

--- a/fileglancer/filestore.py
+++ b/fileglancer/filestore.py
@@ -132,7 +132,7 @@ class FileInfo(BaseModel):
     @classmethod
     def from_stat(cls, path: str, absolute_path: str,
                   lstat_result: os.stat_result, stat_result: os.stat_result,
-                  current_user: str = None, fsps: Optional[list] = None,
+                  current_user: Optional[str] = None, fsps: Optional[list] = None,
                   root_path: Optional[str] = None,
                   user_groups: Optional[set[str]] = None):
         """
@@ -279,7 +279,7 @@ class Filestore:
         return full_path
 
 
-    def _get_file_info_from_path(self, full_path: str, current_user: str = None,
+    def _get_file_info_from_path(self, full_path: str, current_user: Optional[str] = None,
                                     fsps: Optional[list] = None,
                                     user_groups: Optional[set[str]] = None) -> FileInfo:
         """
@@ -354,7 +354,7 @@ class Filestore:
         )
 
 
-    def _file_info_from_direntry(self, entry: os.DirEntry, current_user: str = None,
+    def _file_info_from_direntry(self, entry: os.DirEntry, current_user: Optional[str] = None,
                                     fsps: Optional[list] = None,
                                     user_groups: Optional[set[str]] = None) -> FileInfo:
         """Build a FileInfo from a DirEntry, using entry.stat() instead of os.lstat/os.stat.
@@ -431,7 +431,7 @@ class Filestore:
         return os.path.abspath(os.path.join(self.root_path, relative_path))
 
 
-    def get_file_info(self, path: Optional[str] = None, current_user: str = None,
+    def get_file_info(self, path: Optional[str] = None, current_user: Optional[str] = None,
                       fsps: Optional[list] = None) -> FileInfo:
         """
         Get the FileInfo for a file or directory at the given path.
@@ -490,7 +490,7 @@ class Filestore:
             return True
 
 
-    def yield_file_infos_paginated(self, path: Optional[str] = None, current_user: str = None,
+    def yield_file_infos_paginated(self, path: Optional[str] = None, current_user: Optional[str] = None,
                                     fsps: Optional[list] = None, limit: int = 200,
                                     cursor: Optional[str] = None,
                                     *, max_count: int) -> tuple[list[FileInfo], bool, Optional[str], int, bool]:
@@ -567,7 +567,7 @@ class Filestore:
         next_cursor = page_entries[-1].name if has_more and page_entries else None
         return file_infos, has_more, next_cursor, total_count, is_truncated
 
-    def yield_file_infos(self, path: Optional[str] = None, current_user: str = None,
+    def yield_file_infos(self, path: Optional[str] = None, current_user: Optional[str] = None,
                           fsps: Optional[list] = None) -> Generator[FileInfo, None, None]:
         """
         Yield a FileInfo object for each child of the given path.
@@ -602,7 +602,7 @@ class Filestore:
                 continue
 
 
-    def stream_file_contents(self, path: str = None, buffer_size: int = DEFAULT_BUFFER_SIZE, file_handle = None) -> Generator[bytes, None, None]:
+    def stream_file_contents(self, path: Optional[str] = None, buffer_size: int = DEFAULT_BUFFER_SIZE, file_handle = None) -> Generator[bytes, None, None]:
         """
         Stream the contents of a file at the given path or from an open file handle.
 
@@ -638,7 +638,7 @@ class Filestore:
                         break
                     yield chunk
 
-    def stream_file_range(self, path: str = None, start: int = 0, end: int = 0, buffer_size: int = DEFAULT_BUFFER_SIZE, file_handle = None) -> Generator[bytes, None, None]:
+    def stream_file_range(self, path: Optional[str] = None, start: int = 0, end: int = 0, buffer_size: int = DEFAULT_BUFFER_SIZE, file_handle = None) -> Generator[bytes, None, None]:
         """
         Stream a specific byte range of a file at the given path or from an open file handle.
 

--- a/fileglancer/filestore.py
+++ b/fileglancer/filestore.py
@@ -6,12 +6,6 @@ rooted at a specific directory.
 import itertools
 import os
 import stat
-try:
-    import pwd
-    import grp
-except ImportError:
-    pwd = None  # type: ignore[assignment]
-    grp = None  # type: ignore[assignment]
 import shutil
 
 from pydantic import BaseModel
@@ -20,6 +14,10 @@ from loguru import logger
 
 from .database import find_fsp_in_paths
 from .model import FileSharePath
+from .platform_compat import optional_module
+
+pwd = optional_module("pwd")
+grp = optional_module("grp")
 
 # Default buffer size for streaming file contents
 DEFAULT_BUFFER_SIZE = 8192

--- a/fileglancer/issues.py
+++ b/fileglancer/issues.py
@@ -1,6 +1,7 @@
 
 import json
 from datetime import datetime
+from typing import Any
 
 from loguru import logger
 from atlassian import Jira
@@ -23,7 +24,7 @@ def get_jira_client() -> Jira:
     return Jira(url=jira_server, username=jira_username, password=jira_token, cloud=True)
 
 
-def create_jira_ticket(summary: str, description: str, project_key: str, issue_type: str) -> str:
+def create_jira_ticket(summary: str, description: str, project_key: str, issue_type: str) -> dict[str, Any]:
     """
     Creates a new JIRA ticket using the Atlassian Python API
     
@@ -48,7 +49,12 @@ def create_jira_ticket(summary: str, description: str, project_key: str, issue_t
     
     # Create the issue
     new_issue = jira.issue_create(fields=issue_dict)
-    logger.debug(f"JIRA ticket created: {new_issue['key']}")
+    if not isinstance(new_issue, dict):
+        raise RuntimeError("JIRA did not return a ticket object")
+    ticket_key = new_issue.get("key")
+    if not isinstance(ticket_key, str):
+        raise RuntimeError("JIRA did not return a ticket key")
+    logger.debug(f"JIRA ticket created: {ticket_key}")
     return new_issue
 
 
@@ -59,7 +65,7 @@ def parse_datetime(datetime_str: str) -> datetime:
     return datetime.fromisoformat(datetime_str.replace('Z', '+00:00'))
 
 
-def get_jira_ticket_details(ticket_key: str) -> dict:
+def get_jira_ticket_details(ticket_key: str) -> dict[str, Any]:
     """
     Get the status of a JIRA ticket
     
@@ -70,7 +76,12 @@ def get_jira_ticket_details(ticket_key: str) -> dict:
         str: The status of the ticket
     """
     jira = get_jira_client()
-    issue = jira.issue(ticket_key)['fields']
+    issue_response = jira.issue(ticket_key)
+    if not isinstance(issue_response, dict):
+        raise RuntimeError(f"JIRA did not return ticket details for {ticket_key}")
+    issue = issue_response.get("fields")
+    if not isinstance(issue, dict):
+        raise RuntimeError(f"JIRA ticket details for {ticket_key} did not include fields")
     
     if DEBUG:
         print(json.dumps(issue, indent=4))
@@ -99,12 +110,18 @@ def get_jira_ticket_details(ticket_key: str) -> dict:
     comments_data = issue.get('comment', {}).get('comments', [])
     for c in comments_data:
         try:
+            if not isinstance(c, dict):
+                continue
+            created_raw = c.get('created')
+            updated_raw = c.get('updated')
+            if not isinstance(created_raw, str) or not isinstance(updated_raw, str):
+                continue
             comment = TicketComment(
                 author_name=c.get('author', {}).get('name', 'Unknown'),
                 author_display_name=c.get('author', {}).get('displayName', 'Unknown'),
                 body=c.get('body', ''),
-                created=parse_datetime(c['created']) if 'created' in c else None,
-                updated=parse_datetime(c['updated']) if 'updated' in c else None
+                created=parse_datetime(created_raw),
+                updated=parse_datetime(updated_raw)
             )
             issue_details['comments'].append(comment)
         except Exception as e:

--- a/fileglancer/platform_compat.py
+++ b/fileglancer/platform_compat.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
@@ -157,6 +158,42 @@ def username_for_uid(uid: int) -> str:
             except KeyError:
                 pass
     return str(uid)
+
+
+def process_is_alive(pid: int) -> bool:
+    """Return whether a process with *pid* is currently running.
+
+    A process owned by another user counts as alive.  Used by the local
+    executor to decide whether a recorded job PID has finished.
+
+    This avoids ``os.kill(pid, 0)`` as a liveness probe: on Windows that
+    call routes through ``TerminateProcess`` and would kill the target
+    rather than inspect it.
+    """
+    if sys.platform == "win32":
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+        SYNCHRONIZE = 0x00100000
+        WAIT_TIMEOUT = 0x00000102
+        handle = kernel32.OpenProcess(SYNCHRONIZE, False, pid)
+        if not handle:
+            return False
+        try:
+            # Signaled (WAIT_OBJECT_0) means the process has exited;
+            # WAIT_TIMEOUT means it is still running.
+            return kernel32.WaitForSingleObject(handle, 0) == WAIT_TIMEOUT
+        finally:
+            kernel32.CloseHandle(handle)
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but is owned by another user.
+        return True
+    return True
 
 
 def groupname_for_gid(gid: int) -> str:

--- a/fileglancer/platform_compat.py
+++ b/fileglancer/platform_compat.py
@@ -1,0 +1,159 @@
+"""Small cross-platform helpers for optional OS-specific functionality.
+
+This module keeps platform-only imports (``fcntl``, ``msvcrt``, ``pwd``,
+``grp``) out of application modules so type checkers can analyze the project
+for all supported platforms without pretending those modules always exist.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from collections.abc import Callable
+from pathlib import Path
+from types import TracebackType
+from typing import Any, cast
+
+
+def optional_module(module_name: str) -> Any:
+    """Return an imported module, or ``None`` when it is unavailable."""
+    try:
+        return importlib.import_module(module_name)
+    except ImportError:
+        return None
+
+
+def _optional_os_int(fn_name: str) -> int | None:
+    fn = getattr(os, fn_name, None)
+    if not callable(fn):
+        return None
+    get_value = cast(Callable[[], int], fn)
+    return get_value()
+
+
+def current_uid() -> int | None:
+    """Return the current real uid when the platform exposes one."""
+    return _optional_os_int("getuid")
+
+
+def effective_uid() -> int | None:
+    """Return the current effective uid when the platform exposes one."""
+    return _optional_os_int("geteuid")
+
+
+def current_gid() -> int | None:
+    """Return the current real gid when the platform exposes one."""
+    return _optional_os_int("getgid")
+
+
+def group_ids_for_user(username: str, primary_gid: int) -> list[int]:
+    """Return group IDs for *username* using platform support if available."""
+    getgrouplist = getattr(os, "getgrouplist", None)
+    if not callable(getgrouplist):
+        raise RuntimeError("os.getgrouplist is not available on this platform")
+    get_groups = cast(Callable[[str, int], list[int]], getgrouplist)
+    return get_groups(username, primary_gid)
+
+
+class FileLockUnavailable(OSError):
+    """Raised when a non-blocking file lock cannot be acquired."""
+
+
+class FileLock:
+    """A non-blocking exclusive file lock backed by portalocker."""
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self.path = Path(path)
+        self._lock: Any | None = None
+
+    def __enter__(self) -> FileLock:
+        self.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.release()
+
+    def acquire(self) -> None:
+        if self._lock is not None:
+            return
+
+        import portalocker
+        from portalocker import exceptions as portalocker_exceptions
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock = portalocker.Lock(str(self.path), mode="a+", timeout=0)
+        try:
+            lock.acquire()
+        except portalocker_exceptions.LockException as e:
+            raise FileLockUnavailable(str(e)) from e
+
+        self._lock = lock
+
+    def release(self) -> None:
+        lock = self._lock
+        if lock is None:
+            return
+        self._lock = None
+        lock.release()
+
+
+def effective_user_home() -> str:
+    """Return the effective user's home directory.
+
+    On POSIX this uses ``geteuid`` plus the passwd database so it keeps working
+    when a process changes effective UID but the ``HOME`` environment variable
+    still points at the original user.  On platforms without ``pwd``, it falls
+    back to normal ``~`` expansion.
+    """
+
+    if os.name == "posix":
+        pwd = optional_module("pwd")
+        uid = effective_uid()
+        if pwd is not None and uid is not None:
+            try:
+                return str(pwd.getpwuid(uid).pw_dir)
+            except KeyError:
+                pass
+
+    return os.path.expanduser("~")
+
+
+def named_user_home(username: str) -> str:
+    """Return a named user's home directory when the platform can resolve it."""
+
+    if os.name == "posix":
+        pwd = optional_module("pwd")
+        if pwd is not None:
+            try:
+                return str(pwd.getpwnam(username).pw_dir)
+            except KeyError as e:
+                raise RuntimeError(f"Unknown user: {username}") from e
+
+    expanded = os.path.expanduser(f"~{username}")
+    if expanded.startswith("~"):
+        raise RuntimeError(
+            f"Cannot resolve home directory for user {username!r} on this platform"
+        )
+    return expanded
+
+
+def user_home(username: str | None = None) -> str:
+    """Return the current or named user's home directory."""
+    return named_user_home(username) if username else effective_user_home()
+
+
+def username_for_uid(uid: int) -> str:
+    """Return a username for *uid*, or the uid string when unavailable."""
+    if os.name == "posix":
+        pwd = optional_module("pwd")
+        if pwd is not None:
+            try:
+                return str(pwd.getpwuid(uid).pw_name)
+            except KeyError:
+                pass
+    return str(uid)

--- a/fileglancer/platform_compat.py
+++ b/fileglancer/platform_compat.py
@@ -157,3 +157,47 @@ def username_for_uid(uid: int) -> str:
             except KeyError:
                 pass
     return str(uid)
+
+
+def groupname_for_gid(gid: int) -> str:
+    """Return a group name for *gid*, or the gid string when unavailable."""
+    if os.name == "posix":
+        grp = optional_module("grp")
+        if grp is not None:
+            try:
+                return str(grp.getgrgid(gid).gr_name)
+            except KeyError:
+                pass
+    return str(gid)
+
+
+def group_names_for_user(username: str) -> set[str]:
+    """Return the set of group names *username* belongs to, including the
+    primary group.
+
+    Returns an empty set on platforms without the POSIX group database.
+    """
+    groups: set[str] = set()
+    if os.name != "posix":
+        return groups
+
+    grp = optional_module("grp")
+    pwd = optional_module("pwd")
+    if grp is None:
+        return groups
+
+    try:
+        for g in grp.getgrall():
+            if username in g.gr_mem:
+                groups.add(g.gr_name)
+    except (KeyError, OSError):
+        pass
+
+    if pwd is not None:
+        try:
+            primary_gid = pwd.getpwnam(username).pw_gid
+            groups.add(grp.getgrgid(primary_gid).gr_name)
+        except (KeyError, OSError):
+            pass
+
+    return groups

--- a/fileglancer/platform_compat.py
+++ b/fileglancer/platform_compat.py
@@ -212,12 +212,10 @@ def group_names_for_user(username: str) -> set[str]:
     """Return the set of group names *username* belongs to, including the
     primary group.
 
-    Returns an empty set on platforms without the POSIX group database.
+    Returns an empty set on platforms without the POSIX group database
+    (i.e. where the ``grp`` module cannot be imported).
     """
     groups: set[str] = set()
-    if os.name != "posix":
-        return groups
-
     grp = optional_module("grp")
     pwd = optional_module("pwd")
     if grp is None:

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -20,9 +20,10 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, HTTPException, Request, Query, Path, Body, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse, Response, JSONResponse, PlainTextResponse, StreamingResponse, FileResponse
-from fastapi.exceptions import RequestValidationError, StarletteHTTPException
+from fastapi.exceptions import RequestValidationError
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from urllib.parse import quote, unquote
 
 from fileglancer import database as db
@@ -94,7 +95,8 @@ def _convert_external_bucket(db_bucket: db.ExternalBucketDB) -> ExternalBucket:
 def _convert_proxied_path(db_path: db.ProxiedPathDB, external_proxy_url: Optional[HttpUrl]) -> ProxiedPath:
     """Convert a database ProxiedPathDB model to a Pydantic ProxiedPath model"""
     if external_proxy_url:
-        url = f"{external_proxy_url}/{db_path.sharing_key}/{quote(db_path.url_prefix, safe='/')}"
+        base_url = str(external_proxy_url).rstrip("/")
+        url = HttpUrl(f"{base_url}/{db_path.sharing_key}/{quote(db_path.url_prefix, safe='/')}")
     else:
         logger.warning(f"No external proxy URL was provided, proxy links will not be available.")
         url = None
@@ -651,7 +653,7 @@ def create_app(settings):
 
     @app.get("/api/file-share-paths", response_model=FileSharePathResponse,
              description="Get all file share paths from the database")
-    async def get_file_share_paths() -> List[FileSharePath]:
+    async def get_file_share_paths() -> FileSharePathResponse:
         with db.get_db_session(settings.db_url) as session:
             paths = db.get_file_share_paths(session)
             return FileSharePathResponse(paths=paths)
@@ -667,7 +669,7 @@ def create_app(settings):
 
     @app.get("/api/external-buckets/{fsp_name}", response_model=ExternalBucketResponse,
              description="Get the external buckets for a given FSP name")
-    async def get_external_buckets(fsp_name: str) -> ExternalBucket:
+    async def get_external_buckets_by_fsp(fsp_name: str) -> ExternalBucketResponse:
         with db.get_db_session(settings.db_url) as session:
             buckets = [_convert_external_bucket(bucket) for bucket in db.get_external_buckets(session, fsp_name)]
             return ExternalBucketResponse(buckets=buckets)
@@ -741,6 +743,12 @@ def create_app(settings):
         issue_type = body.get("issue_type")
         summary = body.get("summary")
         description = body.get("description")
+        if not isinstance(fsp_name, str) or not isinstance(path, str):
+            raise HTTPException(status_code=400, detail="fsp_name and path are required")
+        if not isinstance(project_key, str) or not isinstance(issue_type, str):
+            raise HTTPException(status_code=400, detail="project_key and issue_type are required")
+        if not isinstance(summary, str) or not isinstance(description, str):
+            raise HTTPException(status_code=400, detail="summary and description are required")
         try:
             # Create ticket in JIRA
             jira_ticket = create_jira_ticket(
@@ -750,7 +758,8 @@ def create_app(settings):
                 description=description
             )
             logger.info(f"Created JIRA ticket: {jira_ticket}")
-            if not jira_ticket or 'key' not in jira_ticket:
+            ticket_key = jira_ticket.get("key")
+            if not isinstance(ticket_key, str):
                 raise HTTPException(status_code=500, detail="Failed to create JIRA ticket")
 
             # Save reference to the ticket in the database
@@ -760,13 +769,13 @@ def create_app(settings):
                     username=username,
                     fsp_name=fsp_name,
                     path=path,
-                    ticket_key=jira_ticket['key']
+                    ticket_key=ticket_key
                 )
                 if db_ticket is None:
                     raise HTTPException(status_code=500, detail="Failed to create ticket entry in database")
 
                 # Get the full ticket details from JIRA
-                ticket_details = get_jira_ticket_details(jira_ticket['key'])
+                ticket_details = get_jira_ticket_details(ticket_key)
 
                 # Return DTO with details from both JIRA and database
                 ticket = _convert_ticket(db_ticket)
@@ -1826,7 +1835,14 @@ def create_app(settings):
             return dt.replace(tzinfo=UTC)
         return dt
 
-    def _convert_job(db_job: db.JobDB, service_url: str = None, files: dict = None) -> Job:
+    def _ensure_utc_required(dt: datetime) -> datetime:
+        """Re-attach UTC timezone to a non-null datetime from the DB."""
+        result = _ensure_utc(dt)
+        assert result is not None
+        return result
+
+    def _convert_job(db_job: db.JobDB, service_url: Optional[str] = None,
+                     files: Optional[Dict[str, JobFileInfo]] = None) -> Job:
         """Convert a database JobDB to a Pydantic Job model.
 
         File-reading fields (service_url, files) must be passed in pre-computed
@@ -1852,7 +1868,7 @@ def create_app(settings):
             pull_latest=db_job.pull_latest,
             cluster_job_id=db_job.cluster_job_id,
             service_url=service_url,
-            created_at=_ensure_utc(db_job.created_at),
+            created_at=_ensure_utc_required(db_job.created_at),
             started_at=_ensure_utc(db_job.started_at),
             finished_at=_ensure_utc(db_job.finished_at),
             files=files,

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -1,12 +1,6 @@
 import os
 import re
 import sys
-try:
-    import pwd
-    import grp
-except ImportError:
-    pwd = None  # type: ignore[assignment]
-    grp = None  # type: ignore[assignment]
 import json
 import secrets
 from datetime import datetime, timedelta, timezone, UTC
@@ -40,6 +34,7 @@ from fileglancer.issues import create_jira_ticket, get_jira_ticket_details, dele
 from fileglancer.utils import format_timestamp, guess_content_type, parse_range_header
 from fileglancer.filestore import Filestore, RootCheckError
 from fileglancer.log import AccessLogMiddleware
+from fileglancer.platform_compat import effective_uid
 from fileglancer.worker_pool import WorkerPool, WorkerError, WorkerDead
 from fileglancer import sshkeys
 
@@ -326,10 +321,11 @@ def create_app(settings):
                 )
                 print(f"\n❌ Configuration Error:\n  {msg}\n", file=sys.stderr)
                 raise RuntimeError(msg)
-            if os.geteuid() != 0:
+            euid = effective_uid()
+            if euid != 0:
                 msg = (
                     f"use_access_flags=True requires running the server as root, "
-                    f"but the current user is uid={os.geteuid()}.\n"
+                    f"but the current user is uid={euid}.\n"
                     f"  Fix: either run as root (so per-user workers can setuid "
                     f"for file access), or set use_access_flags=false (workers "
                     f"will then run as the current user — fine for local "

--- a/fileglancer/settings.py
+++ b/fileglancer/settings.py
@@ -165,8 +165,8 @@ class Settings(BaseSettings):
     
     @model_validator(mode='after')
     def set_jira_browse_url(self):
-        if self.jira_browse_url is None:
-            self.jira_browse_url = f"{self.atlassian_url}/browse"
+        if self.jira_browse_url is None and self.atlassian_url is not None:
+            object.__setattr__(self, "jira_browse_url", HttpUrl(f"{self.atlassian_url}/browse"))
         return self
 
 

--- a/fileglancer/sshkeys.py
+++ b/fileglancer/sshkeys.py
@@ -6,10 +6,6 @@ that are stored in the user's authorized_keys file.
 
 import gc
 import os
-try:
-    import pwd
-except ImportError:
-    pwd = None  # type: ignore[assignment]
 import shutil
 import subprocess
 import tempfile
@@ -18,6 +14,8 @@ from typing import Dict, List, Optional
 from fastapi.responses import Response
 from loguru import logger
 from pydantic import BaseModel, Field, SecretStr
+
+from fileglancer.platform_compat import effective_user_home
 
 # Constants
 AUTHORIZED_KEYS_FILENAME = "authorized_keys"
@@ -131,11 +129,7 @@ def get_ssh_directory() -> str:
     Returns:
         The absolute path to ~/.ssh
     """
-    try:
-        home = pwd.getpwuid(os.geteuid()).pw_dir
-    except (AttributeError, KeyError):
-        home = os.path.expanduser("~")
-    return os.path.join(home, ".ssh")
+    return os.path.join(effective_user_home(), ".ssh")
 
 
 def ensure_ssh_directory_exists(ssh_dir: str) -> None:

--- a/fileglancer/user_worker.py
+++ b/fileglancer/user_worker.py
@@ -73,6 +73,18 @@ def _run_async(coro):
             return future.result()
 
 
+def _response_body_text(response: Any) -> str:
+    """Decode a FastAPI/Starlette response body regardless of bytes-like type."""
+    body = getattr(response, "body", b"")
+    if isinstance(body, memoryview):
+        body = body.tobytes()
+    if isinstance(body, bytearray):
+        body = bytes(body)
+    if isinstance(body, bytes):
+        return body.decode()
+    return str(body)
+
+
 def _set_pdeathsig():
     """Ask the kernel to send SIGTERM when our parent process dies.
 
@@ -357,7 +369,7 @@ def with_filestore(fn):
         fsps = ctx.db.get_file_share_paths()
         filestore, error_response = _get_filestore(request["fsp_name"], fsps)
         if filestore is None:
-            return error_response
+            return error_response or {"error": "Unable to resolve filestore", "status_code": 500}
         return fn(request, ctx, filestore, fsps)
     return wrapper
 
@@ -729,7 +741,7 @@ def _action_generate_ssh_key(request: dict, ctx: WorkerContext) -> dict:
         result = sshkeys.generate_temp_key_and_authorize(ssh_dir, passphrase)
         # TempKeyResponse is a Response object; extract the data we need
         return {
-            "private_key": result.body.decode() if hasattr(result, 'body') else str(result),
+            "private_key": _response_body_text(result) if hasattr(result, 'body') else str(result),
             "fingerprint": result.headers.get("X-SSH-Key-Fingerprint", "") if hasattr(result, 'headers') else "",
             "comment": result.headers.get("X-SSH-Key-Comment", "") if hasattr(result, 'headers') else "",
         }
@@ -804,18 +816,23 @@ def _action_s3_list_objects(request: dict, ctx: WorkerContext) -> dict:
         buffer_size=buffer_size,
     )
 
+    list_kwargs: dict[str, Any] = {"max_keys": request.get("max_keys", 1000)}
+    for key in (
+        "continuation_token",
+        "delimiter",
+        "encoding_type",
+        "fetch_owner",
+        "prefix",
+        "start_after",
+    ):
+        value = request.get(key)
+        if value is not None:
+            list_kwargs[key] = value
+
     # list_objects_v2 is async def but does only sync I/O
-    result = _run_async(client.list_objects_v2(
-        continuation_token=request.get("continuation_token"),
-        delimiter=request.get("delimiter"),
-        encoding_type=request.get("encoding_type"),
-        fetch_owner=request.get("fetch_owner"),
-        max_keys=request.get("max_keys", 1000),
-        prefix=request.get("prefix"),
-        start_after=request.get("start_after"),
-    ))
+    result = _run_async(client.list_objects_v2(**list_kwargs))
     # Result is a fastapi Response object
-    return {"body": result.body.decode(), "media_type": result.media_type, "status_code": result.status_code}
+    return {"body": _response_body_text(result), "media_type": result.media_type, "status_code": result.status_code}
 
 
 @action("s3_head_object")
@@ -858,7 +875,10 @@ def _action_s3_open_object(request: dict, ctx: WorkerContext) -> dict:
         buffer_size=request.get("buffer_size", 256 * 1024),
     )
 
-    result = _run_async(client.open_object(path, range_header))
+    if range_header is None:
+        result = _run_async(client.open_object(path))
+    else:
+        result = _run_async(client.open_object(path, range_header))
 
     if isinstance(result, FileObjectHandle):
         # Keep the file handle alive and pass the fd
@@ -883,7 +903,7 @@ def _action_s3_open_object(request: dict, ctx: WorkerContext) -> dict:
         # Error response
         return {
             "type": "error_response",
-            "body": result.body.decode() if hasattr(result, 'body') else "",
+            "body": _response_body_text(result) if hasattr(result, 'body') else "",
             "status_code": result.status_code,
             "headers": dict(result.headers) if hasattr(result, 'headers') else {},
         }
@@ -1151,6 +1171,10 @@ def main():
         if action == "shutdown":
             logger.info(f"Shutdown requested, exiting")
             break
+
+        if not isinstance(action, str):
+            _send(sock, {"error": f"Invalid action: {action}"})
+            continue
 
         handler = _ACTIONS.get(action)
         if handler is None:

--- a/fileglancer/user_worker.py
+++ b/fileglancer/user_worker.py
@@ -26,13 +26,10 @@ import asyncio
 import ctypes
 import ctypes.util
 import functools
+import getpass
 import json
 import logging
 import os
-try:
-    import pwd
-except ImportError:
-    pwd = None  # type: ignore[assignment]
 import socket
 import struct
 import sys
@@ -41,6 +38,15 @@ from typing import Any, Optional
 
 from loguru import logger
 
+from fileglancer.platform_compat import (
+    current_uid,
+    effective_uid,
+    group_ids_for_user,
+    optional_module,
+    username_for_uid,
+)
+
+pwd = optional_module("pwd")
 
 # Length-prefix format: 4-byte big-endian unsigned int
 _HEADER_FMT = "!I"
@@ -279,9 +285,21 @@ def _get_user_groups(username: str) -> list[str]:
     if cached is not None:
         return cached
 
-    import grp as _grp
+    if os.name != "posix" or pwd is None:
+        _user_groups_cache[username] = []
+        return []
+
+    _grp = optional_module("grp")
+    if _grp is None:
+        _user_groups_cache[username] = []
+        return []
+
     pw = pwd.getpwnam(username)
-    gids = os.getgrouplist(username, pw.pw_gid)
+    try:
+        gids = group_ids_for_user(username, pw.pw_gid)
+    except RuntimeError:
+        _user_groups_cache[username] = []
+        return []
     names = []
     for gid in gids:
         try:
@@ -1107,11 +1125,9 @@ def main():
     os.close(fd)  # close the original fd, we have a dup now
 
     # Determine username
-    uid = os.getuid()
-    try:
-        username = pwd.getpwuid(uid).pw_name
-    except KeyError:
-        username = str(uid)
+    uid = current_uid()
+    username = username_for_uid(uid) if uid is not None else getpass.getuser()
+    euid = effective_uid()
 
     # Worker subprocess never gets DB credentials; all DB access goes back
     # through the parent over the same socket via RpcDbProxy.
@@ -1119,7 +1135,7 @@ def main():
 
     logger.info(
         f"Worker started for {username} "
-        f"(uid={uid} euid={os.geteuid()} pid={os.getpid()})"
+        f"(uid={uid} euid={euid} pid={os.getpid()})"
     )
 
     # Main request/response loop

--- a/fileglancer/worker_pool.py
+++ b/fileglancer/worker_pool.py
@@ -408,10 +408,14 @@ class WorkerPool:
         block the worker on its next write — so failures here are logged
         loudly rather than swallowed.
         """
+        stderr = process.stderr
+        if stderr is None:
+            logger.warning(f"worker {username} has no stderr pipe to forward")
+            return
         try:
             loop = asyncio.get_event_loop()
             while True:
-                line = await loop.run_in_executor(None, process.stderr.readline)
+                line = await loop.run_in_executor(None, stderr.readline)
                 if not line:
                     break
                 logger.debug(f"[worker:{username}] {line.decode().rstrip()}")

--- a/fileglancer/worker_pool.py
+++ b/fileglancer/worker_pool.py
@@ -27,10 +27,6 @@ import array
 import asyncio
 import json
 import os
-try:
-    import pwd
-except ImportError:
-    pwd = None  # type: ignore[assignment]
 import socket
 import struct
 import subprocess
@@ -40,7 +36,15 @@ from typing import Any, Optional
 
 from loguru import logger
 
+from fileglancer.platform_compat import (
+    current_gid,
+    current_uid,
+    group_ids_for_user,
+    optional_module,
+)
 from fileglancer.settings import Settings
+
+pwd = optional_module("pwd")
 
 
 # Length-prefix format: 4-byte big-endian unsigned int
@@ -335,8 +339,16 @@ class WorkerPool:
         # process's user — used for local debugging of the worker code path.
         identity_kwargs: dict = {}
         if self.settings.use_access_flags:
+            if os.name != "posix" or pwd is None:
+                raise WorkerError(
+                    "Running workers as another user requires POSIX pwd/getgrouplist support",
+                    status_code=500,
+                )
             pw = pwd.getpwnam(username)
-            groups = os.getgrouplist(username, pw.pw_gid)
+            try:
+                groups = group_ids_for_user(username, pw.pw_gid)
+            except RuntimeError as e:
+                raise WorkerError(str(e), status_code=500) from e
             identity_kwargs = {
                 "user": pw.pw_uid,
                 "group": pw.pw_gid,
@@ -346,7 +358,7 @@ class WorkerPool:
             log_uid, log_gid = pw.pw_uid, pw.pw_gid
         else:
             home_dir = os.path.expanduser("~")
-            log_uid, log_gid = os.getuid(), os.getgid()
+            log_uid, log_gid = current_uid(), current_gid()
 
         # Create Unix socketpair for IPC
         parent_sock, child_sock = socket.socketpair()

--- a/pixi.lock
+++ b/pixi.lock
@@ -98,6 +98,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.3-py314ha0b5721_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-3.2.0-py314hdafbbf9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
@@ -253,6 +254,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-2.3.3-py314h91eeaa4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portalocker-3.2.0-py314ha42fa4b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
@@ -405,6 +407,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.3.3-py314hc4308db_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/portalocker-3.2.0-py314hee6578b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
@@ -559,6 +562,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.3-py314ha3d490a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portalocker-3.2.0-py314h4dc9dd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
@@ -708,6 +712,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.3-py314hd8fd7ce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/portalocker-3.2.0-py314h86ab7b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.0-pyhcf101f3_0.conda
@@ -725,6 +730,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-311-py314h8f8f202_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py314h2359020_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-kerberos-0.14.0-pyh7428d3b_1.conda
@@ -907,6 +913,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-3.2.0-py314hdafbbf9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -1106,6 +1113,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portalocker-3.2.0-py314ha42fa4b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -1298,6 +1306,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/portalocker-3.2.0-py314hee6578b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -1491,6 +1500,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portalocker-3.2.0-py314h4dc9dd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -1679,6 +1689,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/portalocker-3.2.0-py314h86ab7b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
@@ -1700,6 +1711,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-311-py314h8f8f202_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.3-py314h86ab7b2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.3-py314h2359020_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
@@ -1901,6 +1913,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.2-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -1914,6 +1927,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-3.2.0-py314hdafbbf9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
@@ -1927,6 +1941,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pykrb5-0.9.0-py314h9e40ac2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.410-py314h0f05182_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyspnego-0.12.1-py314hdafbbf9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -1965,6 +1980,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py314h0f05182_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -2144,6 +2160,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nodejs-22.22.2-h42e3414_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.3-py314haac167e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -2157,6 +2174,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portalocker-3.2.0-py314ha42fa4b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py314h2e8dab5_0.conda
@@ -2169,6 +2187,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyright-1.1.410-py314h2e8dab5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyspnego-0.12.1-py314h28a4750_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -2206,6 +2225,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ruamel.yaml.clib-0.2.15-py314h2e8dab5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -2381,6 +2401,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nodejs-22.22.2-h5d72c05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.3-py314h7b24d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -2394,6 +2415,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/portalocker-3.2.0-py314hee6578b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py314hd330473_0.conda
@@ -2409,6 +2431,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pykrb5-0.9.0-py314hd7ffae8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py314h681fd4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py314h9720295_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.410-py314h0b69929_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyspnego-0.12.1-py314hee6578b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -2623,6 +2646,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-22.22.2-h2e6c367_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314h1569ea8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -2636,6 +2660,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portalocker-3.2.0-py314h4dc9dd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
@@ -2651,6 +2676,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pykrb5-0.9.0-py314h112e2b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.1-py314h3a4d195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.1-py314h36abed7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.410-py314ha14b1ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyspnego-0.12.1-py314h4dc9dd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -2860,6 +2886,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nodejs-22.22.2-h80d1838_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.3-py314h02f10f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -2872,6 +2899,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/portalocker-3.2.0-py314h86ab7b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py314hc5dbbe4_0.conda
@@ -2883,6 +2911,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyright-1.1.410-py314hc5dbbe4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyspnego-0.12.1-py314h86ab7b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -2921,6 +2950,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.15-py314hc5dbbe4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyh6dadd2b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -3117,6 +3147,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.2-h273caaf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -3130,6 +3161,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-3.2.0-py312h7900ff3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
@@ -3143,6 +3175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pykrb5-0.9.0-py312hf9980d4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.410-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyspnego-0.12.1-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -3363,6 +3396,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-ha32ae93_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nodejs-22.22.2-h42e3414_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.3-py312h6615c27_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -3376,6 +3410,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portalocker-3.2.0-py312h8025657_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py312hd41f8a7_0.conda
@@ -3389,6 +3424,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pykrb5-0.8.0-py312hb2ae39b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyright-1.1.410-py312hd41f8a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyspnego-0.12.1-py312h996f985_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -3603,6 +3639,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nodejs-22.22.2-h5d72c05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.3-py312h746d82c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -3616,6 +3653,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/portalocker-3.2.0-py312hb401068_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py312hf7082af_0.conda
@@ -3631,6 +3669,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pykrb5-0.9.0-py312hfbceac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-12.1-py312h4a480f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-12.1-py312h1993040_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.410-py312hba6025d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyspnego-0.12.1-py312hb401068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -3845,6 +3884,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-22.22.2-h2e6c367_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py312h84a4f5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -3858,6 +3898,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/portalocker-3.2.0-py312h81bd7bf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py312hb3ab3e3_0.conda
@@ -3873,6 +3914,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pykrb5-0.9.0-py312h858ef95_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-12.1-py312h19bbe71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.1-py312h1de3e18_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.410-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyspnego-0.12.1-py312h81bd7bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -4082,6 +4124,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nodejs-22.22.2-h80d1838_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.3-py312ha3f287d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
@@ -4094,6 +4137,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.3-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/portalocker-3.2.0-py312h2e8e312_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py312he5662c2_0.conda
@@ -4105,6 +4149,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyright-1.1.410-py312he5662c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyspnego-0.12.1-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.2-pyhcf101f3_1.conda
@@ -6314,7 +6359,7 @@ packages:
 - pypi: ./
   name: fileglancer
   version: 2.8.2a0
-  sha256: 26d392ae1a606381f74d6d27c1e9d4eb95f476656105545294ca619694cded6e
+  sha256: 06342d7acad583460e2e52c8f464001dee7c9be54a37693db3bb75b4f10c1ea2
   requires_dist:
   - alembic>=1.17.0
   - atlassian-python-api>=4.0.7
@@ -6328,6 +6373,7 @@ packages:
   - loguru>=0.7.3
   - packaging>=24.0
   - pandas>=2.3.3
+  - portalocker>=3.2.0,<4
   - psycopg2-binary>=2.9.10,<3
   - py-cluster-api>=0.6.0
   - pydantic-settings>=2.11.0
@@ -10145,6 +10191,18 @@ packages:
   - pkg:pypi/nh3?source=hash-mapping
   size: 602914
   timestamp: 1774451974303
+- conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
+  sha256: 4fa40e3e13fc6ea0a93f67dfc76c96190afd7ea4ffc1bac2612d954b42cdc3ee
+  md5: eb52d14a901e23c39e9e7b4a1a5c015f
+  depends:
+  - python >=3.10
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/nodeenv?source=hash-mapping
+  size: 40866
+  timestamp: 1766261270149
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.22.2-h273caaf_0.conda
   sha256: 96b2973e280a867f1ad96fdb4413e4a24e2953487fd4cfce579214712b92f452
   md5: 81a057418ed2da9bd0463429d94ee140
@@ -11145,6 +11203,130 @@ packages:
   - pkg:pypi/pluggy?source=hash-mapping
   size: 25877
   timestamp: 1764896838868
+- conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-3.2.0-py312h7900ff3_1.conda
+  sha256: f0cb3cfcc51394f5b52ec92e8fe27f8fff02853fe2e66c3ae111d7149e440115
+  md5: 21a906c6a6f29bb1cb968a7711f6f894
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 56441
+  timestamp: 1757395777358
+- conda: https://conda.anaconda.org/conda-forge/linux-64/portalocker-3.2.0-py314hdafbbf9_1.conda
+  sha256: 58d33d2a3a63f95d1ef19b637c45aabc27d81aba8519edc83960e014c7135a4e
+  md5: c03f75d0af8312aec028884b73401713
+  depends:
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 59348
+  timestamp: 1757395767450
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portalocker-3.2.0-py312h8025657_1.conda
+  sha256: 36b338e2937dd759907b11c8ace12692b272937b888a4dca24f666e34c3ce44f
+  md5: 7b62c51b88a2a9ce57f2491fa06f138e
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 56513
+  timestamp: 1757396557977
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/portalocker-3.2.0-py314ha42fa4b_1.conda
+  sha256: 17da078008412b4b3bb70855a0a16adabeae333c277376e3786b4ac1fdc2f511
+  md5: 495548a8ed11f4c3f59d22db43d149e7
+  depends:
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 59203
+  timestamp: 1757396880238
+- conda: https://conda.anaconda.org/conda-forge/osx-64/portalocker-3.2.0-py312hb401068_1.conda
+  sha256: 491aa766e34db0ee31057bdaa23ed29c63f762cb934d271c685a820ae26b1c2e
+  md5: c8c581b1d406d8c9bcee852623d9177f
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 56744
+  timestamp: 1757395853974
+- conda: https://conda.anaconda.org/conda-forge/osx-64/portalocker-3.2.0-py314hee6578b_1.conda
+  sha256: b232d994c46e5d8fac3d4bbe2f7532e16b4c10db1b2173ede03849e97b646ee1
+  md5: 1dd2f132cf857512fb094fb30d093a92
+  depends:
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 59348
+  timestamp: 1757395841049
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/portalocker-3.2.0-py312h81bd7bf_1.conda
+  sha256: 9e9eefb4775b169fa22f96edcd8f5059f682d288c5971266163a5ea2718aaacc
+  md5: 505081291f86f371172d75a2672a1804
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 56879
+  timestamp: 1757395908630
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/portalocker-3.2.0-py314h4dc9dd8_1.conda
+  sha256: 54c0b79696889a8c79770dacc56c9a4103cbd49073af876ed8a34a5d197dc279
+  md5: 4888e09aa7e6c31c9d48d637fd0cf35c
+  depends:
+  - python >=3.14.0rc2,<3.15.0a0
+  - python >=3.14.0rc2,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 60059
+  timestamp: 1757396050476
+- conda: https://conda.anaconda.org/conda-forge/win-64/portalocker-3.2.0-py312h2e8e312_1.conda
+  sha256: 25d0bed230ea674bd25bdcf7ff6b04f6b5e62a3f3b5063ad4db2d8889f520171
+  md5: 0a7736a4a7856e71b89a0d2af1c34414
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - pywin32
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 57079
+  timestamp: 1757395862534
+- conda: https://conda.anaconda.org/conda-forge/win-64/portalocker-3.2.0-py314h86ab7b2_1.conda
+  sha256: b01a4f4ecc45d0f4b0942ee2bbe6923460e4fc4d56d25a3e5227681cd91f9a8d
+  md5: 29d678b4d88b1365b8ca9a3e84a9ba92
+  depends:
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - pywin32
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/portalocker?source=hash-mapping
+  size: 59853
+  timestamp: 1757395857386
 - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
   sha256: 4d7ec90d4f9c1f3b4a50623fefe4ebba69f651b102b373f7c0e9dbbfa43d495c
   md5: a11ab1f31af799dd93c3a39881528884
@@ -11956,6 +12138,166 @@ packages:
   - pkg:pypi/pyproject-hooks?source=hash-mapping
   size: 15528
   timestamp: 1733710122949
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.410-py312h5253ce2_0.conda
+  sha256: 5122f6e11656d0c32972a5b59b9533d117820d6fd57afd014f9e768818f76ee8
+  md5: 1ecfa7459025353f0727e0d36a2137a9
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3804681
+  timestamp: 1780370991525
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyright-1.1.410-py314h0f05182_0.conda
+  sha256: 646031115365dac8445ec935f61c8ccc8879dd7c184a279e6adee41339cf69c7
+  md5: 60b35e9e4e4eb39469a3ddd85b2390f4
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3805792
+  timestamp: 1780370993729
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyright-1.1.410-py312hd41f8a7_0.conda
+  sha256: 8fdd270a231c3f99634dc4816b730eee0e6a9e32aaaa71081912190eecff97ab
+  md5: 1d60f75a2aaacb8df5feaaba4b91ba65
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - python 3.12.* *_cpython
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3808915
+  timestamp: 1780370999262
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyright-1.1.410-py314h2e8dab5_0.conda
+  sha256: a9bba2aa32fef90bee4732b8fbc0390ebf25cb1dbcf6538d2583cd64ce5e748e
+  md5: aca526d7a5ada5fd0fa2519f45f8f743
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - libgcc >=14
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=hash-mapping
+  size: 3809753
+  timestamp: 1780370994137
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.410-py312hba6025d_0.conda
+  sha256: 8ddb003b827a1e93d34bab3334fa40048a96e092d75d9e7f05d1560df7c9187d
+  md5: d38d2b108a4ea45a082230eeea7263d9
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3805478
+  timestamp: 1780371178490
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyright-1.1.410-py314h0b69929_0.conda
+  sha256: a5ea3a51cac0a6e256e85f9fe5e1efb592455dbadc685d857811677fa3b1b555
+  md5: 1c3a93e3ee8ea244571046d5be1a6c6b
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - __osx >=11.0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=hash-mapping
+  size: 3806948
+  timestamp: 1780371182153
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.410-py312hb3ab3e3_0.conda
+  sha256: d7152c285bb157c87d763929b0e044a813ad29f734ef97fef78b58cfd76acb5b
+  md5: f86ea27be8c88712016cee44be4572b6
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - __osx >=11.0
+  - python 3.12.* *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3809119
+  timestamp: 1780371154762
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyright-1.1.410-py314ha14b1ff_0.conda
+  sha256: 60d4ffcdbfa22b844807d53c23a93047872979c23e7adfc4c0a7915367ba6164
+  md5: 702ec2315cef0e0a7457cd1a1c14718e
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - __osx >=11.0
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3810766
+  timestamp: 1780371120272
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyright-1.1.410-py312he5662c2_0.conda
+  sha256: e2bd0c660a9683636899277e82d33372f2a5454b4448125b0b75fbcefa2ab154
+  md5: b8d7348c8d7b3e8e92074c64f9000a8a
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3824160
+  timestamp: 1780371048281
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyright-1.1.410-py314hc5dbbe4_0.conda
+  sha256: 2532c75d7039364cba1ab477ac2a451e143a3f0bd9f856cabb49e30f709983f9
+  md5: 5cce7503b31e23cf809d3f19720f4d32
+  depends:
+  - nodeenv >=1.6.0
+  - nodejs
+  - python
+  - typing_extensions >=4.1
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  purls:
+  - pkg:pypi/pyright?source=compressed-mapping
+  size: 3825215
+  timestamp: 1780371039907
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
   sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
   md5: e2fd202833c4a981ce8a65974fe4abd1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
     "packaging >=24.0",
     "uvicorn >=0.38.0",
     "x2s3 >=1.2.0",
-    "py-cluster-api >=0.6.0"
+    "py-cluster-api >=0.6.0",
+    "portalocker >=3.2.0,<4"
 ]
 
 [project.scripts]
@@ -95,6 +96,7 @@ channels = ["conda-forge"]
 platforms = ["osx-arm64", "osx-64", "linux-64", "linux-aarch64", "win-64"]
 
 [tool.pixi.feature.test.tasks]
+pyright-check = { cmd = "pyright -p pyrightconfig.json", default-environment = "test" }
 test-pip-install = { cmd = "pip install -e .", default-environment = "test" }
 test-backend = { cmd = "pytest --cov=fileglancer --cov-report=html --cov-report=term", depends-on = ["test-pip-install"], default-environment = "test" }
 test-frontend = { cmd = "cd frontend && npm test", default-environment = "test" }
@@ -108,6 +110,7 @@ pytest-cov = ">=7.0.0,<8"
 pytest-jupyter = ">=0.10.1,<0.11"
 requests-mock = ">=1.12.1,<2"
 pytest-jupyter-server = ">=0.6.0"
+pyright = ">=1.1.410,<2"
 
 [tool.pixi.feature.release.tasks]
 version = "hatch version"
@@ -185,6 +188,7 @@ cryptography = ">=41.0.0"
 sqlalchemy = ">=2.0.44,<3"
 packaging = ">=24.0"
 uvicorn = ">=0.38.0,<0.39"
+portalocker = ">=3.2.0,<4"
 
 [tool.pixi.pypi-dependencies]
 fileglancer = { path = ".", editable = true }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,15 @@
+{
+  "include": ["fileglancer"],
+  "exclude": [
+    "**/__pycache__",
+    ".pixi",
+    ".venv",
+    "frontend",
+    "htmlcov"
+  ],
+  "venvPath": ".pixi/envs",
+  "venv": "default",
+  "pythonVersion": "3.12",
+  "pythonPlatform": "All",
+  "typeCheckingMode": "standard"
+}

--- a/tests/test_filestore.py
+++ b/tests/test_filestore.py
@@ -552,10 +552,19 @@ class TestCheckPermissions:
 
 class TestGetUserGroups:
 
-    @patch("fileglancer.filestore.pwd")
-    @patch("fileglancer.filestore.grp")
-    def test_includes_supplementary_groups(self, mock_grp, mock_pwd):
+    @staticmethod
+    def _patch_modules(mock_grp, mock_pwd):
+        """Route platform_compat.optional_module to the supplied mocks."""
+        modules = {"grp": mock_grp, "pwd": mock_pwd}
+        return patch(
+            "fileglancer.platform_compat.optional_module",
+            side_effect=lambda name: modules.get(name),
+        )
+
+    def test_includes_supplementary_groups(self):
         """Returns groups where the user appears in gr_mem."""
+        mock_grp = MagicMock()
+        mock_pwd = MagicMock()
         mock_grp.getgrall.return_value = [
             MagicMock(gr_name="staff", gr_mem=["alice", "bob"]),
             MagicMock(gr_name="dev", gr_mem=["alice"]),
@@ -564,41 +573,45 @@ class TestGetUserGroups:
         mock_pwd.getpwnam.return_value = MagicMock(pw_gid=100)
         mock_grp.getgrgid.return_value = MagicMock(gr_name="primary")
 
-        groups = FileInfo._get_user_groups("alice")
+        with self._patch_modules(mock_grp, mock_pwd):
+            groups = FileInfo._get_user_groups("alice")
         assert "staff" in groups
         assert "dev" in groups
         assert "ops" not in groups
 
-    @patch("fileglancer.filestore.pwd")
-    @patch("fileglancer.filestore.grp")
-    def test_includes_primary_group(self, mock_grp, mock_pwd):
+    def test_includes_primary_group(self):
         """Returns the user's primary group even if not in gr_mem."""
+        mock_grp = MagicMock()
+        mock_pwd = MagicMock()
         mock_grp.getgrall.return_value = []
         mock_pwd.getpwnam.return_value = MagicMock(pw_gid=100)
         mock_grp.getgrgid.return_value = MagicMock(gr_name="primary")
 
-        groups = FileInfo._get_user_groups("alice")
+        with self._patch_modules(mock_grp, mock_pwd):
+            groups = FileInfo._get_user_groups("alice")
         assert "primary" in groups
 
-    @patch("fileglancer.filestore.pwd")
-    @patch("fileglancer.filestore.grp")
-    def test_handles_unknown_user(self, mock_grp, mock_pwd):
+    def test_handles_unknown_user(self):
         """Returns empty set if user doesn't exist."""
+        mock_grp = MagicMock()
+        mock_pwd = MagicMock()
         mock_grp.getgrall.return_value = []
         mock_pwd.getpwnam.side_effect = KeyError("no such user")
 
-        groups = FileInfo._get_user_groups("nonexistent")
+        with self._patch_modules(mock_grp, mock_pwd):
+            groups = FileInfo._get_user_groups("nonexistent")
         assert groups == set()
 
-    @patch("fileglancer.filestore.pwd")
-    @patch("fileglancer.filestore.grp")
-    def test_handles_getgrall_failure(self, mock_grp, mock_pwd):
+    def test_handles_getgrall_failure(self):
         """Gracefully handles grp.getgrall() failure."""
+        mock_grp = MagicMock()
+        mock_pwd = MagicMock()
         mock_grp.getgrall.side_effect = OSError("nss failure")
         mock_pwd.getpwnam.return_value = MagicMock(pw_gid=100)
         mock_grp.getgrgid.return_value = MagicMock(gr_name="primary")
 
-        groups = FileInfo._get_user_groups("alice")
+        with self._patch_modules(mock_grp, mock_pwd):
+            groups = FileInfo._get_user_groups("alice")
         # Still gets primary group despite getgrall failure
         assert "primary" in groups
 

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,8 +1,6 @@
 """Tests for the job poll loop: file-lock election and status-update logic."""
 
 import asyncio
-import pytest
-fcntl = pytest.importorskip("fcntl", reason="fcntl is not available on Windows")
 import multiprocessing
 import subprocess
 import time
@@ -12,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock, call
 
 from fileglancer.apps.core import _poll_jobs, _poll_local_jobs, _POLL_LOCK_PATH
+from fileglancer.platform_compat import FileLock, FileLockUnavailable
 
 
 # ---------------------------------------------------------------------------
@@ -147,17 +146,13 @@ def _try_poll_with_lock(counter, sync_barrier):
     """Attempt to acquire the poll lock and increment a shared counter."""
     sync_barrier.wait()
     try:
-        with open(_POLL_LOCK_PATH, "w") as f:
-            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            try:
-                with counter.get_lock():
-                    counter.value += 1
-                # Hold lock long enough for the other process to attempt
-                # acquisition and fail with LOCK_NB
-                time.sleep(0.5)
-            finally:
-                fcntl.flock(f, fcntl.LOCK_UN)
-    except OSError:
+        with FileLock(_POLL_LOCK_PATH):
+            with counter.get_lock():
+                counter.value += 1
+            # Hold lock long enough for the other process to attempt
+            # acquisition and fail with the non-blocking lock
+            time.sleep(0.5)
+    except FileLockUnavailable:
         pass
 
 
@@ -180,30 +175,20 @@ class TestPollLockElection:
             poll_called = True
 
         # Hold the lock from this thread
-        lock_file = open(_POLL_LOCK_PATH, "w")
-        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
-
-        try:
+        with FileLock(_POLL_LOCK_PATH):
             # Run one iteration of the poll loop with a short sleep
             # The loop should fail to acquire the lock and skip
             async def run_one_iteration():
                 with patch("fileglancer.apps.core._poll_jobs", fake_poll_jobs):
                     # Run the poll loop body once (not the infinite loop)
                     try:
-                        with open(_POLL_LOCK_PATH, "w") as f:
-                            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                            try:
-                                fake_poll_jobs(settings)
-                            finally:
-                                fcntl.flock(f, fcntl.LOCK_UN)
-                    except OSError:
+                        with FileLock(_POLL_LOCK_PATH):
+                            fake_poll_jobs(settings)
+                    except FileLockUnavailable:
                         pass  # Lock held — should skip
 
             asyncio.run(run_one_iteration())
             assert not poll_called, "_poll_jobs should not run when lock is held"
-        finally:
-            fcntl.flock(lock_file, fcntl.LOCK_UN)
-            lock_file.close()
 
     def test_poll_runs_when_lock_available(self):
         """When no one holds the lock, _poll_jobs should execute."""
@@ -217,13 +202,9 @@ class TestPollLockElection:
         # Ensure lock file is not held
         async def run_one_iteration():
             try:
-                with open(_POLL_LOCK_PATH, "w") as f:
-                    fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    try:
-                        fake_poll_jobs(settings)
-                    finally:
-                        fcntl.flock(f, fcntl.LOCK_UN)
-            except OSError:
+                with FileLock(_POLL_LOCK_PATH):
+                    fake_poll_jobs(settings)
+            except FileLockUnavailable:
                 pass
 
         asyncio.run(run_one_iteration())
@@ -232,11 +213,13 @@ class TestPollLockElection:
     def test_concurrent_processes_only_one_wins(self):
         """Simulate two worker processes racing for the lock — only one should poll.
 
-        fcntl.flock is per-process (not per-thread), so we must use
-        multiprocessing to test real mutual exclusion — matching how
-        uvicorn workers are separate OS processes.
+        The lock is held by separate OS processes, matching how uvicorn
+        workers contend for poll-loop ownership.
         """
-        ctx = multiprocessing.get_context("fork")
+        start_method = (
+            "fork" if "fork" in multiprocessing.get_all_start_methods() else "spawn"
+        )
+        ctx = multiprocessing.get_context(start_method)
         won_count = ctx.Value("i", 0)
         barrier = ctx.Barrier(2, timeout=5)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -472,7 +472,9 @@ class TestWorkerMainLoop:
         def target():
             # Simulate what main() does, but with our socket
             sock = child_sock
-            uid = os.getuid()
+            from fileglancer.platform_compat import current_uid
+
+            uid = current_uid()
             try:
                 username = os.environ.get("USER", str(uid))
             except KeyError:


### PR DESCRIPTION
In order to review the changes on the `apps-improvements` branch in my IDE, I wanted things to pass error-check in Pyright. This turned into a large refactor, including a new cross-platform locking layer that cleans up some of the code while expanding its capabilities. 

With the new file locking layer, we don't need to do stuff like this:
```
try:
    import fcntl
except ImportError:
    fcntl = None  # type: ignore[assignment]
```

On the other hand, there is a lot of churn.

> **Base branch:** this PR targets `apps-improvements`, not `main`. The diff is just the cross-platform / Pyright work.

## Summary

- Add a cross-platform compatibility layer (`fileglancer/platform_compat.py`) for optional POSIX-only behavior and portalocker-backed file locking.
- Add Pyright support via `pyrightconfig.json` and a `pixi run pyright-check` task, configured with `pythonPlatform: "All"` so Linux/macOS/Windows are all validated in one run.
- Make database models, app adapters, worker IPC/S3 paths, Jira handling, and server helpers Pyright-clean across platforms.

## The cross-platform compatibility layer

`platform_compat.py` is the single place that touches platform-only modules (`pwd`, `grp`, `fcntl`/`portalocker`, Windows `ctypes`). It exposes:

- **`FileLock` / `FileLockUnavailable`** — a non-blocking exclusive file lock backed by `portalocker`, replacing the raw `fcntl.flock` calls in the job poll loop. Same semantics (one worker wins the poll election per interval), no more `try: import fcntl` guards.
- **User / group helpers** — `effective_user_home`, `named_user_home`, `user_home`, `username_for_uid`, `groupname_for_gid`, `group_names_for_user`, `current_uid`/`effective_uid`/`current_gid`, `group_ids_for_user`. These wrap the `pwd`/`grp`/`os.get*id` calls and degrade gracefully on non-POSIX.
- **`process_is_alive(pid)`** — a portable process-liveness probe (see the bug fix below).

`filestore.py`, `sshkeys.py`, `user_worker.py`, `worker_pool.py`, and `apps/core.py` were updated to route through these helpers instead of importing `pwd`/`grp`/`fcntl` directly.

## Behavioral fix: local-executor job liveness on Windows

This is the one change that is **not** just typing. `_poll_local_jobs` used `os.kill(pid, 0)` as a liveness probe. On Windows `os.kill` routes through `TerminateProcess`, so it would *kill* the job it was polling, and it doesn't raise `ProcessLookupError` for a dead PID. `process_is_alive()` now keeps the `os.kill(pid, 0)` probe on POSIX and uses a non-destructive `OpenProcess(SYNCHRONIZE)` + `WaitForSingleObject` check on Windows.

This bug was dormant because `tests/test_poll.py` was skipped wholesale on Windows via a module-level `pytest.importorskip("fcntl")`. Removing the `fcntl` dependency (now `FileLock`) un-skipped the file and surfaced it.

## SQLAlchemy 2.0 typed ORM

`database.py` migrates the models from the legacy `declarative_base()` + `Column(...)` style to the 2.0 typed style: a `DeclarativeBase` subclass with `Mapped[...]` annotations and `mapped_column(...)`. This is what makes the models type-check cleanly; column nullability is now reflected in the types (`Mapped[Optional[str]]` etc.).

## Smaller semantic changes bundled in

These came out of making the code provably correct for the type checker, and are slight behavior changes worth a look during review:

- **auth.py** — revoke the session and return `None` when `session_secret_key` is unset, instead of hashing `None`.
- **issues.py** — skip JIRA comments that lack `created`/`updated` rather than passing `None` into the required `datetime` fields (the old path could raise at model validation).
- **server.py** — add `400` validation for the JIRA ticket endpoint body; normalize proxied-path URLs with `rstrip("/")` + `HttpUrl` to avoid double slashes; rename the second `get_external_buckets` handler to `get_external_buckets_by_fsp` (resolves a shadowed function name); tighten a few response-model return annotations.
- **settings.py** — only derive `jira_browse_url` when `atlassian_url` is set.

## Tests

- `tests/test_poll.py` — dropped the module-level `importorskip("fcntl")`, reworked the lock tests onto the shared `FileLock` abstraction, and added a `spawn` fallback where `fork` is unavailable, so the poll suite runs on Windows.
- `tests/test_filestore.py` — `TestGetUserGroups` now patches `platform_compat.optional_module` instead of the removed `filestore.pwd`/`filestore.grp` globals (same assertions).
- `tests/test_worker.py` — uses `platform_compat.current_uid`.


@StephanPreibisch @JaneliaSciComp/fileglancer 