### PR TITLE
Serve data links as an S3 bucket so they browse in Neuroglancer

### DIFF
--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -472,10 +472,6 @@ def create_app(settings):
         the name out of the share URL (as Neuroglancer does, which decodes the
         path) asks for it decoded, so match whichever form was requested.
         """
-        # ponytail: a name that genuinely needs percent-encoding (a space, say)
-        # comes back out of the listing as '+', which won't resolve as a URL --
-        # such links read fine but don't browse. The fix is to store url_prefix
-        # decoded, not to paper over it here.
         stored = link["url_prefix"]
         decoded = unquote(stored)
         rest = requested_prefix[len(base):] if requested_prefix.startswith(base) else ""

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -48,7 +48,7 @@ from fileglancer.worker_pool import (
 from fileglancer.user_worker import serialize_job_for_worker
 from fileglancer import sshkeys
 
-from x2s3.utils import get_read_access_acl, get_nosuchbucket_response, get_error_response, generate_request_id
+from x2s3.utils import get_read_access_acl, get_nosuchbucket_response, get_error_response, generate_request_id, get_list_xml
 from x2s3.client_file import FileProxyClient
 from x2s3.client import ObjectHandle
 
@@ -216,6 +216,11 @@ def _convert_proxied_path(db_path: db.ProxiedPathDB, external_proxy_url: Optiona
         updated_at=db_path.updated_at,
         url=url
     )
+
+
+# The /files space is served as a single S3 bucket named for its first path
+# segment, which is how a path-style S3 client reads the share URL.
+FILES_BUCKET_NAME = "files"
 
 
 # Regex: allow unreserved URI chars (RFC 3986), plus / for path separators and common safe chars
@@ -424,6 +429,60 @@ def create_app(settings):
             result.pop("_fd_mode", None)
             return result
 
+    def _resolve_sharing_key(sharing_key: str, key: str) -> dict | Response:
+        """Resolve a sharing key to the shared link's mount path, owner and name.
+
+        `key` is only used to build the S3 error responses.
+        """
+        with db.get_db_session(settings.db_url) as session:
+
+            proxied_path = db.get_proxied_path_by_sharing_key(session, sharing_key)
+            if not proxied_path:
+                return get_nosuchbucket_response(key)
+
+            # Treat legacy "." (FSP-root sentinel) as empty so old records that
+            # were created before _normalize_proxied_path still resolve.
+            stored_path = "" if proxied_path.path == "." else proxied_path.path
+            stored_prefix = "" if proxied_path.url_prefix == "." else proxied_path.url_prefix
+
+            fsp = db.get_file_share_path(session, proxied_path.fsp_name)
+            if not fsp:
+                return get_error_response(400, "InvalidArgument", f"File share path {proxied_path.fsp_name} not found", key)
+            expanded_mount_path = os.path.expanduser(fsp.mount_path)
+            # For FSP-root links (empty path) use the mount path directly to
+            # avoid a stray trailing slash in mount_path.
+            mount_path = f"{expanded_mount_path}/{stored_path}" if stored_path else expanded_mount_path
+            return {
+                "mount_path": mount_path,
+                "username": proxied_path.username,
+                "url_prefix": stored_prefix,
+                "default_name": os.path.basename(stored_path) or fsp.name,
+            }
+
+
+    def _link_virtual_prefix(link: dict, requested_prefix: str, base: str = "") -> str:
+        """The key prefix a client sees in front of a shared link's own files.
+
+        Those leading key segments have no counterpart on disk, so x2s3 is
+        told about them as a virtual prefix. `base` is whatever precedes the
+        link name in the bucket's key space: the sharing key at the /files
+        bucket root, nothing when the sharing key is itself the bucket.
+
+        A stored url_prefix may be percent-encoded, while a client that took
+        the name out of the share URL (as Neuroglancer does, which decodes the
+        path) asks for it decoded, so match whichever form was requested.
+        """
+        # ponytail: a name that genuinely needs percent-encoding (a space, say)
+        # comes back out of the listing as '+', which won't resolve as a URL --
+        # such links read fine but don't browse. The fix is to store url_prefix
+        # decoded, not to paper over it here.
+        stored = link["url_prefix"]
+        decoded = unquote(stored)
+        rest = requested_prefix[len(base):] if requested_prefix.startswith(base) else ""
+        name = decoded if decoded != stored and rest.startswith(decoded) else stored
+        return f"{base}{name}/" if name else base
+
+
     def _resolve_proxy_info(sharing_key: str, captured_path: str) -> Tuple[dict | Response, str]:
         """Resolve a sharing key to proxy info (mount_path, target_name, username, subpath).
 
