### PR TITLE
Cache the file share path list instead of re-reading it per request

### DIFF
--- a/fileglancer/database.py
+++ b/fileglancer/database.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine.url import make_url
 from sqlalchemy.pool import StaticPool
 from typing import Optional, Dict, List, Tuple
 from loguru import logger
-from cachetools import LRUCache
+from cachetools import LRUCache, TTLCache
 
 from fileglancer.giturls import canonical_github_url
 from fileglancer.model import FileSharePath
@@ -29,6 +29,15 @@ _engine_cache = {}
 
 # Sharing key cache - LRU cache for ProxiedPathDB objects
 _sharing_key_cache = None
+
+# File share path cache. The list changes rarely (written by an external
+# process) and is read on every proxied data request and every worker file
+# action, so it is cached for a short window rather than re-queried per call.
+# Keyed by database URL: a process can talk to more than one database (the test
+# suite builds a fresh one per module), and an unkeyed cache would serve one
+# database's shares for another's.
+FSP_CACHE_TTL_SECONDS = 60
+_fsp_cache = TTLCache(maxsize=8, ttl=FSP_CACHE_TTL_SECONDS)
 
 def _get_sharing_key_cache():
     """Get or initialize the sharing key cache"""
@@ -418,6 +427,41 @@ def get_all_paths(session, fsp_name: Optional[str] = None):
     return query.all()
 
 
+def _load_file_share_paths(session: Session) -> List[FileSharePath]:
+    """Build the full file share path list from config or the database.
+
+    Priority:
+    1. Check local configuration first - if paths exist in local configuration, use those
+    2. Otherwise, check the database
+    """
+    settings = get_settings()
+    file_share_mounts = settings.file_share_mounts
+
+    if file_share_mounts:
+        return [FileSharePath(
+            name=slugify_path(path),
+            zone='Local',
+            group='local',
+            storage='home' if path in ("~", "~/") else 'local',
+            mount_path=path,
+            mac_path=path,
+            windows_path=path,
+            linux_path=path,
+        ) for path in file_share_mounts]
+
+    db_paths = get_all_paths(session)
+    return [FileSharePath(
+        name=path.name,
+        zone=path.zone,
+        group=path.group,
+        storage=path.storage,
+        mount_path=path.mount_path,
+        mac_path=path.mac_path,
+        windows_path=path.windows_path,
+        linux_path=path.linux_path,
+    ) for path in db_paths]
+
+
 def get_file_share_paths(session: Session, fsp_name: Optional[str] = None):
     """
     Get all file share paths from either the local configuration or the database.
@@ -425,9 +469,12 @@ def get_file_share_paths(session: Session, fsp_name: Optional[str] = None):
     This is the single source of truth for retrieving file share paths.
     Returns a list of FileSharePath model objects (not database models).
 
-    Priority:
-    1. Check local configuration first - if paths exist in local configuration, use those
-    2. Otherwise, check the database
+    Served from a short-lived process-local cache. Every proxied data request
+    resolves its file share path through here (once per chunk a viewer pulls),
+    as does every file action dispatched to a worker, so the uncached cost is
+    paid on the hottest paths in the app. Nothing in Fileglancer writes the
+    file_share_paths table -- it is populated externally -- so there is no
+    event to invalidate on and the cache is a plain TTL.
 
     Args:
         session: Database session
@@ -436,39 +483,14 @@ def get_file_share_paths(session: Session, fsp_name: Optional[str] = None):
     Returns:
         List of FileSharePath objects ready to be used in responses
     """
-    settings = get_settings()
-    file_share_mounts = settings.file_share_mounts
-
-    if file_share_mounts:
-        paths = []
-        for path in file_share_mounts:
-            name = slugify_path(path)
-            paths.append(FileSharePath(
-                name=name,
-                zone='Local',
-                group='local',
-                storage = 'home' if path in ("~", "~/") else 'local',
-                mount_path=path,
-                mac_path=path,
-                windows_path=path,
-                linux_path=path,
-            ))
-        if fsp_name:
-            paths = [path for path in paths if path.name == fsp_name]
-        return paths
-    else:
-        # Use database paths
-        db_paths = get_all_paths(session, fsp_name)
-        return [FileSharePath(
-            name=path.name,
-            zone=path.zone,
-            group=path.group,
-            storage=path.storage,
-            mount_path=path.mount_path,
-            mac_path=path.mac_path,
-            windows_path=path.windows_path,
-            linux_path=path.linux_path,
-        ) for path in db_paths]
+    key = str(session.get_bind().url)
+    paths = _fsp_cache.get(key)
+    if paths is None:
+        paths = _fsp_cache[key] = _load_file_share_paths(session)
+    if fsp_name:
+        return [path for path in paths if path.name == fsp_name]
+    # Copy so a caller mutating the list can't corrupt the cached one.
+    return list(paths)
 
 
 def get_file_share_path(session: Session, name: str) -> Optional[FileSharePath]:

--- a/fileglancer/worker_pool.py
+++ b/fileglancer/worker_pool.py
@@ -38,9 +38,15 @@ import sys
 import time
 from typing import Any, Optional
 
+from cachetools import TTLCache
 from loguru import logger
 
+from fileglancer.database import FSP_CACHE_TTL_SECONDS
 from fileglancer.settings import Settings
+
+# Worker-bound (JSON-serialized) file share paths, keyed by database URL for the
+# same reason the model-level cache is; see _fetch_fsp_rows.
+_fsp_row_cache = TTLCache(maxsize=8, ttl=FSP_CACHE_TTL_SECONDS)
 
 
 # Length-prefix format: 4-byte big-endian unsigned int
@@ -75,10 +81,21 @@ def _timeout_for_action(action: str) -> float:
 
 
 def _fetch_fsp_rows(db_url: str) -> list[dict]:
-    """Read the file share paths and serialize them for the worker."""
+    """Read the file share paths and serialize them for the worker.
+
+    The serialized form is cached as well as the underlying list: dumping a few
+    hundred models costs more than the query does once the query is cached, and
+    every file action dispatched to a worker pays it. Same TTL, so the worker
+    sees a list no staler than the rest of the app does.
+    """
     from fileglancer import database as db
-    with db.get_db_session(db_url) as session:
-        return [f.model_dump(mode="json") for f in db.get_file_share_paths(session)]
+
+    rows = _fsp_row_cache.get(db_url)
+    if rows is None:
+        with db.get_db_session(db_url) as session:
+            rows = [f.model_dump(mode="json") for f in db.get_file_share_paths(session)]
+        _fsp_row_cache[db_url] = rows
+    return rows
 
 
 def prepare_worker_request(request: dict, db_url: str) -> dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,20 @@ requires_ssh_keygen = pytest.mark.skipif(
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_fsp_caches():
+    """Drop the file-share-path caches between tests.
+
+    They are keyed by database URL, so tests can't read each other's shares,
+    but a test that adds a share to its own database and reads it back would
+    otherwise be racing the TTL.
+    """
+    from fileglancer import database, worker_pool
+    database._fsp_cache.clear()
+    worker_pool._fsp_row_cache.clear()
+    yield
+
+
 def pytest_sessionstart(session):
     """
     Called after the Session object has been created and before performing collection

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -10,7 +10,7 @@ from conftest import requires_symlinks
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from fileglancer.database import *
-from fileglancer.database import _find_best_fsp_match
+from fileglancer.database import _find_best_fsp_match, _fsp_cache
 from fileglancer.model import FileSharePath
 from fileglancer.utils import slugify_path
 
@@ -91,6 +91,43 @@ def fsp(db_session, temp_dir):
     db_session.query(FileSharePathDB).delete()
     db_session.commit()
     db_session.close()
+
+
+def test_file_share_paths_are_served_from_cache(db_session):
+    """Repeat reads come from the cache, so changes lag by up to the TTL."""
+    db_session.add(FileSharePathDB(
+        name="s1", zone="z", group="g", storage="local", mount_path="/s1"))
+    db_session.commit()
+    assert [p.name for p in get_file_share_paths(db_session)] == ["s1"]
+
+    # Row deleted underneath: still served from the cache until it expires.
+    db_session.query(FileSharePathDB).delete()
+    db_session.commit()
+    assert [p.name for p in get_file_share_paths(db_session)] == ["s1"]
+
+    _fsp_cache.clear()
+    assert get_file_share_paths(db_session) == []
+
+
+def test_file_share_path_cache_is_keyed_by_database(db_session, temp_dir):
+    """A second database in the same process must not see the first's shares."""
+    db_session.add(FileSharePathDB(
+        name="first", zone="z", group="g", storage="local", mount_path="/first"))
+    db_session.commit()
+    assert [p.name for p in get_file_share_paths(db_session)] == ["first"]
+
+    other_engine = create_engine(f"sqlite:///{os.path.join(temp_dir, 'other.db')}")
+    Base.metadata.create_all(other_engine)
+    other_session = sessionmaker(bind=other_engine)()
+    try:
+        other_session.add(FileSharePathDB(
+            name="second", zone="z", group="g", storage="local", mount_path="/second"))
+        other_session.commit()
+        assert [p.name for p in get_file_share_paths(other_session)] == ["second"]
+        assert [p.name for p in get_file_share_paths(db_session)] == ["first"]
+    finally:
+        other_session.close()
+        other_engine.dispose()
 
 
 def test_user_preferences(db_session):


### PR DESCRIPTION
Follow-up to #403, which noted that the file share path list is still fetched and serialized on every file action. It turns out the worker dispatch path isn't even the hottest caller.

## Where the cost actually was

| caller | frequency |
| --- | --- |
| `server.py:428` `_resolve_proxy_info` -> `get_file_share_path` | **every proxied data request** — once per chunk a viewer pulls through a sharing link |
| `worker_pool.py:81` `_fetch_fsp_rows` | every file action dispatched to a worker |
| `server.py:830` `GET /api/file-share-paths` | frontend polling |
| `apps/command.py:393`, `database.py:724` | per app launch / per proxied-path create |

Each of those was doing a full `SELECT` plus a rebuild of every `FileSharePath` model, and the worker path then dumped all of them to JSON. So the fix belongs in `database.get_file_share_paths`, not at the call site #403 happened to touch — caching there would have left the per-chunk path untouched.

Also worth knowing: `get_fsp_names_to_mount_paths` and `find_fsp_by_path` are both dead (zero callers), so they're not in the list above. The first is already flagged in `notes/ponytail-audit.md`.

## Why a TTL and not invalidation

`file_share_paths` is populated out-of-band by a separate process, not by anything running in the server — the only reference to `FileSharePathDB` in this repo is the read query at `database.py:415`. So no request handler is ever in a position to know the list changed, and there is no in-process event to invalidate on.

That leaves polling something cheaper than the full list (the `last_refresh` row exists for roughly this purpose) versus plain bounded staleness. The arithmetic says don't bother: the cache converts a per-request cost into a per-TTL cost, so at 60s the rebuild is a **0.008% duty cycle** — one 5ms rebuild per minute per process, against thousands of requests a second on the proxy path during a viewer session. Precise invalidation would add code to eliminate a query that no longer happens in any meaningful quantity.

The TTL is also not the binding constraint on how fast a new share appears: the out-of-band updater has its own schedule, and it is the larger term. Tightening the TTL is a one-constant change if that ever stops being true.

Two caches, both keyed by database URL:

- `database._fsp_cache` — the `FileSharePath` model list, so every caller above benefits
- `worker_pool._fsp_row_cache` — the JSON-serialized rows, because once the query is cached the `model_dump` per row is what dominates the worker path, and it lets `_fetch_fsp_rows` skip creating a session at all on a hit

The keying matters: a process can talk to more than one database (the test suite builds a fresh one per module), and an unkeyed cache serves one database's shares for another's. There's a regression test for exactly that.

## Benchmark

Method: N shares in a sqlite DB, median per-call time over 5 batches of 500 calls, warmed first. `db+1ms` injects 1ms per query via a `before_cursor_execute` listener to model a database that isn't on localhost. Every scenario asserts the returned list is the right length and contents first, so a cache that returned the wrong thing couldn't look fast. Script is not committed; it's a throwaway.

100 shares:

| | before | after | |
| --- | --- | --- | --- |
| full list | 1050us | 2.6us | 400x |
| by name (the proxy path) | 184us | 7.2us | 26x |
| worker rows | 1487us | 1.7us | 870x |
| by name, db+1ms | 1253us | 7.2us | 174x |

500 shares:

| | before | after | |
| --- | --- | --- | --- |
| full list | 5291us | 3.8us | 1390x |
| by name | 187us | 26.1us | 7x |
| worker rows | 6783us | 1.7us | 4000x |

Two honest caveats on those numbers. sqlite on the same filesystem is the best case for the old code, so the local figures understate what a non-local database sees — that's what the `db+1ms` row is for. And the by-name lookup now scans the cached list in Python where it used to push a `WHERE` into SQL, so its win shrinks as the share count grows: 26x at 100 shares, 7x at 500, and it would only lose to the query somewhere north of ~3500 shares. A name-keyed dict would fix that if we ever get there; not worth it now.

## Behaviour change

An operator adding a share waits up to 60s for it to appear, and `GET /api/file-share-paths` can be up to 60s stale. `tests/conftest.py` clears both caches between tests so nothing races the TTL.

## Validation

- `pixi run -e test test-backend` — 770 passed (768 on main, plus the two new tests)
- both new tests were mutation-checked: making the cache unkeyed fails only `test_file_share_path_cache_is_keyed_by_database`, and removing the cache fails only `test_file_share_paths_are_served_from_cache`
- backend only, no frontend changes

@StephanPreibisch @JaneliaSciComp/fileglancer 