### PR TITLE
feat: Neuroglancer base url preference when deployment overrides default

### DIFF
--- a/docs/ViewersConfiguration.md
+++ b/docs/ViewersConfiguration.md
@@ -114,6 +114,12 @@ viewers:
 
 ```
 
+#### Per-user override of the Neuroglancer URL
+
+When a deployment overrides Neuroglancer's URL with `instance_template_url` (for example, to point at an internal Neuroglancer instance), individual users can still switch their own links back to the manifest default (the external Neuroglancer at `neuroglancer-demo.appspot.com`) from **Preferences → Neuroglancer**.
+
+This choice is a per-user preference (`viewerUrlSources`); it does not change the deployment configuration and only affects the user who sets it. The option only appears when the deployment actually overrides the Neuroglancer URL — if the configured URL already equals the manifest default, there is nothing to switch between and no control is shown.
+
 ### Add a custom viewer
 
 To add a new viewer, create a capability manifest YAML file, host it at a URL, and reference it in the config:

--- a/frontend/src/__tests__/unitTests/viewerUrl.test.ts
+++ b/frontend/src/__tests__/unitTests/viewerUrl.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+
+import { resolveViewerTemplate } from '@/utils/viewerUrl';
+import type { ValidViewer } from '@/contexts/ViewersContext';
+
+const viewer = {
+  key: 'neuroglancer',
+  displayName: 'Neuroglancer',
+  urlTemplate: 'https://ng.internal.example.org/#!',
+  manifestTemplateUrl: 'https://neuroglancer-demo.appspot.com/#!',
+  logoPath: '',
+  label: 'View in Neuroglancer',
+  manifest: {} as ValidViewer['manifest']
+} satisfies ValidViewer;
+
+describe('resolveViewerTemplate', () => {
+  test('defaults to the configured template when no source is set', () => {
+    expect(resolveViewerTemplate(viewer, undefined)).toBe(viewer.urlTemplate);
+    expect(resolveViewerTemplate(viewer, 'configured')).toBe(
+      viewer.urlTemplate
+    );
+  });
+
+  test('uses the manifest default when source is "manifest"', () => {
+    expect(resolveViewerTemplate(viewer, 'manifest')).toBe(
+      viewer.manifestTemplateUrl
+    );
+  });
+
+  test('falls back to the configured template when manifest default is empty', () => {
+    const noManifest = { ...viewer, manifestTemplateUrl: '' };
+    expect(resolveViewerTemplate(noManifest, 'manifest')).toBe(
+      noManifest.urlTemplate
+    );
+  });
+
+  test('uses the custom URL when provided', () => {
+    expect(
+      resolveViewerTemplate(viewer, { custom: 'https://custom.example/#!' })
+    ).toBe('https://custom.example/#!');
+  });
+
+  test('falls back to the configured template for an empty custom URL', () => {
+    expect(resolveViewerTemplate(viewer, { custom: '' })).toBe(
+      viewer.urlTemplate
+    );
+  });
+});

--- a/frontend/src/components/NGLinks.tsx
+++ b/frontend/src/components/NGLinks.tsx
@@ -10,6 +10,7 @@ import FgDialog from '@/components/ui/Dialogs/FgDialog';
 import { useNGLinkContext } from '@/contexts/NGLinkContext';
 import type { CreateNGLinkPayload, NGLink } from '@/queries/ngLinkQueries';
 import { copyToClipboard } from '@/utils/copyText';
+import { useDefaultNeuroglancerBaseUrl } from '@/hooks/useDefaultNeuroglancerBaseUrl';
 import FgButton from './designSystem/atoms/FgButton';
 
 export default function NGLinks() {
@@ -22,6 +23,7 @@ export default function NGLinks() {
   const [showDialog, setShowDialog] = useState(false);
   const [editItem, setEditItem] = useState<NGLink | undefined>(undefined);
   const [deleteItem, setDeleteItem] = useState<NGLink | undefined>(undefined);
+  const defaultBaseUrl = useDefaultNeuroglancerBaseUrl();
 
   const handleOpenCreate = () => {
     setEditItem(undefined);
@@ -134,6 +136,7 @@ export default function NGLinks() {
       </div>
       {showDialog ? (
         <NGLinkDialog
+          defaultBaseUrl={defaultBaseUrl}
           editItem={editItem}
           onClose={handleClose}
           onCreate={handleCreate}

--- a/frontend/src/components/Preferences.tsx
+++ b/frontend/src/components/Preferences.tsx
@@ -29,8 +29,16 @@ export default function Preferences() {
             <Typography className="font-semibold mb-4" type="lead">
               Data links
             </Typography>
-            <div className="flex flex-col gap-4 pl-4 max-w-md">
+            <div className="pl-4 max-w-md">
               <DataLinkOptions />
+            </div>
+          </div>
+
+          <div>
+            <Typography className="font-semibold mb-4" type="lead">
+              Neuroglancer links
+            </Typography>
+            <div className="pl-4 max-w-md">
               <NeuroglancerOptions />
             </div>
           </div>

--- a/frontend/src/components/ui/Dialogs/NGLinkDialog.tsx
+++ b/frontend/src/components/ui/Dialogs/NGLinkDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import type { ChangeEvent } from 'react';
 import { Typography } from '@material-tailwind/react';
 
@@ -13,6 +13,9 @@ import {
   validateJsonState,
   constructNeuroglancerUrl
 } from '@/utils';
+import { resolveViewerTemplate } from '@/utils/viewerUrl';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
+import { useViewersContext } from '@/contexts/ViewersContext';
 import FgButton from '@/components/designSystem/atoms/FgButton';
 import FgFormField from '@/components/designSystem/molecules/FgFormField';
 import FgInput from '@/components/designSystem/atoms/formElements/FgInput';
@@ -29,6 +32,7 @@ type NGLinkDialogProps = {
   readonly editItem?: NGLink;
 };
 
+// Fallback used only when no Neuroglancer viewer is configured.
 const DEFAULT_BASE_URL = 'https://neuroglancer-demo.appspot.com/';
 
 export default function NGLinkDialog({
@@ -43,10 +47,33 @@ export default function NGLinkDialog({
   const urlInputRef = useRef<HTMLInputElement>(null);
   const shouldAutoSelectUrl = useRef(false);
 
+  const { validViewers } = useViewersContext();
+  const { viewerUrlSources } = usePreferencesContext();
+
+  // The base URL a new short link defaults to, honoring the deployment's
+  // configured Neuroglancer URL and the user's per-viewer URL preference.
+  const defaultBaseUrl = useMemo(() => {
+    const source = viewerUrlSources['neuroglancer'];
+    const neuroglancer = validViewers.find(v => v.key === 'neuroglancer');
+    if (neuroglancer) {
+      const template = resolveViewerTemplate(neuroglancer, source);
+      // Strip the '#!' state fragment to get the bare base URL.
+      return template.split('#!')[0] || DEFAULT_BASE_URL;
+    }
+    // No Neuroglancer viewer is configured, so 'configured'/'manifest' have no
+    // template to resolve. A user-supplied custom URL is the only preference
+    // value that carries a URL on its own; otherwise fall back to the external
+    // default.
+    if (typeof source === 'object' && source.custom) {
+      return source.custom.split('#!')[0] || DEFAULT_BASE_URL;
+    }
+    return DEFAULT_BASE_URL;
+  }, [validViewers, viewerUrlSources]);
+
   const [inputMode, setInputMode] = useState<'url' | 'state'>('url');
   const [neuroglancerUrl, setNeuroglancerUrl] = useState('');
   const [stateJson, setStateJson] = useState('');
-  const [baseUrl, setBaseUrl] = useState(DEFAULT_BASE_URL);
+  const [baseUrl, setBaseUrl] = useState(defaultBaseUrl);
   const [shortName, setShortName] = useState('');
   const [title, setTitle] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -78,11 +105,21 @@ export default function NGLinkDialog({
       setShortName('');
       setTitle('');
       setStateJson('');
-      setBaseUrl(DEFAULT_BASE_URL);
       setUrlValidationError(null);
       setStateValidationError(null);
     }
   }, [editItem]);
+
+  // When creating a new link, keep the base URL aligned with the resolved
+  // default as it becomes available (viewers finishing loading) or changes
+  // (preference update). Owns the create-mode base URL so the reset above
+  // stays keyed on editItem alone and never clears a half-filled form. Does
+  // not run in edit mode, so existing links keep their stored base URL.
+  useEffect(() => {
+    if (!editItem) {
+      setBaseUrl(defaultBaseUrl);
+    }
+  }, [defaultBaseUrl, editItem]);
 
   // Auto-select the URL text once after it's populated in edit mode
   useEffect(() => {
@@ -131,7 +168,7 @@ export default function NGLinkDialog({
     if (!isEditMode) {
       setNeuroglancerUrl('');
       setStateJson('');
-      setBaseUrl(DEFAULT_BASE_URL);
+      setBaseUrl(defaultBaseUrl);
     }
     setUrlValidationError(null);
     setStateValidationError(null);
@@ -172,7 +209,7 @@ export default function NGLinkDialog({
     setInputMode('url');
     setNeuroglancerUrl('');
     setStateJson('');
-    setBaseUrl(DEFAULT_BASE_URL);
+    setBaseUrl(defaultBaseUrl);
     setShortName('');
     setTitle('');
     onClose();
@@ -294,7 +331,7 @@ export default function NGLinkDialog({
               autoFocus
               id="neuroglancer-url"
               onChange={handleUrlChange}
-              placeholder="https://neuroglancer-demo.appspot.com/#!{...}"
+              placeholder={`${defaultBaseUrl}#!{...}`}
               ref={urlInputRef}
               size="lg"
               type="text"