@@ -440,36 +499,24 @@ def create_app(settings):
                 return captured[len(prefix) + 1:]
             return None
 
-        with db.get_db_session(settings.db_url) as session:
+        link = _resolve_sharing_key(sharing_key, captured_path)
+        if isinstance(link, Response):
+            return link, ""
 
-            proxied_path = db.get_proxied_path_by_sharing_key(session, sharing_key)
-            if not proxied_path:
-                return get_nosuchbucket_response(captured_path), ""
+        stored_prefix = link["url_prefix"]
+        subpath = try_strip_prefix(captured_path, stored_prefix)
+        if subpath is None:
+            subpath = try_strip_prefix(captured_path, unquote(stored_prefix))
+        if subpath is None:
+            return get_error_response(404, "NoSuchKey", f"Path mismatch for sharing key {sharing_key}", captured_path), ""
 
-            # Treat legacy "." (FSP-root sentinel) as empty so old records that
-            # were created before _normalize_proxied_path still resolve.
-            stored_path = "" if proxied_path.path == "." else proxied_path.path
-            stored_prefix = "" if proxied_path.url_prefix == "." else proxied_path.url_prefix
-
-            subpath = try_strip_prefix(captured_path, stored_prefix)
-            if subpath is None:
-                subpath = try_strip_prefix(captured_path, unquote(stored_prefix))
-            if subpath is None:
-                return get_error_response(404, "NoSuchKey", f"Path mismatch for sharing key {sharing_key}", captured_path), ""
-
-            fsp = db.get_file_share_path(session, proxied_path.fsp_name)
-            if not fsp:
-                return get_error_response(400, "InvalidArgument", f"File share path {proxied_path.fsp_name} not found", captured_path), ""
-            expanded_mount_path = os.path.expanduser(fsp.mount_path)
-            # For FSP-root links (empty path) use the mount path directly to
-            # avoid a stray trailing slash in mount_path.
-            mount_path = f"{expanded_mount_path}/{stored_path}" if stored_path else expanded_mount_path
-            target_name = captured_path.rsplit('/', 1)[-1] if captured_path else (os.path.basename(stored_path) or fsp.name)
-            return {
-                "mount_path": mount_path,
-                "target_name": target_name,
-                "username": proxied_path.username,
-            }, subpath
+        target_name = captured_path.rsplit('/', 1)[-1] if captured_path else link["default_name"]
+        return {
+            "mount_path": link["mount_path"],
+            "target_name": target_name,
+            "username": link["username"],
+            "url_prefix": stored_prefix,
+        }, subpath
 
 
     @asynccontextmanager
@@ -1341,6 +1388,70 @@ def create_app(settings):
         return NeuroglancerShortLinkResponse(links=links)
 
 
