### PR TITLE
ci: run Chromatic on authorized fork PRs, skip unauthorized ones

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,26 +4,43 @@ on:
   workflow_dispatch:
   push:
     branches: main
-  pull_request:
+  # pull_request_target runs in the context of the base repository, so the
+  # CHROMATIC_PROJECT_TOKEN secret is available even for pull requests opened
+  # from forks (a plain `pull_request` event withholds secrets from forks,
+  # which makes Chromatic fail). The job below checks out the PR head commit
+  # explicitly and is gated so untrusted fork code never runs with the secret.
+  pull_request_target:
     branches: "*"
 
 jobs:
   chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
+    # Run for pushes/manual dispatch and for same-repository PRs. For PRs from a
+    # fork, only run when the author is a trusted collaborator (OWNER, MEMBER, or
+    # COLLABORATOR) so the secret is exposed only to users who already have write
+    # access. PRs from unauthorized forks fall through this condition and the job
+    # is skipped (neutral) rather than failing.
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     defaults:
       run:
         working-directory: ./frontend
+    env:
+      CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      CHROMATIC_SLUG: ${{ github.repository }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-        env:
-          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
-          CHROMATIC_SLUG: ${{ github.repository }}
+          # For fork PRs, check out the contributor's head commit from their fork.
+          # Falls back to the base repository for pushes and same-repo PRs.
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24.14.0

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -52,7 +52,7 @@ jobs:
         # ⚠️ See your package manager's documentation for the correct command to install dependencies in a CI environment.
         run: npm ci
       - name: Run Chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@14cfaef73576e69f95f47f60058063f46ca38719 # v18.1.0
         with:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -37,6 +37,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # Don't persist the base-repo GITHUB_TOKEN in .git/config: this job
+          # checks out untrusted fork code and runs `npm ci` (lifecycle scripts),
+          # which could otherwise read the token. Chromatic doesn't need it.
+          persist-credentials: false
           # For fork PRs, check out the contributor's head commit from their fork.
           # Falls back to the base repository for pushes and same-repo PRs.
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}


### PR DESCRIPTION
## Make Chromatic work for fork PRs

A plain `pull_request` event withholds repository secrets from forks, so `CHROMATIC_PROJECT_TOKEN` is empty for pull requests opened from a fork and the Chromatic job fails. This reworks the workflow so fork PRs are handled deliberately.

### Changes
- **Trigger → `pull_request_target`** so the `CHROMATIC_PROJECT_TOKEN` secret is available even for fork PRs.
- **Job gate (`if:`)** — the job runs for pushes, manual dispatch, same-repo PRs, and fork PRs whose author is a trusted collaborator (`OWNER` / `MEMBER` / `COLLABORATOR`, via `author_association`). PRs from **unauthorized forks fall through the condition and the job is skipped (neutral) rather than failing**.
- **Checkout** now pins the PR head commit from the contributor's fork (`repository: head.repo.full_name`, `ref: head.sha`), so authorized fork PRs build the actual fork branch. Falls back to the base repo for pushes/same-repo PRs.
- Fixed two pre-existing bugs: the `CHROMATIC_*` env vars were attached to the checkout step (where the Chromatic action could not read them) — moved to job-level `env` — and the `CHROMATIC_SHA` push fallback used `github.ref` (a ref name) instead of `github.sha`.

### Security note
`pull_request_target` runs with secrets in scope, and this workflow checks out the PR head. The `if:` gate is the mitigation: untrusted fork code is never reached because the job is skipped for non-collaborator authors, and collaborators already have write access to the repo. Authorization uses `author_association` (no extra API call); note `MEMBER` is a slightly loose proxy for repo write access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)