@@ -328,7 +365,7 @@ export default function NGLinkDialog({
                 onChange={(e: ChangeEvent<HTMLInputElement>) =>
                   setBaseUrl(e.target.value)
                 }
-                placeholder="https://neuroglancer-demo.appspot.com/"
+                placeholder={defaultBaseUrl}
                 size="lg"
                 type="text"
                 value={baseUrl}

--- a/frontend/src/components/ui/Dialogs/NGLinkDialog.tsx
+++ b/frontend/src/components/ui/Dialogs/NGLinkDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type { ChangeEvent } from 'react';
 import { Typography } from '@material-tailwind/react';
 
@@ -13,9 +13,7 @@ import {
   validateJsonState,
   constructNeuroglancerUrl
 } from '@/utils';
-import { resolveViewerTemplate } from '@/utils/viewerUrl';
-import { usePreferencesContext } from '@/contexts/PreferencesContext';
-import { useViewersContext } from '@/contexts/ViewersContext';
+import { DEFAULT_NEUROGLANCER_BASE_URL } from '@/hooks/useDefaultNeuroglancerBaseUrl';
 import FgButton from '@/components/designSystem/atoms/FgButton';
 import FgFormField from '@/components/designSystem/molecules/FgFormField';
 import FgInput from '@/components/designSystem/atoms/formElements/FgInput';
@@ -30,10 +28,13 @@ type NGLinkDialogProps = {
   readonly onCreate?: (payload: CreateNGLinkPayload) => Promise<void>;
   readonly onUpdate?: (payload: UpdateNGLinkPayload) => Promise<void>;
   readonly editItem?: NGLink;
+  /**
+   * Base URL a new short link defaults to, resolved from the deployment config
+   * and the user's Neuroglancer URL preference by the parent. Falls back to the
+   * external default when not provided.
+   */
+  readonly defaultBaseUrl?: string;
 };
-
-// Fallback used only when no Neuroglancer viewer is configured.
-const DEFAULT_BASE_URL = 'https://neuroglancer-demo.appspot.com/';
 
 export default function NGLinkDialog({
   open,
@@ -41,34 +42,12 @@ export default function NGLinkDialog({
   onClose,
   onCreate,
   onUpdate,
-  editItem
+  editItem,
+  defaultBaseUrl = DEFAULT_NEUROGLANCER_BASE_URL
 }: NGLinkDialogProps) {
   const isEditMode = !!editItem;
   const urlInputRef = useRef<HTMLInputElement>(null);
   const shouldAutoSelectUrl = useRef(false);
-
-  const { validViewers } = useViewersContext();
-  const { viewerUrlSources } = usePreferencesContext();
-
-  // The base URL a new short link defaults to, honoring the deployment's
-  // configured Neuroglancer URL and the user's per-viewer URL preference.
-  const defaultBaseUrl = useMemo(() => {
-    const source = viewerUrlSources['neuroglancer'];
-    const neuroglancer = validViewers.find(v => v.key === 'neuroglancer');
-    if (neuroglancer) {
-      const template = resolveViewerTemplate(neuroglancer, source);
-      // Strip the '#!' state fragment to get the bare base URL.
-      return template.split('#!')[0] || DEFAULT_BASE_URL;
-    }
-    // No Neuroglancer viewer is configured, so 'configured'/'manifest' have no
-    // template to resolve. A user-supplied custom URL is the only preference
-    // value that carries a URL on its own; otherwise fall back to the external
-    // default.
-    if (typeof source === 'object' && source.custom) {
-      return source.custom.split('#!')[0] || DEFAULT_BASE_URL;
-    }
-    return DEFAULT_BASE_URL;
-  }, [validViewers, viewerUrlSources]);
 
   const [inputMode, setInputMode] = useState<'url' | 'state'>('url');
   const [neuroglancerUrl, setNeuroglancerUrl] = useState('');

--- a/frontend/src/components/ui/PreferencesPage/DataLinkOptions.tsx
+++ b/frontend/src/components/ui/PreferencesPage/DataLinkOptions.tsx
@@ -74,7 +74,7 @@ export default function DataLinkOptions({
   };
 
   return (
-    <>
+    <div className="space-y-4">
       <FgSwitch
         checked={automaticOption.checked}
         id={automaticOption.id}
@@ -83,6 +83,6 @@ export default function DataLinkOptions({
         showState
       />
       {hideSubpathMode ? null : <SubpathModeOptions />}
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/ui/PreferencesPage/NeuroglancerOptions.tsx
+++ b/frontend/src/components/ui/PreferencesPage/NeuroglancerOptions.tsx
@@ -1,8 +1,20 @@
+import { Typography } from '@material-tailwind/react';
 import toast from 'react-hot-toast';
 
 import FgSwitch from '@/components/designSystem/atoms/formElements/FgSwitch';
+import FgRadio from '@/components/designSystem/atoms/formElements/FgRadio';
 import FgFieldSet from '@/components/designSystem/molecules/FgFieldSet';
 import { usePreferencesContext } from '@/contexts/PreferencesContext';
+import { useViewersContext } from '@/contexts/ViewersContext';
+
+/** Best-effort hostname for display; falls back to the raw template. */
+function hostLabel(template: string): string {
+  try {
+    return new URL(template).hostname;
+  } catch {
+    return template;
+  }
+}
 
 export default function NeuroglancerOptions() {
   const {
@@ -11,65 +23,114 @@ export default function NeuroglancerOptions() {
     disableNeuroglancerStateGeneration,
     toggleDisableNeuroglancerStateGeneration,
     disableHeuristicalLayerTypeDetection,
-    toggleDisableHeuristicalLayerTypeDetection
+    toggleDisableHeuristicalLayerTypeDetection,
+    viewerUrlSources,
+    setViewerUrlSource
   } = usePreferencesContext();
+  const { validViewers } = useViewersContext();
+
+  const neuroglancer = validViewers.find(v => v.key === 'neuroglancer');
+
+  // Only offer the URL choice when the deployment overrides the Neuroglancer URL
+  // (i.e. the configured template differs from the manifest default). Otherwise
+  // both options resolve to the same URL and the control is meaningless.
+  const showUrlSourceChoice =
+    !!neuroglancer &&
+    !!neuroglancer.manifestTemplateUrl &&
+    neuroglancer.manifestTemplateUrl !== neuroglancer.urlTemplate;
+
+  const currentSource =
+    viewerUrlSources['neuroglancer'] === 'manifest' ? 'manifest' : 'configured';
+
+  const handleUrlSourceChange = async (source: 'configured' | 'manifest') => {
+    const result = await setViewerUrlSource('neuroglancer', source);
+    if (result.success) {
+      toast.success('Neuroglancer URL preference updated');
+    } else {
+      toast.error(result.error);
+    }
+  };
 
   return (
-    <FgFieldSet legend="Neuroglancer">
-      <FgSwitch
-        checked={useLegacyMultichannelApproach ?? false}
-        id="use_legacy_multichannel_approach"
-        label="Generate multichannel state for Neuroglancer"
-        onChange={async () => {
-          const result = await toggleUseLegacyMultichannelApproach();
-          if (result.success) {
-            toast.success(
-              useLegacyMultichannelApproach
-                ? 'Disabled multichannel state generation for Neuroglancer'
-                : 'Enabled multichannel state generation for Neuroglancer'
-            );
-          } else {
-            toast.error(result.error);
-          }
-        }}
-        showState
-      />
-      <FgSwitch
-        checked={disableNeuroglancerStateGeneration}
-        id="disable_neuroglancer_state_generation"
-        label="Disable Neuroglancer state generation"
-        onChange={async () => {
-          const result = await toggleDisableNeuroglancerStateGeneration();
-          if (result.success) {
-            toast.success(
-              disableNeuroglancerStateGeneration
-                ? 'Neuroglancer state generation is now enabled'
-                : 'Neuroglancer state generation is now disabled'
-            );
-          } else {
-            toast.error(result.error);
-          }
-        }}
-        showState
-      />
-      <FgSwitch
-        checked={disableHeuristicalLayerTypeDetection ?? false}
-        id="disable_heuristical_layer_type_detection"
-        label="Disable heuristical layer type determination"
-        onChange={async () => {
-          const result = await toggleDisableHeuristicalLayerTypeDetection();
-          if (result.success) {
-            toast.success(
-              disableHeuristicalLayerTypeDetection
-                ? 'Heuristical layer type determination is now enabled'
-                : 'Heuristical layer type determination is now disabled'
-            );
-          } else {
-            toast.error(result.error);
-          }
-        }}
-        showState
-      />
-    </FgFieldSet>
+    <div className="space-y-4">
+      {showUrlSourceChoice ? (
+        <FgFieldSet legend="Base URL">
+          <FgRadio
+            checked={currentSource === 'configured'}
+            color="primary"
+            id="neuroglancer_url_configured"
+            label={`Internal Neuroglancer (${hostLabel(neuroglancer.urlTemplate)})`}
+            name="neuroglancer_url_source"
+            onChange={() => handleUrlSourceChange('configured')}
+            value="configured"
+          />
+          <FgRadio
+            checked={currentSource === 'manifest'}
+            color="primary"
+            id="neuroglancer_url_manifest"
+            label={`External Neuroglancer (${hostLabel(neuroglancer.manifestTemplateUrl)})`}
+            name="neuroglancer_url_source"
+            onChange={() => handleUrlSourceChange('manifest')}
+            value="manifest"
+          />
+        </FgFieldSet>
+      ) : null}
+      <FgFieldSet legend="State generation options">
+        <FgSwitch
+          checked={useLegacyMultichannelApproach ?? false}
+          id="use_legacy_multichannel_approach"
+          label="Generate multichannel state for Neuroglancer"
+          onChange={async () => {
+            const result = await toggleUseLegacyMultichannelApproach();
+            if (result.success) {
+              toast.success(
+                useLegacyMultichannelApproach
+                  ? 'Disabled multichannel state generation for Neuroglancer'
+                  : 'Enabled multichannel state generation for Neuroglancer'
+              );
+            } else {
+              toast.error(result.error);
+            }
+          }}
+          showState
+        />
+        <FgSwitch
+          checked={disableNeuroglancerStateGeneration}
+          id="disable_neuroglancer_state_generation"
+          label="Disable Neuroglancer state generation"
+          onChange={async () => {
+            const result = await toggleDisableNeuroglancerStateGeneration();
+            if (result.success) {
+              toast.success(
+                disableNeuroglancerStateGeneration
+                  ? 'Neuroglancer state generation is now enabled'
+                  : 'Neuroglancer state generation is now disabled'
+              );
+            } else {
+              toast.error(result.error);
+            }
+          }}
+          showState
+        />
+        <FgSwitch
+          checked={disableHeuristicalLayerTypeDetection ?? false}
+          id="disable_heuristical_layer_type_detection"
+          label="Disable heuristical layer type determination"
+          onChange={async () => {
+            const result = await toggleDisableHeuristicalLayerTypeDetection();
+            if (result.success) {
+              toast.success(
+                disableHeuristicalLayerTypeDetection
+                  ? 'Heuristical layer type determination is now enabled'
+                  : 'Heuristical layer type determination is now disabled'
+              );
+            } else {
+              toast.error(result.error);
+            }
+          }}
+          showState
+        />
+      </FgFieldSet>
+    </div>
   );
 }

--- a/frontend/src/contexts/PreferencesContext.tsx
+++ b/frontend/src/contexts/PreferencesContext.tsx
@@ -39,6 +39,18 @@ export type FolderPreference = {
   fspName: string;
 };
 
+/**
+ * Which URL to use for a given viewer. Defaults to 'configured' when a viewer
+ * is absent from the map.
+ *   - 'configured': the deployment default (viewers.config instance_template_url
+ *     override, else the manifest default)
+ *   - 'manifest': the capability-manifest library's default (e.g. the external
+ *     Neuroglancer at appspot)
+ *   - { custom }: a user-supplied template URL (reserved for future UI)
+ */
+export type ViewerUrlSource = 'configured' | 'manifest' | { custom: string };
+export type ViewerUrlSources = Record<string, ViewerUrlSource>;
+
 type PreferencesContextType = {
   //Full query for accessing loading/error states
   preferenceQuery: ReturnType<typeof usePreferencesQuery>;
@@ -52,6 +64,7 @@ type PreferencesContextType = {
   disableNeuroglancerStateGeneration: boolean;
   disableHeuristicalLayerTypeDetection: boolean;
   useLegacyMultichannelApproach: boolean;
+  viewerUrlSources: ViewerUrlSources;
   isFilteredByGroups: boolean;
   showTutorial: boolean;
   defaultExtraArgs: string;
@@ -84,6 +97,10 @@ type PreferencesContextType = {
   toggleDisableNeuroglancerStateGeneration: () => Promise<Result<void>>;
   toggleDisableHeuristicalLayerTypeDetection: () => Promise<Result<void>>;
   toggleUseLegacyMultichannelApproach: () => Promise<Result<void>>;
+  setViewerUrlSource: (
+    viewerKey: string,
+    source: ViewerUrlSource
+  ) => Promise<Result<void>>;
   toggleFilterByGroups: () => Promise<Result<void>>;
   toggleShowTutorial: () => Promise<Result<void>>;
   updateDefaultExtraArgs: (args: string) => Promise<Result<void>>;
@@ -255,6 +272,25 @@ export const PreferencesProvider = ({
       'useLegacyMultichannelApproach',
       preferencesQuery.data?.useLegacyMultichannelApproach || false
     );
+  };
+
+  const setViewerUrlSource = async (
+    viewerKey: string,
+    source: ViewerUrlSource
+  ): Promise<Result<void>> => {
+    try {
+      const updated: ViewerUrlSources = {
+        ...(preferencesQuery.data?.viewerUrlSources || {}),
+        [viewerKey]: source
+      };
+      await updatePreferenceMutation.mutateAsync({
+        key: 'viewerUrlSources',
+        value: updated
+      });
+      return createSuccess(undefined);
+    } catch (error) {
+      return handleError(error);
+    }
   };
 
   const toggleShowTutorial = async (): Promise<Result<void>> => {
@@ -550,6 +586,7 @@ export const PreferencesProvider = ({
       preferencesQuery.data?.disableHeuristicalLayerTypeDetection || false,
     useLegacyMultichannelApproach:
       preferencesQuery.data?.useLegacyMultichannelApproach || false,
+    viewerUrlSources: preferencesQuery.data?.viewerUrlSources || {},
     isFilteredByGroups: preferencesQuery.data?.isFilteredByGroups ?? true,
     showTutorial: preferencesQuery.data?.showTutorial ?? true,
     defaultExtraArgs: preferencesQuery.data?.defaultExtraArgs || '',
@@ -579,6 +616,7 @@ export const PreferencesProvider = ({
     toggleDisableNeuroglancerStateGeneration,
     toggleDisableHeuristicalLayerTypeDetection,
     toggleUseLegacyMultichannelApproach,
+    setViewerUrlSource,
     toggleFilterByGroups,
     toggleShowTutorial,
     updateDefaultExtraArgs,

--- a/frontend/src/contexts/ViewersContext.tsx
+++ b/frontend/src/contexts/ViewersContext.tsx
@@ -26,6 +26,13 @@ export interface ValidViewer {
   displayName: string;
   /** URL template (may contain {dataLink} placeholder) */
   urlTemplate: string;
+  /**
+   * The capability-manifest library's default template, before any instance
+   * override from viewers.config. Empty string if the manifest has no
+   * template_url. Used to let users opt back to the manifest default (e.g. the
+   * external Neuroglancer at appspot) when a deployment overrides the URL.
+   */
+  manifestTemplateUrl: string;
   /** Logo path */
   logoPath: string;
   /** Tooltip/alt text label */
@@ -124,10 +131,15 @@ export function ViewersProvider({
           }
 
           // Replace {DATA_URL} with {dataLink} for consistency with existing code
-          const normalizedUrlTemplate = urlTemplate.replace(
-            /{DATA_URL}/g,
-            '{dataLink}'
-          );
+          const normalizeTemplate = (template: string) =>
+            template.replace(/{DATA_URL}/g, '{dataLink}');
+          const normalizedUrlTemplate = normalizeTemplate(urlTemplate);
+
+          // The manifest's own default template (before any instance override),
+          // normalized the same way. Empty string if the manifest has none.
+          const manifestTemplateUrl = manifest.viewer.template_url
+            ? normalizeTemplate(manifest.viewer.template_url)
+            : '';
 
           // Create valid viewer entry
           const key = normalizeViewerName(manifest.viewer.name);
@@ -139,6 +151,7 @@ export function ViewersProvider({
             key,
             displayName,
             urlTemplate: normalizedUrlTemplate,
+            manifestTemplateUrl,
             logoPath,
             label,
             manifest

--- a/frontend/src/hooks/useDefaultNeuroglancerBaseUrl.ts
+++ b/frontend/src/hooks/useDefaultNeuroglancerBaseUrl.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
+import { useViewersContext } from '@/contexts/ViewersContext';
+import { resolveViewerTemplate } from '@/utils/viewerUrl';
+
+// Used only when no Neuroglancer viewer is configured and no custom URL is set.
+export const DEFAULT_NEUROGLANCER_BASE_URL =
+  'https://neuroglancer-demo.appspot.com/';
+
+/**
+ * The Neuroglancer base URL (the part before the '#!' state fragment) that new
+ * short links should default to, honoring the deployment's configured URL and
+ * the user's per-viewer URL preference.
+ */
+export function useDefaultNeuroglancerBaseUrl(): string {
+  const { validViewers } = useViewersContext();
+  const { viewerUrlSources } = usePreferencesContext();
+
+  return useMemo(() => {
+    const source = viewerUrlSources['neuroglancer'];
+    const neuroglancer = validViewers.find(v => v.key === 'neuroglancer');
+    if (neuroglancer) {
+      const template = resolveViewerTemplate(neuroglancer, source);
+      // Strip the '#!' state fragment to get the bare base URL.
+      return template.split('#!')[0] || DEFAULT_NEUROGLANCER_BASE_URL;
+    }
+    // No Neuroglancer viewer is configured, so 'configured'/'manifest' have no
+    // template to resolve. A user-supplied custom URL is the only preference
+    // value that carries a URL on its own; otherwise fall back to the external
+    // default.
+    if (typeof source === 'object' && source.custom) {
+      return source.custom.split('#!')[0] || DEFAULT_NEUROGLANCER_BASE_URL;
+    }
+    return DEFAULT_NEUROGLANCER_BASE_URL;
+  }, [validViewers, viewerUrlSources]);
+}

--- a/frontend/src/hooks/useN5Metadata.ts
+++ b/frontend/src/hooks/useN5Metadata.ts
@@ -2,10 +2,17 @@ import { useMemo } from 'react';
 import { useFileBrowserContext } from '@/contexts/FileBrowserContext';
 import { useProxiedPathContext } from '@/contexts/ProxiedPathContext';
 import { useExternalBucketContext } from '@/contexts/ExternalBucketContext';
+import { usePreferencesContext } from '@/contexts/PreferencesContext';
+import { useViewersContext } from '@/contexts/ViewersContext';
+import { resolveViewerTemplate } from '@/utils/viewerUrl';
 import { useN5MetadataQuery } from '@/queries/n5Queries';
 import type { N5Metadata, N5OpenWithToolUrls } from '@/queries/n5Queries';
 
 export type { N5Metadata, N5OpenWithToolUrls };
+
+// Fallback used only when no Neuroglancer viewer is configured.
+const FALLBACK_NEUROGLANCER_BASE_URL =
+  'https://neuroglancer-demo.appspot.com/#!';
 
 /**
  * Get the Neuroglancer source URL for N5 format
@@ -51,6 +58,8 @@ export default function useN5Metadata() {
   const { fileQuery } = useFileBrowserContext();
   const { currentDirProxiedPathQuery } = useProxiedPathContext();
   const { externalDataUrlQuery } = useExternalBucketContext();
+  const { viewerUrlSources } = usePreferencesContext();
+  const { validViewers } = useViewersContext();
 
   // Fetch N5 metadata
   const n5MetadataQuery = useN5MetadataQuery({
@@ -66,7 +75,15 @@ export default function useN5Metadata() {
       return null;
     }
 
-    const neuroglancerBaseUrl = 'https://neuroglancer-demo.appspot.com/#!';
+    // Resolve the Neuroglancer base URL from the deployment config and the
+    // user's per-viewer URL preference, matching the OME-Zarr/Zarr path.
+    const neuroglancer = validViewers.find(v => v.key === 'neuroglancer');
+    const neuroglancerBaseUrl = neuroglancer
+      ? resolveViewerTemplate(
+          neuroglancer,
+          viewerUrlSources['neuroglancer']
+        ).split('#!')[0] + '#!'
+      : FALLBACK_NEUROGLANCER_BASE_URL;
 
     const url =
       externalDataUrlQuery.data || currentDirProxiedPathQuery.data?.url;
@@ -86,7 +103,9 @@ export default function useN5Metadata() {
   }, [
     metadata,
     currentDirProxiedPathQuery.data?.url,
-    externalDataUrlQuery.data
+    externalDataUrlQuery.data,
+    validViewers,
+    viewerUrlSources
   ]);
 
   return {

--- a/frontend/src/hooks/useZarrMetadata.ts
+++ b/frontend/src/hooks/useZarrMetadata.ts
@@ -18,6 +18,7 @@ import {
   determineLayerType
 } from '@/omezarr-helper';
 import { buildUrl } from '@/utils';
+import { resolveViewerTemplate } from '@/utils/viewerUrl';
 import * as zarr from 'zarrita';
 
 export type { OpenWithToolUrls, ZarrMetadata };
@@ -31,7 +32,8 @@ export default function useZarrMetadata() {
   const {
     disableNeuroglancerStateGeneration,
     disableHeuristicalLayerTypeDetection,
-    useLegacyMultichannelApproach
+    useLegacyMultichannelApproach,
+    viewerUrlSources
   } = usePreferencesContext();
   const {
     validViewers,
@@ -135,13 +137,19 @@ export default function useZarrMetadata() {
           continue;
         }
 
+        // Resolve the template based on the user's per-viewer URL preference
+        const effectiveTemplate = resolveViewerTemplate(
+          viewer,
+          viewerUrlSources[viewer.key]
+        );
+
         // Generate the viewer URL
-        let viewerUrl = viewer.urlTemplate;
+        let viewerUrl = effectiveTemplate;
 
         // Special handling for Neuroglancer to maintain existing state generation logic
         if (viewer.key === 'neuroglancer') {
           // Extract base URL from template (everything before #!)
-          const neuroglancerBaseUrl = viewer.urlTemplate.split('#!')[0] + '#!';
+          const neuroglancerBaseUrl = effectiveTemplate.split('#!')[0] + '#!';
           if (disableNeuroglancerStateGeneration) {
             viewerUrl =
               neuroglancerBaseUrl +
@@ -194,9 +202,13 @@ export default function useZarrMetadata() {
         } else {
           // Neuroglancer
           if (url) {
+            // Resolve the template based on the user's per-viewer URL preference
+            const effectiveTemplate = resolveViewerTemplate(
+              viewer,
+              viewerUrlSources[viewer.key]
+            );
             // Extract base URL from template (everything before #!)
-            const neuroglancerBaseUrl =
-              viewer.urlTemplate.split('#!')[0] + '#!';
+            const neuroglancerBaseUrl = effectiveTemplate.split('#!')[0] + '#!';
             if (disableNeuroglancerStateGeneration) {
               openWithToolUrls.neuroglancer =
                 neuroglancerBaseUrl +
@@ -229,6 +241,7 @@ export default function useZarrMetadata() {
     externalDataUrlQuery.data,
     disableNeuroglancerStateGeneration,
     useLegacyMultichannelApproach,
+    viewerUrlSources,
     layerType,
     effectiveZarrVersion,
     validViewers,

--- a/frontend/src/queries/preferencesQueries.ts
+++ b/frontend/src/queries/preferencesQueries.ts
@@ -17,7 +17,8 @@ import type {
   ZonePreference,
   FileSharePathPreference,
   FolderPreference,
-  FolderFavorite
+  FolderFavorite,
+  ViewerUrlSources
 } from '@/contexts/PreferencesContext';
 import {
   getResponseJsonOrError,
@@ -37,6 +38,7 @@ type PreferencesApiResponse = {
   disableNeuroglancerStateGeneration?: { value: boolean };
   disableHeuristicalLayerTypeDetection?: { value: boolean };
   useLegacyMultichannelApproach?: { value: boolean };
+  viewerUrlSources?: { value: ViewerUrlSources };
   isFilteredByGroups?: { value: boolean };
   showTutorial?: { value: boolean };
   defaultExtraArgs?: { value: string };
@@ -70,6 +72,7 @@ export type PreferencesQueryData = {
   disableNeuroglancerStateGeneration: boolean;
   disableHeuristicalLayerTypeDetection: boolean;
   useLegacyMultichannelApproach: boolean;
+  viewerUrlSources: ViewerUrlSources;
   isFilteredByGroups: boolean;
   showTutorial: boolean;
   defaultExtraArgs: string;
@@ -242,6 +245,7 @@ const createTransformPreferences = (
         rawData.disableHeuristicalLayerTypeDetection?.value || false,
       useLegacyMultichannelApproach:
         rawData.useLegacyMultichannelApproach?.value || false,
+      viewerUrlSources: rawData.viewerUrlSources?.value || {},
       isFilteredByGroups: rawData.isFilteredByGroups?.value ?? true,
       showTutorial: rawData.showTutorial?.value ?? true,
       defaultExtraArgs: rawData.defaultExtraArgs?.value || '',

--- a/frontend/src/utils/viewerUrl.ts
+++ b/frontend/src/utils/viewerUrl.ts
@@ -1,0 +1,24 @@
+import type { ValidViewer } from '@/contexts/ViewersContext';
+import type { ViewerUrlSource } from '@/contexts/PreferencesContext';
+
+/**
+ * Resolve the URL template to use for a viewer given the user's chosen source.
+ *
+ * Falls back to the deployment-configured template for an absent/unknown source
+ * or when the requested template is empty, so callers always get a usable value.
+ */
+export function resolveViewerTemplate(
+  viewer: ValidViewer,
+  source: ViewerUrlSource | undefined
+): string {
+  if (!source || source === 'configured') {
+    return viewer.urlTemplate;
+  }
+  if (source === 'manifest') {
+    return viewer.manifestTemplateUrl || viewer.urlTemplate;
+  }
+  if (typeof source === 'object' && source.custom) {
+    return source.custom;
+  }
+  return viewer.urlTemplate;
+}


### PR DESCRIPTION
This PR adds a preference to the preference page that allows the user to select one of two options for the Neuroglancer deployment - either the new override at fileglancer.int.janelia.org or the capability-manifest default at neuroglancer-demo.appspot.com. The preference is only shown if the capability-manifest default is overridden in `viewers.config.yaml`.

This PR lets users choose which Neuroglancer instance their links point to. It adds a "Neuroglancer" section to the Preferences page with a two-option toggle: 
- the deployment-configured instance (set via `instance_template_url` in `viewers.config.yaml` — e.g. fileglancer.int.janelia.org in our production deployment) or the 
- capability-manifest default (neuroglancer-demo.appspot.com). The toggle only appears when the deployment overrides the Neuroglancer URL; otherwise both options  are identical and it's hidden.

The selected preference is applied everywhere the app generates a Neuroglancer URL: the "Open with Neuroglancer" links for OME-Zarr, Zarr, and N5 datasets, and  the default base URL in the "Create Neuroglancer Short Link" dialog. 

The underlying per-viewer preference model is also designed to support fully custom URLs and other viewers in the future, though only the Neuroglancer configured/external choice is exposed now.

Note - this PR requires the changes in [PR #14 in fileglancer-hub](https://github.com/JaneliaSciComp/fileglancer-hub/pull/14), which change the `nginx.conf` template to serve Neuroglancer from fileglancer.int.janelia.org/neuroglancer/.

@krokicki 