+    async def _list_objects(link: dict, bucket_name: str, virtual_prefix: str,
+                            continuation_token, delimiter, encoding_type,
+                            fetch_owner, max_keys, prefix, start_after) -> Response:
+        """Run an S3 ListObjectsV2 against one shared link."""
+        result = await _worker_exec(link["username"], "s3_list_objects",
+                                    mount_path=link["mount_path"],
+                                    target_name=bucket_name,
+                                    virtual_prefix=virtual_prefix,
+                                    continuation_token=continuation_token,
+                                    delimiter=delimiter,
+                                    encoding_type=encoding_type,
+                                    fetch_owner=fetch_owner,
+                                    max_keys=max_keys,
+                                    prefix=prefix,
+                                    start_after=start_after)
+        return Response(content=result["body"], media_type=result.get("media_type", "application/xml"),
+                        status_code=result.get("status_code", 200))
+
+
+    @app.get("/files/")
+    async def bucket_dispatcher(list_type: Optional[int] = Query(None, alias="list-type"),
+                                continuation_token: Optional[str] = Query(None, alias="continuation-token"),
+                                delimiter: Optional[str] = Query(None, alias="delimiter"),
+                                encoding_type: Optional[str] = Query(None, alias="encoding-type"),
+                                fetch_owner: Optional[bool] = Query(None, alias="fetch-owner"),
+                                max_keys: Optional[int] = Query(1000, alias="max-keys"),
+                                prefix: Optional[str] = Query(None, alias="prefix"),
+                                start_after: Optional[str] = Query(None, alias="start-after")):
+        """S3 bucket root for data links.
+
+        The whole /files space is one S3 bucket, so a key looks like
+        `{sharing_key}/{link name}/{path}`, and a client that wants to browse a
+        link asks the bucket root for everything under that prefix. That is how
+        Neuroglancer lists a directory: it takes the first path segment of the
+        share URL as the bucket and the rest as the prefix.
+
+        Sharing keys are secret, so this never enumerates them. Without a
+        prefix that names one exactly, the answer is an empty listing --
+        identical for a missing, partial or unknown key, so the endpoint can't
+        be probed for valid keys. Empty rather than an error is deliberate:
+        Neuroglancer remembers per-server whether S3 listing works at all, and
+        an error here would turn off browsing for the valid links too.
+        """
+        if not list_type:
+            return get_error_response(404, "NoSuchKey", "The bucket root is not an object", "")
+        if list_type != 2:
+            return get_error_response(400, "InvalidArgument", f"Invalid list type {list_type}", "")
+
+        prefix = prefix or ''
+        sharing_key = prefix.split('/', 1)[0]
+        link = _resolve_sharing_key(sharing_key, prefix) if sharing_key else None
+        if not isinstance(link, dict):
+            xml = get_list_xml([], [], Name=FILES_BUCKET_NAME, Prefix=prefix, Delimiter=delimiter,
+                               MaxKeys=max_keys, EncodingType=encoding_type, KeyCount=0,
+                               IsTruncated='false', ContinuationToken=continuation_token,
+                               StartAfter=start_after)
+            return Response(content=xml, media_type="application/xml")
+
+        return await _list_objects(link, FILES_BUCKET_NAME,
+                                   _link_virtual_prefix(link, prefix, f"{sharing_key}/"),
+                                   continuation_token, delimiter, encoding_type,
+                                   fetch_owner, max_keys, prefix, start_after)
+
+
     @app.get("/files/{sharing_key}/{path:path}")
     async def target_dispatcher(request: Request,
                                 sharing_key: str,
@@ -1357,27 +1468,26 @@ def create_app(settings):
         if 'acl' in request.query_params:
             return get_read_access_acl()
 
-        info, subpath = _resolve_proxy_info(sharing_key, path)
-        if isinstance(info, Response):
-            return info
-
         if list_type:
-            if list_type == 2:
-                result = await _worker_exec(info["username"], "s3_list_objects",
-                                            mount_path=info["mount_path"],
-                                            target_name=info["target_name"],
-                                            continuation_token=continuation_token,
-                                            delimiter=delimiter,
-                                            encoding_type=encoding_type,
-                                            fetch_owner=fetch_owner,
-                                            max_keys=max_keys,
-                                            prefix=prefix,
-                                            start_after=start_after)
-                return Response(content=result["body"], media_type=result.get("media_type", "application/xml"),
-                                status_code=result.get("status_code", 200))
-            else:
+            # Reached when the sharing key is the bucket, i.e. a client pointed
+            # at /files as its endpoint. A bucket has no path of its own, so
+            # what was captured is ignored and the listing is driven by the
+            # prefix. Keys still carry the link name, so they resolve as URLs
+            # under the share URL.
+            link = _resolve_sharing_key(sharing_key, path)
+            if isinstance(link, Response):
+                return link
+            if list_type != 2:
                 return get_error_response(400, "InvalidArgument", f"Invalid list type {list_type}", path)
+            return await _list_objects(link, sharing_key,
+                                       _link_virtual_prefix(link, prefix or ''),
+                                       continuation_token, delimiter, encoding_type,
+                                       fetch_owner, max_keys, prefix, start_after)
         else:
+            info, subpath = _resolve_proxy_info(sharing_key, path)
+            if isinstance(info, Response):
+                return info
+
             range_header = request.headers.get("range")
 
             result = await _worker_exec(

--- a/fileglancer/user_worker.py
+++ b/fileglancer/user_worker.py
@@ -887,6 +887,8 @@ def _action_s3_list_objects(request: dict, ctx: WorkerContext) -> dict:
         proxy_kwargs={"target_name": target_name},
         path=mount_path,
         buffer_size=buffer_size,
+        # Key segments the client sees that have no counterpart on disk
+        virtual_prefix=request.get("virtual_prefix"),
     )
 
     # list_objects_v2 is async def but does only sync I/O

--- a/pixi.lock
+++ b/pixi.lock
@@ -172,9 +172,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
@@ -341,8 +341,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -502,8 +502,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl
@@ -666,8 +666,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
@@ -826,7 +826,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl
@@ -1048,9 +1048,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -1266,8 +1266,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
@@ -1471,8 +1471,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
@@ -1679,8 +1679,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
@@ -1884,7 +1884,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl
@@ -2145,9 +2145,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
@@ -2401,8 +2401,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -2652,8 +2652,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl
@@ -2906,8 +2906,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
@@ -3154,7 +3154,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl
@@ -3418,7 +3418,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
@@ -3676,7 +3676,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -3928,7 +3928,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/11/e7a70a209eb9a067c0d3212b518a0134e3484f5178c7533878b6b514d469/aiohttp-3.14.3-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
@@ -4181,8 +4181,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ea/b4/05b4131c407006cd1e410e9c6539f16a0945724677e5364447313c15ea3e/yarl-1.24.5-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
@@ -4431,7 +4431,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/76/9b/f2f8f108da17ecef2cc3efc424e8b7ad3782b1a8360f7b8eae8ced84f6ea/aiohttp-3.14.3-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/27/41eb51bbd1b8d89546b83897cfb0164f1e109304fd408dbb151b639eec0f/yarl-1.24.5-cp312-cp312-win_amd64.whl
@@ -15828,7 +15828,7 @@ packages:
   - python-jose==3.5.0
   - sqlalchemy==2.0.51
   - uvicorn==0.38.0
-  - x2s3==1.3.0
+  - x2s3==1.5.1
   - hatch==1.17.1 ; extra == 'release'
   - twine==6.2.0 ; extra == 'release'
   - coverage==7.15.1 ; python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'test'
@@ -16201,6 +16201,31 @@ packages:
   - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
   - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
+  name: x2s3
+  version: 1.5.1
+  sha256: cc5612f17cbabadb0c13fa0f0c903376becf6d138abfe1e20e855c6edb6e5f95
+  requires_dist:
+  - aiobotocore>=2.22
+  - boto3>=1.37
+  - botocore>=1.37
+  - fastapi>=0.115
+  - loguru>=0.7
+  - pydantic>=2.11
+  - pydantic-settings>=2.9
+  - pydantic-settings-yaml>=0.2.0
+  - python-dateutil>=2.9
+  - starlette>=0.46
+  - uvicorn>=0.34
+  - uvloop>=0.21 ; sys_platform != 'win32'
+  - jinja2>=3.1
+  - pytest>=8.3 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-html ; extra == 'test'
+  - httpx>=0.28 ; extra == 'test'
+  - build ; extra == 'release'
+  - twine ; extra == 'release'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl
   name: yarl
   version: 1.24.5
@@ -16243,31 +16268,6 @@ packages:
   requires_dist:
   - typing-extensions>=4.1.0 ; python_full_version < '3.11'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/b0/6c/c25618e34b8ba7c26ef4f3f84df70e9e6c0fc8aa3806d04c1ab952051c8f/x2s3-1.3.0-py3-none-any.whl
-  name: x2s3
-  version: 1.3.0
-  sha256: deb292575bd242004a903ba1bd1892d6528a91f501d348b932322fbf4f4131fe
-  requires_dist:
-  - aiobotocore>=2.22
-  - boto3>=1.37
-  - botocore>=1.37
-  - fastapi>=0.115
-  - loguru>=0.7
-  - pydantic>=2.11
-  - pydantic-settings>=2.9
-  - pydantic-settings-yaml>=0.2.0
-  - python-dateutil>=2.9
-  - starlette>=0.46
-  - uvicorn>=0.34
-  - uvloop>=0.21 ; sys_platform != 'win32'
-  - jinja2>=3.1
-  - pytest>=8.3 ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-html ; extra == 'test'
-  - httpx>=0.28 ; extra == 'test'
-  - build ; extra == 'release'
-  - twine ; extra == 'release'
-  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl
   name: propcache
   version: 0.5.2

--- a/pixi.lock
+++ b/pixi.lock
@@ -172,10 +172,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -341,9 +341,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -502,10 +502,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -666,9 +666,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -826,9 +826,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -1048,11 +1048,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/48/a2/87a0b61a3078be07ab04ec574ef6c683c764590ed0d2a50d00cbb23aeae7/pydantic_settings_yaml-0.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -1266,10 +1266,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -1471,11 +1471,11 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -1679,10 +1679,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -1884,10 +1884,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/fe/b23e9bca77cafecd1a10450066a1a4ca329149ad36aa86cdf8e67c2d2fa5/hatch_nodejs_version-0.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -2145,10 +2145,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e8/f20557aca240d88e69850ad1ee91756821d094bb1310565c04d25c6682a2/yarl-1.24.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/b7/1da684a04175473fa4cddbf9a2f572e79514c3fd27a74597f43057d4f3da/aiohttp-3.14.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -2401,9 +2401,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/f7/a9a1d6fa7dd9e388f95b30f6ad3ec4e285f6c8f61f44ce16070c3fcfe414/yarl-1.24.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -2652,10 +2652,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/97/a3/7056b86dc0d9ec709ea9777eae3b0161428f943372f8b98c01c11593b682/aiohttp-3.14.3-cp314-cp314-macosx_10_15_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -2906,9 +2906,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/85/ed/0357a015892fd68058bf2d39d3fd1958e459b997a7db30aaa6aaa434ae96/aiohttp-3.14.3-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -3154,9 +3154,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cf/52/6daa2ee9d95e5c98b8128f8df91eb692eb423ab274b8cf08db52152fad26/yarl-1.24.5-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -3418,8 +3418,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -3676,8 +3676,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -3928,8 +3928,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/88/11/e7a70a209eb9a067c0d3212b518a0134e3484f5178c7533878b6b514d469/aiohttp-3.14.3-cp312-cp312-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -4181,9 +4181,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/f4/5a7d76dc844d3ff8ed1f1a043158aa393794aebb787d3e2f8c0fe87f674f/aiobotocore-3.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ea/b4/05b4131c407006cd1e410e9c6539f16a0945724677e5364447313c15ea3e/yarl-1.24.5-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
@@ -4431,10 +4431,10 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/76/9b/f2f8f108da17ecef2cc3efc424e8b7ad3782b1a8360f7b8eae8ced84f6ea/aiohttp-3.14.3-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/84/47/07046e0acedc12fe2bae79cf6c73ad67f51ae9d67df64d06b0f3eac73d36/pytest_html-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c4/27/41eb51bbd1b8d89546b83897cfb0164f1e109304fd408dbb151b639eec0f/yarl-1.24.5-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/1d/c52e66ff32ba7911664e6c4c2ac62e1c6d2d1e7550c7ac185d3f4b70a8a4/boto3-1.43.46-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/72/d08f606f8b99e9dd16d45e01da49e7e4f8109a5484dc1b6ab6f88d309aef/py_cluster_api-0.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
@@ -15828,7 +15828,7 @@ packages:
   - python-jose==3.5.0
   - sqlalchemy==2.0.51
   - uvicorn==0.38.0
-  - x2s3==1.5.1
+  - x2s3==1.5.2
   - hatch==1.17.1 ; extra == 'release'
   - twine==6.2.0 ; extra == 'release'
   - coverage==7.15.1 ; python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin' and extra == 'test'
@@ -16201,31 +16201,6 @@ packages:
   - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
   - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/97/c7/829d78ada82f24def3ae9ad03764ae9cc31e0c3efd7c391e3be96660aab9/x2s3-1.5.1-py3-none-any.whl
-  name: x2s3
-  version: 1.5.1
-  sha256: cc5612f17cbabadb0c13fa0f0c903376becf6d138abfe1e20e855c6edb6e5f95
-  requires_dist:
-  - aiobotocore>=2.22
-  - boto3>=1.37
-  - botocore>=1.37
-  - fastapi>=0.115
-  - loguru>=0.7
-  - pydantic>=2.11
-  - pydantic-settings>=2.9
-  - pydantic-settings-yaml>=0.2.0
-  - python-dateutil>=2.9
-  - starlette>=0.46
-  - uvicorn>=0.34
-  - uvloop>=0.21 ; sys_platform != 'win32'
-  - jinja2>=3.1
-  - pytest>=8.3 ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-html ; extra == 'test'
-  - httpx>=0.28 ; extra == 'test'
-  - build ; extra == 'release'
-  - twine ; extra == 'release'
-  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/98/35/ba9436e579bd48a8801f2021d842d9ab4994c26e4c7dd3a4c1f1bcb57a9e/yarl-1.24.5-cp314-cp314-macosx_10_15_x86_64.whl
   name: yarl
   version: 1.24.5
@@ -16311,6 +16286,31 @@ packages:
   - multidict>=4.0
   - propcache>=0.2.1
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d0/2c/9990e39d2648610eb2b19d84aee00dac81677629fd739e62d0451e81d2b0/x2s3-1.5.2-py3-none-any.whl
+  name: x2s3
+  version: 1.5.2
+  sha256: 2165f06d8e262a5b14f04c68cba165f3c2451776cb52f5e602e39d6143bafc69
+  requires_dist:
+  - aiobotocore>=2.22
+  - boto3>=1.37
+  - botocore>=1.37
+  - fastapi>=0.115
+  - loguru>=0.7
+  - pydantic>=2.11
+  - pydantic-settings>=2.9
+  - pydantic-settings-yaml>=0.2.0
+  - python-dateutil>=2.9
+  - starlette>=0.46
+  - uvicorn>=0.34
+  - uvloop>=0.21 ; sys_platform != 'win32'
+  - jinja2>=3.1
+  - pytest>=8.3 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-html ; extra == 'test'
+  - httpx>=0.28 ; extra == 'test'
+  - build ; extra == 'release'
+  - twine ; extra == 'release'
+  requires_python: '>=3.12'
 - pypi: https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl
   name: multidict
   version: 6.7.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "sqlalchemy ==2.0.51",
     "packaging ==26.2",
     "uvicorn ==0.38.0",
-    "x2s3 ==1.5.1",
+    "x2s3 ==1.5.2",
     "py-cluster-api ==0.8.0"
 ]
 
