### PR TITLE
Fix for options that can have multiple values other than strings

### DIFF
--- a/fileglancer/apps/core.py
+++ b/fileglancer/apps/core.py
@@ -270,7 +270,8 @@ def _find_manifests_in_repo(repo_dir: Path) -> list[tuple[str, AppManifest]]:
             if adapter.can_handle(repo_dir):
                 results.append(("", adapter.convert(repo_dir)))
         except Exception as e:
-            logger.warning(f"Adapter {type(adapter).__name__} failed: {e}")
+            raise ValueError(f"Adapter {type(adapter).__name__} failed: {e}")
+
 
     return results
 

--- a/fileglancer/apps/nextflow.py
+++ b/fileglancer/apps/nextflow.py
@@ -74,7 +74,10 @@ def _convert_property(name: str, prop: dict, is_required: bool) -> AppParameter:
     if prop.get("hidden"):
         kwargs["hidden"] = True
 
-    return AppParameter(**kwargs)
+    try:
+        return AppParameter(**kwargs)
+    except Exception as e:
+        raise ValueError(f"Error validating {name}: {e}")
 
 
 class NextflowAdapter:

--- a/fileglancer/model.py
+++ b/fileglancer/model.py
@@ -334,7 +334,7 @@ class AppParameter(BaseModel):
     description: Optional[str] = Field(description="Description of the parameter", default=None)
     required: bool = Field(description="Whether the parameter is required", default=False)
     default: Optional[Any] = Field(description="Default value for the parameter", default=None)
-    options: Optional[List[Any]] = Field(description="Allowed values for enum type", default=None)
+    options: Optional[List[str|int|float]] = Field(description="Allowed values for enum type", default=None)
     min: Optional[float] = Field(description="Minimum value for numeric types", default=None)
     max: Optional[float] = Field(description="Maximum value for numeric types", default=None)
     pattern: Optional[str] = Field(description="Regex validation pattern for string types", default=None)

--- a/fileglancer/model.py
+++ b/fileglancer/model.py
@@ -334,7 +334,7 @@ class AppParameter(BaseModel):
     description: Optional[str] = Field(description="Description of the parameter", default=None)
     required: bool = Field(description="Whether the parameter is required", default=False)
     default: Optional[Any] = Field(description="Default value for the parameter", default=None)
-    options: Optional[List[str]] = Field(description="Allowed values for enum type", default=None)
+    options: Optional[List[Any]] = Field(description="Allowed values for enum type", default=None)
     min: Optional[float] = Field(description="Minimum value for numeric types", default=None)
     max: Optional[float] = Field(description="Maximum value for numeric types", default=None)
     pattern: Optional[str] = Field(description="Regex validation pattern for string types", default=None)


### PR DESCRIPTION
This is the fix for https://github.com/JaneliaSciComp/fileglancer/issues/386. The problem was not related to the branch as the ticket mentioned but the schema optional values. The branch failed because of this particular parameter which was only in the branch and not in main:
```
                "segmentation_zarr_format": {
                    "type": "integer",
                    "default": 2,
                    "enum": [2, 3],
                    "description": "Zarr format version (2 or 3) for segmentation output zarr containers",
                    "fa_icon": "fas fa-file-archive"
                },
```