### PR TITLE
feat: change default dataLinkSubpathMode to the transparent path

### DIFF
--- a/frontend/src/contexts/PreferencesContext.tsx
+++ b/frontend/src/contexts/PreferencesContext.tsx
@@ -551,7 +551,8 @@ export const PreferencesProvider = ({
     hideDotFiles: preferencesQuery.data?.hideDotFiles || false,
     areDataLinksAutomatic:
       preferencesQuery.data?.areDataLinksAutomatic ?? false,
-    dataLinkSubpathMode: preferencesQuery.data?.dataLinkSubpathMode ?? 'name',
+    dataLinkSubpathMode:
+      preferencesQuery.data?.dataLinkSubpathMode ?? 'full_path',
     disableNeuroglancerStateGeneration:
       preferencesQuery.data?.disableNeuroglancerStateGeneration || false,
     disableHeuristicalLayerTypeDetection:

--- a/frontend/src/queries/preferencesQueries.ts
+++ b/frontend/src/queries/preferencesQueries.ts
@@ -237,7 +237,7 @@ const createTransformPreferences = (
         (rawData.dataLinkSubpathMode?.value as
           | 'name'
           | 'full_path'
-          | 'custom') ?? 'name',
+          | 'custom') ?? 'full_path',
       disableNeuroglancerStateGeneration:
         rawData.disableNeuroglancerStateGeneration?.value || false,
       disableHeuristicalLayerTypeDetection:

--- a/frontend/ui-tests/tests/data-link-operations.spec.ts
+++ b/frontend/ui-tests/tests/data-link-operations.spec.ts
@@ -21,6 +21,23 @@ const navigateToZarrDir = async (
   await page.waitForSelector('text=zarr.json', { timeout: 10000 });
 };
 
+const createLinkWithDirectoryNameOnlyFormat = async (page: any) => {
+  // Change data link format to "Directory name only" in the dialog
+  const advancedSettingsAccordion = page.getByRole('button', {
+    name: /advanced settings/i
+  });
+  await advancedSettingsAccordion.click();
+  const nameOnlyInput = page.getByLabel('Directory name only');
+  await nameOnlyInput.click();
+  await expect(nameOnlyInput).toBeChecked();
+  // Confirm in dialog
+  const confirmButton = page.getByRole('button', {
+    name: /confirm|create|yes/i
+  });
+  await expect(confirmButton).toBeVisible({ timeout: 5000 });
+  await confirmButton.click();
+};
+
 test.describe('Data Link Operations', () => {
   // These tests involve multiple full-page navigations with API calls
   test.setTimeout(60_000);
@@ -54,16 +71,31 @@ test.describe('Data Link Operations', () => {
       name: /delete/i
     });
 
-    await test.step('Turn on automatic data links via the data link dialog', async () => {
+    await test.step('Data link format defaults to transparent path', async () => {
       const neuroglancerLink = page.getByRole('link', {
         name: 'Neuroglancer logo'
       });
       await neuroglancerLink.click();
 
       // Confirm the data link creation in the dialog
-      await expect(confirmButton).toBeVisible({ timeout: 5000 });
+      await expect(confirmButton).toBeVisible();
 
-      // Enable automatic data links
+      // Check that the data link format is set to "Transparent path" in the dialog
+      const advancedSettingsAccordion = page.getByRole('button', {
+        name: /advanced settings/i
+      });
+      await advancedSettingsAccordion.click();
+      const fullPathInput = page.getByLabel('Full path');
+      await expect(fullPathInput).toBeChecked();
+    });
+
+    await test.step('Change data link format to directory name only', async () => {
+      const nameOnlyInput = page.getByLabel('Directory name only');
+      await nameOnlyInput.click();
+      await expect(nameOnlyInput).toBeChecked();
+    });
+
+    await test.step('Turn on automatic data links via the data link dialog', async () => {
       const autoLinkCheckbox = page.getByRole('checkbox', {
         name: 'Enable automatic data link creation'
       });
@@ -182,12 +214,7 @@ test.describe('Data Link Operations', () => {
     // Click the toggle to create a data link
     await dataLinkToggle.click();
 
-    // Confirm in dialog
-    const confirmButton = page.getByRole('button', {
-      name: /confirm|create|yes/i
-    });
-    await expect(confirmButton).toBeVisible({ timeout: 5000 });
-    await confirmButton.click();
+    await createLinkWithDirectoryNameOnlyFormat(page);
 
     await expect(
       page.getByText('Data link created successfully')
@@ -236,12 +263,7 @@ test.describe('Data Link Operations', () => {
     });
     await neuroglancerLink.click();
 
-    // Confirm in dialog
-    const confirmButton = page.getByRole('button', {
-      name: /confirm|create|yes/i
-    });
-    await expect(confirmButton).toBeVisible({ timeout: 5000 });
-    await confirmButton.click();
+    await createLinkWithDirectoryNameOnlyFormat(page);
 
     await expect(
       page.getByText('Data link created successfully')

--- a/frontend/ui-tests/tests/data-link-table-filtering.spec.ts
+++ b/frontend/ui-tests/tests/data-link-table-filtering.spec.ts
@@ -137,7 +137,7 @@ test.describe('Data Link Table Filtering', () => {
       await expect(page.getByRole('heading', { name: /links/i })).toBeVisible();
 
       // Check for the real link (zarr_v3_ome.zarr should be in the table)
-      await expect(page.getByText(zarrDirName, { exact: true })).toBeVisible();
+      await expect(page.getByText(global.testTempDir)).toBeVisible();
     });
 
     await test.step('Verify Mock Link 1 is now on Page 2 of the table', async () => {
@@ -204,7 +204,7 @@ test.describe('Data Link Table Filtering', () => {
       await searchInput.fill(zarrDirName);
 
       // Verify only the real data link is visible
-      await expect(page.getByText(zarrDirName, { exact: true })).toBeVisible();
+      await expect(page.getByText(global.testTempDir)).toBeVisible();
       await expect(
         page.getByText('Mock Link 1', { exact: true })
       ).not.toBeVisible();
@@ -222,7 +222,7 @@ test.describe('Data Link Table Filtering', () => {
       ).toBeVisible();
 
       // Verify the filter is still active (only real link visible)
-      await expect(page.getByText(zarrDirName, { exact: true })).toBeVisible();
+      await expect(page.getByText(global.testTempDir)).toBeVisible();
       await expect(page.getByText('Mock Link 1')).not.toBeVisible();
     });
 
@@ -237,7 +237,7 @@ test.describe('Data Link Table Filtering', () => {
       await page.waitForTimeout(500);
 
       // Verify the filter is still active (only real link visible)
-      await expect(page.getByText(zarrDirName, { exact: true })).toBeVisible();
+      await expect(page.getByText(global.testTempDir)).toBeVisible();
       await expect(page.getByText('Mock Link 1')).not.toBeVisible();
     });
 
@@ -249,7 +249,7 @@ test.describe('Data Link Table Filtering', () => {
       // Click on the file path link
       const filePathLink = page
         .getByRole('link')
-        .filter({ hasText: zarrDirName });
+        .filter({ hasText: global.testTempDir });
       await filePathLink.click();
 
       // Wait for navigation to complete


### PR DESCRIPTION
Clickup id: 86ahwwz3q
Data links now default to the full, transparent path instead of just the directory/file name. Updates both the preference-parsing fallback and the context fallback so a fresh user with no saved preference gets 'full_path'.
@krokicki 