@@ -210,7 +210,7 @@ fileglancer = { path = ".", editable = true }
 # have no [tool.pixi.*] conda mirror to restore a range from. Not read by
 # pixi or pip -- sync_pyproject_versions.py is the only consumer.
 [tool.sync-pypi-versions.ranges]
-x2s3 = ">=1.5.1,<2"
+x2s3 = ">=1.5.2,<2"
 py-cluster-api = ">=0.8.0,<0.9"
 build = ">=1.3.0,<2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "sqlalchemy ==2.0.51",
     "packaging ==26.2",
     "uvicorn ==0.38.0",
-    "x2s3 ==1.3.0",
+    "x2s3 ==1.5.1",
     "py-cluster-api ==0.8.0"
 ]
 
@@ -210,7 +210,7 @@ fileglancer = { path = ".", editable = true }
 # have no [tool.pixi.*] conda mirror to restore a range from. Not read by
 # pixi or pip -- sync_pyproject_versions.py is the only consumer.
 [tool.sync-pypi-versions.ranges]
-x2s3 = ">=1.3.0,<2"
+x2s3 = ">=1.5.1,<2"
 py-cluster-api = ">=0.8.0,<0.9"
 build = ">=1.3.0,<2"
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -2039,3 +2039,34 @@ def test_sharing_key_as_bucket_agrees_with_bucket_root(test_client, temp_dir):
     # and the first key segment in the other.
     assert [f"/files/{sharing_key}/{k}" for k in keys] == [f"/files/{k}" for k in root_keys]
     assert [f"/files/{sharing_key}/{p}" for p in common_prefixes] == [f"/files/{p}" for p in root_common]
