### PR TITLE
Use explicit --manifest-path for pixi jobs instead of unsetting PIXI_PROJECT_MANIFEST

### DIFF
--- a/fileglancer/apps/jobs.py
+++ b/fileglancer/apps/jobs.py
@@ -870,12 +870,16 @@ async def submit_job(
 
         # Set up the script preamble:
         # - FG_WORK_DIR: the job's working directory (used by subsequent variables)
-        # - Unset PIXI_PROJECT_MANIFEST so pixi uses the repo's own manifest
+        # - FG_MANIFEST_DIR: the directory containing the app's manifest (pixi.toml,
+        #   runnables.yaml, etc.), so commands can reference it explicitly instead
+        #   of relying on the cwd. Always points at the manifest directory, even
+        #   when effective_working_dir is "work" (the repo stays reachable there
+        #   via the `repo` symlink).
         # - SERVICE_URL_PATH: for service-type jobs, where to write the service URL
         # - cd into the repo so commands can find project files (pixi.toml, scripts, etc.)
         preamble_lines = [
-            "unset PIXI_PROJECT_MANIFEST",
             f"export FG_WORK_DIR={shlex.quote(str(work_dir))}",
+            f'export FG_MANIFEST_DIR="$FG_WORK_DIR"/{shlex.quote(cd_suffix)}',
             # Where the script reports its startup phase (e.g. pulling a container
             # image). The UI reads this to explain a wait before a service is ready.
             'export FG_PHASE_PATH="$FG_WORK_DIR/phase"',

--- a/fileglancer/apps/pixi.py
+++ b/fileglancer/apps/pixi.py
@@ -139,7 +139,7 @@ def _task_to_entry_point(name: str, task: dict) -> AppEntryPoint | None:
         cmd = " ".join(cmd)
 
     # Build the pixi run command
-    command = f"pixi run {name}"
+    command = f'pixi run --manifest-path "$FG_MANIFEST_DIR" {name}'
 
     description = task.get("description")
 

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -2857,8 +2857,10 @@ class TestSubmitJobAssembly:
         )
         script = self._submitted(calls)["command"]
 
-        assert script.startswith("unset PIXI_PROJECT_MANIFEST")
-        assert f"export FG_WORK_DIR={shlex.quote(job.work_dir)}" in script
+        assert script.startswith(f"export FG_WORK_DIR={shlex.quote(job.work_dir)}")
+        # FG_MANIFEST_DIR always points at the manifest's directory, so
+        # pixi-style commands can pass --manifest-path explicitly.
+        assert 'export FG_MANIFEST_DIR="$FG_WORK_DIR"/repo' in script
         # Default working dir is the repo snapshot (no manifest subdir here).
         assert 'cd "$FG_WORK_DIR"/repo' in script
         assert "conda activate tools" in script


### PR DESCRIPTION
## Summary
- pixi's `--manifest-path` flag always overrides the `PIXI_PROJECT_MANIFEST` env var (verified against pixi 0.70.2), so this switches the generated pixi command to `pixi run --manifest-path "$FG_MANIFEST_DIR" <task>` instead of unsetting `PIXI_PROJECT_MANIFEST` and relying on cwd-based manifest discovery.
- Introduces `FG_MANIFEST_DIR`, exported alongside `FG_WORK_DIR` in every generated job script (all app types, not just pixi), pointing at the directory containing the app's manifest.
- Updates `docs/AuthoringApps.md` to document the new env var and command format.

## Test plan
- [x] `pixi run -e test test-backend` — all 317 tests pass
- [ ] Manually submit a pixi-based app job and confirm the generated script contains `export FG_MANIFEST_DIR=...` and `pixi run --manifest-path "$FG_MANIFEST_DIR" <task>`, with no `unset PIXI_PROJECT_MANIFEST` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)