### PR TITLE
fix(dev): reinstall lefthook git hooks on npm install

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
         "src/**/*.{ts,tsx}"
     ],
     "scripts": {
+        "prepare": "npx lefthook install",
         "dev": "vite",
         "build": "vite build",
         "build:prod": "vite build --mode production",


### PR DESCRIPTION
This PR adds a `prepare` script to `frontend/package.json` that run `npx lefthook install` whenever `npm install` runs. I added this because I noticed some PRs were getting stuck on prettier/eslint issues in CI that should have been caught by the lefthook pre-push hook. The issue was new worktrees, new container rebuilds, and new clones of the repo did not have lefthook installed unless `npx lefthook install` was manually run. Now lefthook will automatically be installed in these cases (as long as `npm install` is run at some point).
@krokicki