+
+
+def test_bucket_root_lists_names_with_spaces(test_client, temp_dir):
+    """Names that need encoding have to survive the listing.
+
+    A client reads a key out of the listing and asks for it back, so a space
+    has to come back as %20 (which decodes to a space) rather than '+' (which
+    does not).
+    """
+    os.makedirs(os.path.join(temp_dir, "my data", "sub dir"), exist_ok=True)
+    with open(os.path.join(temp_dir, "my data", "my file.txt"), "w") as f:
+        f.write("spaced")
+    response = test_client.post("/api/proxied-path", params={"fsp_name": "tempdir", "path": "my data"})
+    assert response.status_code == 200
+    data = response.json()
+    sharing_key, url_prefix = data["sharing_key"], data["url_prefix"]
+    assert url_prefix == "my%20data", "link names are stored percent-encoded"
+
+    # The link name reaches the server either as stored or decoded, depending
+    # on how far the client unwound the share URL, and both have to list
+    for name in [url_prefix, "my data"]:
+        root = _listing(test_client, "/files/?list-type=2&delimiter=/&encoding-type=url"
+                                     f"&prefix={quote(f'{sharing_key}/{name}/')}")
+        keys, common_prefixes = _keys(root)
+        assert len(keys) == 1 and keys[0].endswith("/my%20file.txt"), keys
+        assert len(common_prefixes) == 1 and common_prefixes[0].endswith("/sub%20dir/"), common_prefixes
+
+        # Whatever the listing reported, asking for it back reaches the file
+        response = test_client.get(f"/files/{keys[0]}")
+        assert response.status_code == 200
+        assert response.text == "spaced"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1919,3 +1919,123 @@ def test_viewers_config_file_missing(temp_dir):
         dispose_engine(db_url)
         fileglancer.settings.get_settings = original_get_settings
         fileglancer.database.get_settings = original_get_settings
