### PR TITLE
fix: skip file/dir access checks in server process

### DIFF
--- a/fileglancer/apps/__init__.py
+++ b/fileglancer/apps/__init__.py
@@ -14,6 +14,7 @@ from fileglancer.apps.command import (  # noqa: F401
     _TOOL_REGISTRY,
     build_command,
     build_requirements_check,
+    collect_path_parameters,
     expand_user_path,
     merge_requirements,
     validate_path_for_shell,

--- a/fileglancer/apps/command.py
+++ b/fileglancer/apps/command.py
@@ -268,12 +268,21 @@ def validate_path_for_shell(path_value: str) -> str | None:
     return None
 
 
-def validate_path_in_filestore(path_value: str, fsps: list) -> str | None:
-    """Validate a path exists and is readable within an allowed file share.
+def validate_path_in_filestore(path_value: str, fsps: list, check_access: bool = True) -> str | None:
+    """Validate a path within an allowed file share.
 
-    Performs syntax checks, then resolves the path against the given list of
-    file share paths. Returns an error message string if invalid, or None if
-    valid.
+    Always performs syntax checks and confirms the path resolves within an
+    allowed file share; both checks are euid-independent. When check_access is
+    True, additionally verifies the path exists and is readable.
+
+    The exists/readable check reflects the *calling process's* identity, so it
+    is only meaningful when this runs as the target user (i.e. in the setuid
+    worker). Callers running on the root server must pass check_access=False —
+    otherwise validation reflects root's access, not the user's (false-pass on
+    local FS where root bypasses perms, false-reject on root-squash NFS) — and
+    defer the access check to the worker (see submit_job).
+
+    Returns an error message string if invalid, or None if valid.
     """
     # Syntax check first
     error = validate_path_for_shell(path_value)
@@ -289,22 +298,19 @@ def validate_path_in_filestore(path_value: str, fsps: list) -> str | None:
 
     expanded = os.path.expanduser(normalized)
 
-    # Resolve to a file share path
+    # Resolve to a file share path (euid-independent containment check)
     from fileglancer.database import find_fsp_in_paths
     result = find_fsp_in_paths(fsps, expanded)
     if result is None:
         return "Path is not within an allowed file share"
 
+    if not check_access:
+        return None
+
     fsp, subpath = result
 
     from fileglancer.filestore import Filestore
     filestore = Filestore(fsp)
-    # NOTE: this runs on the server (root in production); validate_path's
-    # exists/readable checks therefore reflect root's access, not the submitting
-    # user's (false-pass on local FS where root bypasses perms, false-reject on
-    # root-squash NFS). Fully correct per-user validation would have to run in
-    # the setuid worker. The file-share containment check above is euid-
-    # independent and still holds.
     return filestore.validate_path(subpath)
 
 
@@ -314,12 +320,14 @@ def validate_path_in_filestore(path_value: str, fsps: list) -> str | None:
 _ENV_VAR_NAME_PATTERN = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
 
 
-def _validate_parameter_value(param: AppParameter, value, session=None, username=None) -> str:
+def _validate_parameter_value(param: AppParameter, value, session=None, username=None,
+                              check_access: bool = True) -> str:
     """Validate a single parameter value against its schema and return the string representation.
 
     When session is provided and param type is file/directory, validates that
     the path is within an allowed file share mount. Otherwise falls back to
-    syntax-only validation.
+    syntax-only validation. check_access is forwarded to validate_path_in_filestore;
+    server-side callers should pass check_access=False (see submit_job).
 
     Raises ValueError if validation fails.
     """
@@ -367,7 +375,7 @@ def _validate_parameter_value(param: AppParameter, value, session=None, username
         str_val = expand_user_path(str_val, username)
         if session is not None:
             fsps = db.get_file_share_paths(session)
-            error = validate_path_in_filestore(str_val, fsps)
+            error = validate_path_in_filestore(str_val, fsps, check_access=check_access)
         else:
             error = validate_path_for_shell(str_val)
         if error:
@@ -392,7 +400,8 @@ def _flatten_param_items(items) -> list:
 
 
 def build_command(entry_point: AppEntryPoint, parameters: dict,
-                  env_parameters: dict = None, session=None, username=None) -> str:
+                  env_parameters: dict = None, session=None, username=None,
+                  check_access: bool = True) -> str:
     """Build a shell command from an entry point and parameter values.
 
     `parameters` and `env_parameters` are independent namespaces: each param
@@ -405,6 +414,9 @@ def build_command(entry_point: AppEntryPoint, parameters: dict,
     are emitted first in declaration order, then positional parameters (no
     flag). When session is provided, file/directory parameters are validated
     against allowed file share mounts. Raises ValueError for invalid parameters.
+    check_access controls whether file/directory paths are checked for
+    existence/readability; server-side callers should pass check_access=False
+    and defer that check to the setuid worker (see submit_job).
     """
     env_parameters = env_parameters or {}
     env_flat = _flatten_param_items(entry_point.env_parameters)
@@ -439,7 +451,8 @@ def build_command(entry_point: AppEntryPoint, parameters: dict,
     for p, value in effective:
         if p.flag is None:
             continue
-        validated = _validate_parameter_value(p, value, session=session, username=username)
+        validated = _validate_parameter_value(p, value, session=session, username=username,
+                                              check_access=check_access)
         if p.type == "boolean":
             if value is True:
                 parts.append(p.flag)
@@ -450,7 +463,8 @@ def build_command(entry_point: AppEntryPoint, parameters: dict,
     for p, value in effective:
         if p.flag is not None:
             continue
-        validated = _validate_parameter_value(p, value, session=session, username=username)
+        validated = _validate_parameter_value(p, value, session=session, username=username,
+                                              check_access=check_access)
         if p.raw:
             if _SHELL_METACHAR_PATTERN.search(validated):
                 raise ValueError(
@@ -461,3 +475,35 @@ def build_command(entry_point: AppEntryPoint, parameters: dict,
             parts.append(shlex.quote(validated))
 
     return (" \\\n  ").join(parts)
+
+
+def collect_path_parameters(entry_point: AppEntryPoint, parameters: dict,
+                            env_parameters: dict = None) -> list[tuple[str, str, str]]:
+    """Collect effective file/directory parameter values needing path validation.
+
+    Mirrors build_command's effective-value computation (user-provided merged
+    with defaults, across both the env and pipeline namespaces) but returns only
+    file/directory parameters as (param_key, param_name, raw_value) tuples.
+
+    Raw (un-expanded) values are returned so that authoritative validation can
+    run in the setuid worker, where '~' and access checks resolve as the target
+    user. See submit_job.
+    """
+    env_parameters = env_parameters or {}
+    env_flat = _flatten_param_items(entry_point.env_parameters)
+    param_flat = _flatten_param_items(entry_point.parameters)
+    groups = ((env_flat, env_parameters), (param_flat, parameters))
+
+    result: list[tuple[str, str, str]] = []
+    for flat, values in groups:
+        for param in flat:
+            if param.type not in ("file", "directory"):
+                continue
+            if param.key in values:
+                value = values[param.key]
+            elif param.default is not None:
+                value = param.default
+            else:
+                continue
+            result.append((param.key, param.name, str(value)))
+    return result

--- a/fileglancer/apps/jobs.py
+++ b/fileglancer/apps/jobs.py
@@ -27,6 +27,7 @@ from fileglancer.apps.manifest import (
 from fileglancer.apps.command import (
     build_command,
     build_requirements_check,
+    collect_path_parameters,
     expand_user_path,
     merge_requirements,
     _ENV_VAR_NAME_PATTERN,
@@ -478,9 +479,32 @@ async def submit_job(
         manifest.requirements, entry_point.requirements
     )
 
-    # Build command (with DB session for path validation against file shares)
+    # Build command (with DB session for path validation against file shares).
+    # check_access=False because this runs on the root server, which can't
+    # reliably stat the user's files (root-squash NFS makes group-readable paths
+    # appear absent). Only euid-independent checks — syntax and file-share
+    # containment — run here; exists/readable is validated as the user below.
     with db.get_db_session(settings.db_url) as session:
-        command = build_command(entry_point, parameters, env_parameters, session=session, username=username)
+        command = build_command(entry_point, parameters, env_parameters,
+                                session=session, username=username, check_access=False)
+
+    # Authoritative per-user path validation: check that file/directory params
+    # exist and are readable, run in the setuid worker as the target user. This
+    # is the same fix applied to data links in commit f9858f48 — the server runs
+    # as a service account that isn't in the user's groups, so a redundant
+    # server-side check would wrongly reject (or, on local FS, wrongly accept)
+    # paths the user can actually access.
+    path_params = collect_path_parameters(entry_point, parameters, env_parameters)
+    if path_params:
+        paths_to_check = {str(i): value for i, (_, _, value) in enumerate(path_params)}
+        validation = await _dispatch(username, "validate_paths", paths=paths_to_check)
+        errors = (validation or {}).get("errors") or {}
+        if errors:
+            # Report the first failure, keyed back to its parameter name, to
+            # match the single-message format build_command would have raised.
+            idx = min(int(i) for i in errors)
+            _, param_name, _ = path_params[idx]
+            raise ValueError(f"Parameter '{param_name}': {errors[str(idx)]}")
 
     # Build resource spec (extra_args passed separately, not from manifest)
     overrides = dict(resources) if resources else {}

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -1317,33 +1317,6 @@ def create_app(settings):
             logger.opt(exception=sys.exc_info()).info("Error requesting head")
             return get_error_response(500, "InternalError", "Error requesting HEAD", path)
 
-
-    def _get_mounted_filestore(fsp: FileSharePath):
-        """Constructs a filestore for the given file share path, checking to make sure it is mounted."""
-        filestore = Filestore(fsp)
-        try:
-            filestore.get_file_info(None)
-        except FileNotFoundError:
-            return None
-        return filestore
-
-
-    def _get_filestore(path_name: str):
-        """Get a filestore for the given path name."""
-        # Get file share path using centralized function and filter for the requested path
-        with db.get_db_session(settings.db_url) as session:
-            fsp = db.get_file_share_path(session, path_name)
-            if fsp is None:
-                return None, f"File share path '{path_name}' not found"
-
-        # Create a filestore for the file share path
-        filestore = _get_mounted_filestore(fsp)
-        if filestore is None:
-            return None, f"File share path '{path_name}' is not mounted"
-
-        return filestore, None
-
-
     # Profile endpoint
     @app.get("/api/profile", description="Get the current user's profile")
     async def get_profile(username: str = Depends(get_current_user)):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fileglancer",
-    "version": "2.10.0-a0",
+    "version": "2.10.0-a1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fileglancer",
-            "version": "2.10.0-a0",
+            "version": "2.10.0-a1",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@bioimagetools/capability-manifest": "0.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fileglancer",
     "type": "module",
-    "version": "2.10.0-a0",
+    "version": "2.10.0-a1",
     "description": "Browse, share, and publish files on the Janelia file system",
     "keywords": [
         "ngff",

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -874,7 +874,8 @@ class TestBuildCommandCheckAccess:
         missing = str(tmp_path / "nope")
         cmd = build_command(self._ep(), {"input": missing},
                             session=object(), check_access=False)
-        assert missing in cmd
+        # build_command normalizes backslashes to forward slashes.
+        assert missing.replace("\\", "/") in cmd
 
     def test_check_access_false_still_rejects_outside_share(self, tmp_path, monkeypatch):
         """check_access=False does not bypass file-share containment."""

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -23,6 +23,7 @@ from fileglancer.apps import (
     _container_sif_name,
     _build_container_script,
     build_command,
+    collect_path_parameters,
     expand_user_path,
 )
 
@@ -747,6 +748,26 @@ class TestValidatePathInFilestore:
         assert error is not None
         assert "invalid characters" in error
 
+    def test_check_access_false_skips_exists_check(self, tmp_path):
+        """With check_access=False, a nonexistent path inside a share passes.
+
+        Exists/readable checks must be deferred to the setuid worker; the
+        server-side call only confirms file-share containment.
+        """
+        from fileglancer.model import FileSharePath
+        fsp = FileSharePath(zone="test", name="test", mount_path=str(tmp_path))
+        missing = str(tmp_path / "no_such_file.txt")
+        # Default (check_access=True) rejects the missing path...
+        assert validate_path_in_filestore(missing, [fsp]) == "Path does not exist"
+        # ...but with check_access=False the containment check alone passes.
+        assert validate_path_in_filestore(missing, [fsp], check_access=False) is None
+
+    def test_check_access_false_still_enforces_containment(self):
+        """check_access=False does not bypass the file-share containment check."""
+        error = validate_path_in_filestore("/nowhere/file.txt", [], check_access=False)
+        assert error is not None
+        assert "not within an allowed file share" in error
+
 
 
 class TestBuildCommandTildeExpansion:
@@ -813,6 +834,98 @@ class TestBuildCommandTildeExpansion:
         )
         cmd = build_command(ep, {"input": "s3://bucket/key"})
         assert "s3://bucket/key" in cmd
+
+
+class TestBuildCommandCheckAccess:
+    """build_command(check_access=False) defers exists checks to the worker."""
+
+    def _ep(self):
+        return AppEntryPoint(
+            id="test",
+            name="test",
+            command="test_cmd",
+            parameters=[{
+                "key": "input",
+                "name": "Input Path",
+                "type": "directory",
+                "flag": "--input",
+            }],
+        )
+
+    def _stub_fsps(self, monkeypatch, tmp_path):
+        """Make build_command's file-share lookup return a share at tmp_path."""
+        from fileglancer.model import FileSharePath
+        import fileglancer.apps.command as command_mod
+
+        fsp = FileSharePath(zone="test", name="test", mount_path=str(tmp_path))
+        monkeypatch.setattr(command_mod.db, "get_file_share_paths",
+                            lambda session: [fsp])
+
+    def test_default_rejects_missing_path(self, tmp_path, monkeypatch):
+        """With a session and the default check_access, a missing path raises."""
+        self._stub_fsps(monkeypatch, tmp_path)
+        missing = str(tmp_path / "nope")
+        with pytest.raises(ValueError, match="Path does not exist"):
+            build_command(self._ep(), {"input": missing}, session=object())
+
+    def test_check_access_false_allows_missing_path(self, tmp_path, monkeypatch):
+        """check_access=False lets a missing-but-contained path build the command."""
+        self._stub_fsps(monkeypatch, tmp_path)
+        missing = str(tmp_path / "nope")
+        cmd = build_command(self._ep(), {"input": missing},
+                            session=object(), check_access=False)
+        assert missing in cmd
+
+    def test_check_access_false_still_rejects_outside_share(self, tmp_path, monkeypatch):
+        """check_access=False does not bypass file-share containment."""
+        self._stub_fsps(monkeypatch, tmp_path)
+        with pytest.raises(ValueError, match="not within an allowed file share"):
+            build_command(self._ep(), {"input": "/somewhere/else"},
+                          session=object(), check_access=False)
+
+
+class TestCollectPathParameters:
+    """collect_path_parameters gathers effective file/directory params."""
+
+    def test_collects_user_and_default_values_across_namespaces(self):
+        ep = AppEntryPoint(
+            id="test",
+            name="test",
+            command="test_cmd",
+            env_parameters=[{
+                "key": "envdir",
+                "name": "Env Dir",
+                "type": "directory",
+                "default": "/data/envdefault",
+            }],
+            parameters=[
+                {"key": "input", "name": "Input Path", "type": "file", "flag": "--input"},
+                {"key": "count", "name": "Count", "type": "integer", "flag": "--count"},
+                {"key": "outdir", "name": "Out Dir", "type": "directory",
+                 "flag": "--outdir", "default": "/data/outdefault"},
+            ],
+        )
+        result = collect_path_parameters(
+            ep,
+            {"input": "/data/in.txt", "count": 5},
+            env_parameters={},
+        )
+        # Only file/directory params; non-path 'count' excluded. Env namespace
+        # default included; pipeline 'outdir' falls back to its default.
+        assert result == [
+            ("envdir", "Env Dir", "/data/envdefault"),
+            ("input", "Input Path", "/data/in.txt"),
+            ("outdir", "Out Dir", "/data/outdefault"),
+        ]
+
+    def test_omits_path_params_without_value_or_default(self):
+        ep = AppEntryPoint(
+            id="test",
+            name="test",
+            command="test_cmd",
+            parameters=[{"key": "input", "name": "Input Path", "type": "file", "flag": "--input"}],
+        )
+        assert collect_path_parameters(ep, {}) == []
 
 
 class TestExpandUserPath:


### PR DESCRIPTION
This PR was motivated by a "Parameter 'Input Path': Path does not exist" error when attempting to submit a job with an input path to the cluster. To fix this, the code now skips the file access check inside `build_command` via a new `check_access` flag that `submit_job`, the function calling `build_command`, sets to `false`. The `build_command` runs in the server process and is root squashed and therefore cannot see the user's group-readable paths. The access check is deferred and run in user worker called after the `build_command` step in `submit_job`. The PR also removes two other functions found in the code base that attempt to `os.lstat`/`os.stat` on a server process - the functions were removed because they are dead code.

Note: this is the same type of bug as was fixed in commit f9858f48821cbab881f5a69c03ad9c6978047381. I asked Claude to look for other potential instances of the server process trying to validate whether a user can access a specific path, and the only instances that came up were the two dead functions mentioned above. However, it's possible this bug may pop up elsewhere. Just flagging this for other's awareness.

@krokicki