+
+
+# --- S3 bucket-root listing of data links -----------------------------------
+
+def _make_data_link(test_client, temp_dir):
+    """Create a data link over a small tree, returning (sharing_key, url_prefix)."""
+    os.makedirs(os.path.join(temp_dir, "test_proxied_path", "sub"), exist_ok=True)
+    with open(os.path.join(temp_dir, "test_proxied_path", "a.txt"), "w") as f:
+        f.write("hello link")
+    response = test_client.post("/api/proxied-path?fsp_name=tempdir&path=test_proxied_path")
+    assert response.status_code == 200
+    data = response.json()
+    return data["sharing_key"], data["url_prefix"]
+
+
+def _listing(test_client, url):
+    from x2s3.utils import parse_xml
+    response = test_client.get(url)
+    assert response.status_code == 200, response.text
+    root = parse_xml(response.text)
+    assert root.tag == "ListBucketResult"
+    return root
+
+
+def _keys(root):
+    return ([c.find('Key').text for c in root.findall('Contents')],
+            [cp.find('Prefix').text for cp in root.findall('CommonPrefixes')])
+
+
+def test_bucket_root_lists_data_link(test_client, temp_dir):
+    """Browsing a data link means listing the /files bucket under its key prefix.
+
+    That is how Neuroglancer lists a directory over plain https: it reads the
+    first path segment of the share URL as the bucket and the rest as a prefix.
+    """
+    sharing_key, url_prefix = _make_data_link(test_client, temp_dir)
+    prefix = f"{sharing_key}/{url_prefix}/"
+
+    root = _listing(test_client, f"/files/?list-type=2&prefix={prefix}&delimiter=/&encoding-type=url")
+    assert root.find('Name').text == "files"
+    assert root.find('Prefix').text == prefix
+    keys, common_prefixes = _keys(root)
+    assert keys == [f"{prefix}a.txt"]
+    assert common_prefixes == [f"{prefix}sub/"]
+
+    # The keys are relative to the bucket, so they resolve as share URLs
+    response = test_client.get(f"/files/{keys[0]}")
+    assert response.status_code == 200
+    assert response.text == "hello link"
+
+
+def test_bucket_root_lists_link_name_as_folder(test_client, temp_dir):
+    """The link name is not on disk, but it browses like a folder."""
+    sharing_key, url_prefix = _make_data_link(test_client, temp_dir)
+
+    # As with a real folder, a prefix is truncated at the next delimiter
+    cases = [(f"{sharing_key}", f"{sharing_key}/"),
+             (f"{sharing_key}/", f"{sharing_key}/{url_prefix}/"),
+             (f"{sharing_key}/{url_prefix[:3]}", f"{sharing_key}/{url_prefix}/")]
+    for prefix, expected in cases:
+        root = _listing(test_client, f"/files/?list-type=2&prefix={prefix}&delimiter=/")
+        keys, common_prefixes = _keys(root)
+        assert keys == []
+        assert common_prefixes == [expected]
+
+
+def test_bucket_root_does_not_enumerate_sharing_keys(test_client, temp_dir):
+    """Sharing keys are secret: the bucket root never gives one away.
+
+    A missing, partial or unknown key all produce the same empty listing, so
+    the endpoint can't be probed for valid keys.
+    """
+    sharing_key, _ = _make_data_link(test_client, temp_dir)
+
+    for prefix in ["", sharing_key[:6], "zzzzzzzzzzzz", "zzzzzzzzzzzz/data/"]:
+        root = _listing(test_client, f"/files/?list-type=2&prefix={prefix}&delimiter=/")
+        keys, common_prefixes = _keys(root)
+        assert keys == [], f"leaked contents for prefix {prefix!r}"
+        assert common_prefixes == [], f"leaked a sharing key for prefix {prefix!r}"
+        assert root.find('KeyCount').text == '0'
+        assert root.find('IsTruncated').text == 'false'
+
+    # Listing has to stay a valid, successful S3 response even when empty:
+    # Neuroglancer caches "this server can't list" per origin on an error,
+    # which would turn off browsing for the valid links too.
+    assert test_client.get("/files/?list-type=2").status_code == 200
+    # Without a trailing slash the request still reaches the bucket root
+    assert test_client.get("/files?list-type=2").status_code == 200
+
+
+def test_bucket_root_is_not_an_object(test_client):
+    """The bucket root is only a listing endpoint, never the SPA or a file."""
+    from x2s3.utils import parse_xml
+    response = test_client.get("/files/")
+    assert response.status_code == 404
+    assert parse_xml(response.text).find('Code').text == 'NoSuchKey'
+    assert test_client.get("/files/?list-type=1").status_code == 400
+
+
+def test_sharing_key_as_bucket_agrees_with_bucket_root(test_client, temp_dir):
+    """A client can also treat the sharing key itself as the bucket.
+
+    Neuroglancer races both readings of a share URL and keeps whichever
+    answers first, so the two must resolve to the same files.
+    """
+    sharing_key, url_prefix = _make_data_link(test_client, temp_dir)
+
+    root = _listing(test_client, f"/files/{sharing_key}/?list-type=2&prefix={url_prefix}/&delimiter=/")
+    assert root.find('Name').text == sharing_key
+    keys, common_prefixes = _keys(root)
+    assert keys == [f"{url_prefix}/a.txt"]
+    assert common_prefixes == [f"{url_prefix}/sub/"]
+
+    bucket_root = _listing(
+        test_client, f"/files/?list-type=2&prefix={sharing_key}/{url_prefix}/&delimiter=/")
+    root_keys, root_common = _keys(bucket_root)
+    # Both readings name the same URLs: the sharing key is the bucket in one
+    # and the first key segment in the other.
+    assert [f"/files/{sharing_key}/{k}" for k in keys] == [f"/files/{k}" for k in root_keys]
+    assert [f"/files/{sharing_key}/{p}" for p in common_prefixes] == [f"/files/{p}" for p in root_common]


### PR DESCRIPTION
Stacked on #435, which needs to be merged first. 

Folder browsing didn't work for data links in Neuroglancer. Verified working against a real Neuroglancer after this change.

### What was wrong

Neuroglancer shows a folder tree over plain `https://` by reading the first path segment of the URL as an S3 bucket and asking that bucket root for everything under the rest as a prefix:

```
GET /files/?list-type=2&prefix={sharing_key}/{link name}/&delimiter=/
```

Nothing answered at `/files/` — the only route was `/files/{sharing_key}/{path}` — so the probe 404'd and Neuroglancer recorded the server as unable to list. Reads were unaffected, which is why this only ever showed up as "the folder tree doesn't work".

### What changed

The whole `/files` space is now one S3 bucket. A key is `{sharing_key}/{link name}/{path}`, which is exactly what a share URL already looks like, so **existing links gain browsing with no change to their URLs**. The first two segments have no counterpart on disk, so they are handed to x2s3's `virtual_prefix` option (JaneliaSciComp/x2s3#28), which strips them from incoming requests and puts them back on the keys it reports.

- **New `GET /files/`** — the bucket root. `list-type=2` only; no list-type is `NoSuchKey`, another list type is `InvalidArgument`, and neither falls through to the SPA.
- **Existing per-key list branch fixed the same way.** It reported keys without the link name, so they didn't resolve as URLs, and it 404'd with "path mismatch" at `/files/{key}/?list-type=2` because a bucket has no path of its own to match. Both readings of a share URL now resolve to the same files, which matters because Neuroglancer races them and keeps whichever answers first.
- **x2s3 1.3.0 → 1.5.2.**

### Sharing keys stay secret

The bucket root never enumerates them. A missing, partial or unknown key all produce the same empty listing, so the endpoint can't be probed, and the only key that can appear in a response is one the caller already supplied in full (exact lookup, no prefix matching; keys are 96 bits).

Empty rather than an error is deliberate: Neuroglancer caches "this server can't list" per origin, so an error at the root would turn off browsing for the valid links too.

This does bend S3 — a real `ListObjectsV2` with no prefix lists the bucket. Nothing in the toolchain cares: Neuroglancer, zarr, tensorstore and s3fs all list under a path, and `aws s3 ls s3://files/{key}/{name}/` works while `aws s3 ls s3://files/` shows nothing.

### Names with spaces

A file or directory whose name contained a space was listed with `+` in place of the space, which no client turns back into a space, so entries showed up but wouldn't open. That was in x2s3's key encoding, fixed in 1.5.2 (JaneliaSciComp/x2s3#30) along with `max-keys` and continuation tokens being ignored inside a virtual prefix. Covered here by a test that lists a link whose name and contents both contain spaces, for the stored and the decoded form of the name, and reads each reported key back to prove it resolves.

The 1.5.2 pin also carries the other fix this depends on: `encoding-type=url` listings used to 500 (JaneliaSciComp/x2s3#29), and Neuroglancer sends that on every listing request.

### Tests

Six new tests in `tests/test_endpoints.py`: bucket-root listing whose keys resolve back as share URLs; the link name browsing like a folder; no enumeration from missing/partial/unknown keys; the root not being an object; both bucket readings naming identical URLs; and the spaces round-trip. Full backend suite passes (927).

@StephanPreibisch @JaneliaSciComp/fileglancer @davidackerman
