### PR TITLE
JSON logging mode for Kibana

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Fileglancer has a React front-end and a FastAPI backend. Uvicorn is used to mana
 
 - [User guide](https://janeliascicomp.github.io/fileglancer-docs/)
 - [Developer guide](docs/Development.md)
+- [Structured logging](docs/StructuredLogging.md)
 
 ## Related repositories
 

--- a/docs/StructuredLogging.md
+++ b/docs/StructuredLogging.md
@@ -1,0 +1,52 @@
+# Structured Logging
+
+Setting `log_format: json` (or `FGC_LOG_FORMAT=json`) makes Fileglancer write one JSON object per line to stdout instead of human-readable text. The field names follow the [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html) (ECS), so Kibana's built-in visualizations understand them without any mapping work.
+
+The default remains `text`; nothing changes unless you turn this on. Turn it on in production, leave it off for development.
+
+## What gets logged
+
+Every log record carries `@timestamp`, `log.level`, `log.logger`, `message`, `service.name`, `service.version` and `process.pid`. Records emitted while serving a request also carry `trace.id`, which is returned to the client in the `x-request-id` response header — so a user reporting a problem can quote an id that pulls up every line for that request, including the ones logged inside the handler.
+
+One access line is logged per request, tagged `event.dataset: fileglancer.access`, with:
+
+| Field | Notes |
+|---|---|
+| `event.duration` | Request duration in **nanoseconds** (the ECS unit). |
+| `http.request.method`, `http.version` | |
+| `http.response.status_code` | |
+| `http.response.body.bytes` | Present when the response declared a Content-Length. |
+| `url.path`, `url.query`, `url.domain` | Path is logged as the client encoded it. |
+| `client.ip`, `client.port` | Corrected for the reverse proxy when running behind one. |
+| `user_agent.original` | |
+| `user.name` | Session or API-token user, absent when unauthenticated. |
+| `labels.token_id` | Present on API-token requests; the id to revoke. |
+| `labels.endpoint` | Handler function name. Group latency by this — raw paths have unbounded cardinality and are useless to aggregate over. |
+| `error.type`, `error.message`, `error.stack_trace` | On records logged with an exception. |
+
+Per-user worker subprocesses log in the same format. In text mode their output is forwarded through the parent tagged `[worker:username]`; in JSON mode they write their own records straight to the shared stdout, identifiable by `process.pid`.
+
+## Shipping to Elasticsearch
+
+Fileglancer logs to stdout, so a shipper reading the container's log files needs only to parse the JSON. For Filebeat:
+
+```yaml
+filebeat.inputs:
+  - type: container
+    paths:
+      - /var/lib/docker/containers/*/*.log
+    json.keys_under_root: true
+    json.add_error_key: true
+```
+
+Since ECS field names are written as dotted keys, Elasticsearch expands them into the usual nested ECS document on ingest.
+
+## Kibana
+
+`event.duration` is a plain number, so a percentile aggregation over it gives p95/p99 directly. Set the field's format to *Duration* (input: nanoseconds) in the data view to have Kibana render it readably. Break it down by `labels.endpoint` to find a slow API route, by `user.name` to find a heavy user, or by `http.response.status_code` for error rates.
+
+## Known limitation
+
+`event.duration` is measured until the response starts, not until the last byte is sent, so file downloads are recorded as time-to-first-byte rather than transfer time. (x2s3, which serves the bulk data, does measure full transfer time.) Charting download latency here would mean rewriting the access log middleware as pure ASGI, the way x2s3's is.
+
+Uvicorn logs two lines ("Started server process", "Waiting for application startup") before it imports the app, so those stay plain text on every start. Everything after that is JSON.

--- a/docs/config.yaml.template
+++ b/docs/config.yaml.template
@@ -4,6 +4,13 @@
 log_level: INFO
 
 #
+# Log output format: 'text' for human-readable logs, or 'json' for one
+# ECS-shaped JSON object per line on stdout, ready for a log shipper to
+# forward to Elasticsearch/Kibana. See docs/StructuredLogging.md.
+#
+log_format: text
+
+#
 # Database URL (runtime - unprivileged user)
 # For SQLite: sqlite:///fileglancer.db
 # For PostgreSQL: postgresql://username:password@hostname:port/database_name

--- a/fileglancer/cli.py
+++ b/fileglancer/cli.py
@@ -159,8 +159,9 @@ def start(host, port, reload, workers, ssl_keyfile, ssl_certfile,
     from fileglancer.settings import get_settings, reload_settings
     settings = get_settings()
     log_level = settings.log_level
-    logger.remove()
-    logger.add(lambda msg: click.echo(msg, nl=False), level=log_level, colorize=True)
+    from fileglancer.logconf import configure_logging
+    configure_logging(log_level, settings.log_format,
+                      text_sink=lambda msg: click.echo(msg, nl=False), colorize=True)
 
     # Set up default database location if not already configured
     if 'FGC_DB_URL' not in os.environ:

--- a/fileglancer/log.py
+++ b/fileglancer/log.py
@@ -4,8 +4,12 @@ Custom access log middleware for FastAPI/Uvicorn
 This middleware logs HTTP access information including authenticated username.
 It replaces Uvicorn's default access logger to provide more detailed logging
 with application-level authentication context.
+
+Each request is logged as one human-readable line, with the same facts also
+attached as Elastic Common Schema fields, which the JSON log format in
+``fileglancer.logconf`` emits for Kibana.
 """
-import logging
+import secrets
 import time
 from typing import Callable
 
@@ -15,6 +19,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import ASGIApp
 
 from fileglancer import auth
+from fileglancer.logconf import SERVICE_NAME
 from fileglancer.settings import Settings
 
 
@@ -27,24 +32,6 @@ def _log_safe(value: str) -> str:
     unchanged.
     """
     return value.encode("unicode_escape").decode("ascii")
-
-
-def disable_uvicorn_access_log():
-    """Silence Uvicorn's own access logger, which AccessLogMiddleware replaces.
-
-    Left enabled, every request is logged twice: once here with the username and
-    duration, once by Uvicorn without them. Uvicorn's ``--no-access-log`` does
-    the same thing from the outside, but it has to be remembered on every launch
-    command, and it was missing from several. Doing it where the middleware is
-    installed covers any way the app is started.
-
-    Matches what Uvicorn's own ``access_log=False`` does. Safe to call more than
-    once, and safe at import time: Uvicorn configures logging before it imports
-    the app, including in each --reload/--workers subprocess.
-    """
-    access_logger = logging.getLogger("uvicorn.access")
-    access_logger.handlers = []
-    access_logger.propagate = False
 
 
 class AccessLogMiddleware(BaseHTTPMiddleware):
@@ -65,7 +52,7 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """Process request and log access information"""
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Extract username from session (if authenticated)
         username = "-"
@@ -77,8 +64,14 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             # Silently handle any authentication errors - user is just not authenticated
             pass
 
-        # Process the request
-        response = await call_next(request)
+        # Bind an id for this request as ECS trace.id, so every line logged
+        # while serving it can be grouped with its access log line in Kibana.
+        # It also goes back to the client as a response header, so a bug report
+        # quoting it is enough to find the request.
+        request_id = secrets.token_hex(8)
+        with logger.contextualize(**{"trace.id": request_id}):
+            response = await call_next(request)
+        response.headers["x-request-id"] = request_id
 
         # Token-authenticated requests have no session cookie, so the lookup
         # above found nothing and username is still '-'. get_user_from_token
@@ -94,7 +87,12 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
                         else token_username)
 
         # Calculate request duration
-        duration_ms = (time.time() - start_time) * 1000
+        # ponytail: BaseHTTPMiddleware returns once the response starts, so for
+        # streamed downloads this is time-to-first-byte, not transfer time.
+        # Rewrite as pure ASGI (see x2s3's AccessLogMiddleware) if download
+        # latency ever needs charting.
+        duration_s = time.perf_counter() - start_time
+        duration_ms = duration_s * 1000
 
         # Extract client information
         client_host = request.client.host if request.client else "unknown"
@@ -128,12 +126,48 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             f"{response.status_code} - {duration_ms:.2f}ms"
         )
 
+        # The same facts as the message above, keyed by ECS field name. Text
+        # mode ignores them; JSON mode merges them into the logged object,
+        # where event.duration is what p95/p99 aggregations run on.
+        fields = {
+            "event.dataset": f"{SERVICE_NAME}.access",
+            # ECS measures event.duration in nanoseconds.
+            "event.duration": int(duration_s * 1_000_000_000),
+            "trace.id": request_id,
+            "http.request.method": request.method,
+            "http.response.status_code": response.status_code,
+            "http.version": http_version,
+            "url.path": _log_safe(path),
+            "client.ip": client_host,
+            "client.port": client_port,
+        }
+        if request.url.query:
+            fields["url.query"] = _log_safe(request.url.query)
+        if username != "-":
+            fields["user.name"] = token_username or username
+            if token_username and token_id:
+                fields["labels.token_id"] = token_id
+        # The handler function name, so latency can be grouped by endpoint.
+        # Raw paths are unbounded cardinality and useless to aggregate over.
+        endpoint = request.scope.get("endpoint")
+        if endpoint is not None:
+            fields["labels.endpoint"] = getattr(endpoint, "__name__", str(endpoint))
+        content_length = response.headers.get("content-length")
+        if content_length is not None:
+            fields["http.response.body.bytes"] = int(content_length)
+        for header, field in (("user-agent", "user_agent.original"),
+                              ("host", "url.domain")):
+            value = request.headers.get(header)
+            if value:
+                fields[field] = _log_safe(value)
+
         # Log at INFO level for successful requests, WARNING for client errors, ERROR for server errors
+        log = logger.bind(**fields)
         if 200 <= response.status_code < 400:
-            logger.info(log_message)
+            log.info(log_message)
         elif 400 <= response.status_code < 500:
-            logger.warning(log_message)
+            log.warning(log_message)
         else:
-            logger.error(log_message)
+            log.error(log_message)
 
         return response

--- a/fileglancer/logconf.py
+++ b/fileglancer/logconf.py
@@ -1,0 +1,118 @@
+"""
+Log output configuration: human-readable text (the default) or JSON.
+
+Setting ``log_format: json`` (or ``FGC_LOG_FORMAT=json``) turns every record
+into a single-line JSON object using Elastic Common Schema field names, which
+a log shipper can parse straight off stdout and hand to Kibana. ECS fields are
+written as dotted keys ("http.response.status_code") rather than nested dicts:
+Elasticsearch expands them on ingest, so the indexed document is the same one
+without any dict-building here.
+
+Kept free of Fileglancer imports so the setuid user worker can configure its
+logging without pulling in the server's auth stack.
+"""
+import json
+import logging
+import sys
+import traceback
+from datetime import timezone
+from importlib.metadata import PackageNotFoundError, version
+
+from loguru import logger
+
+SERVICE_NAME = "fileglancer"
+
+try:
+    SERVICE_VERSION = version("fileglancer")
+except PackageNotFoundError:  # running from a source tree that was never installed
+    SERVICE_VERSION = "unknown"
+
+
+def json_sink(message):
+    """Write one loguru record as one line of ECS-shaped JSON on stdout."""
+    record = message.record
+    payload = {
+        "@timestamp": record["time"].astimezone(timezone.utc)
+                      .isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "log.level": record["level"].name.lower(),
+        "log.logger": record["name"],
+        "message": record["message"],
+        "service.name": SERVICE_NAME,
+        "service.version": SERVICE_VERSION,
+        "process.pid": record["process"].id,
+    }
+    # Anything bound with logger.bind()/contextualize() is already keyed by its
+    # ECS name, so it merges straight in.
+    payload.update(record["extra"])
+
+    exception = record["exception"]
+    if exception:
+        payload["error.type"] = getattr(exception.type, "__name__", "Exception")
+        payload["error.message"] = str(exception.value)
+        payload["error.stack_trace"] = "".join(traceback.format_exception(
+            exception.type, exception.value, exception.traceback))
+
+    sys.stdout.write(json.dumps(payload, default=str) + "\n")
+    sys.stdout.flush()
+
+
+class InterceptHandler(logging.Handler):
+    """Route stdlib logging (uvicorn, sqlalchemy) into loguru.
+
+    Only installed in JSON mode, so that a shipper sees one format on the
+    stream instead of JSON lines mixed with uvicorn's plain text.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+        frame, depth = logging.currentframe(), 2
+        while frame and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+        # Report the stdlib logger's own name rather than the frame loguru
+        # would infer, which is always the logging module itself.
+        logger.opt(depth=depth, exception=record.exc_info).bind(
+            **{"log.logger": record.name}).log(level, record.getMessage())
+
+
+def configure_logging(log_level: str = "INFO", log_format: str = "text",
+                      text_sink=sys.stderr, colorize: bool = None):
+    """Point loguru at the human-readable sink, or at the ECS JSON sink.
+
+    ``text_sink``/``colorize`` only apply to text mode; the CLI passes a click
+    sink so its output stays on the click stream.
+    """
+    logger.remove()
+    if log_format == "json":
+        logger.add(json_sink, level=log_level, format="{message}")
+        logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
+        # Uvicorn installs its own handlers and turns off propagation, so its
+        # lines would stay plain text on a stream that is otherwise all JSON.
+        # Hand them to the root logger, which now goes through loguru.
+        for name in ("uvicorn", "uvicorn.error", "uvicorn.asgi"):
+            uvicorn_logger = logging.getLogger(name)
+            uvicorn_logger.handlers = []
+            uvicorn_logger.propagate = True
+    else:
+        logger.add(text_sink, level=log_level, colorize=colorize)
+
+
+def disable_uvicorn_access_log():
+    """Silence Uvicorn's own access logger, which AccessLogMiddleware replaces.
+
+    Left enabled, every request is logged twice: once here with the username and
+    duration, once by Uvicorn without them. Uvicorn's ``--no-access-log`` does
+    the same thing from the outside, but it has to be remembered on every launch
+    command, and it was missing from several. Doing it where the middleware is
+    installed covers any way the app is started.
+
+    Matches what Uvicorn's own ``access_log=False`` does. Safe to call more than
+    once, and safe at import time: Uvicorn configures logging before it imports
+    the app, including in each --reload/--workers subprocess.
+    """
+    access_logger = logging.getLogger("uvicorn.access")
+    access_logger.handlers = []
+    access_logger.propagate = False

--- a/fileglancer/server.py
+++ b/fileglancer/server.py
@@ -42,7 +42,8 @@ from fileglancer.settings import get_settings
 from fileglancer.issues import create_jira_ticket, get_jira_ticket_details, delete_jira_ticket
 from fileglancer.utils import format_timestamp, guess_content_type, parse_range_header, make_etag, parse_http_date_to_epoch
 from fileglancer.filestore import Filestore, RootCheckError
-from fileglancer.log import AccessLogMiddleware, disable_uvicorn_access_log
+from fileglancer.log import AccessLogMiddleware
+from fileglancer.logconf import configure_logging, disable_uvicorn_access_log
 from fileglancer.worker_pool import (
     WorkerPool, WorkerError, WorkerDead, prepare_worker_request)
 from fileglancer.user_worker import serialize_job_for_worker
@@ -518,9 +519,8 @@ def create_app(settings):
     @asynccontextmanager
     async def lifespan(app: FastAPI):
 
-        # Configure logging based on the log level in the settings
-        logger.remove()
-        logger.add(sys.stderr, level=settings.log_level)
+        # Configure logging based on the log level/format in the settings
+        configure_logging(settings.log_level, settings.log_format)
 
         # use_access_flags requires root + non-CLI mode. Workers themselves
         # are used in any server mode (CLI mode runs in-process).

--- a/fileglancer/settings.py
+++ b/fileglancer/settings.py
@@ -61,6 +61,9 @@ class Settings(BaseSettings):
     """
 
     log_level: str = 'INFO'
+    # 'text' for human-readable logs, 'json' for one ECS-shaped JSON object
+    # per line, ready for a log shipper to forward to Elasticsearch/Kibana.
+    log_format: str = 'text'
     db_url: str = 'sqlite:///fileglancer.db'
     db_admin_url: Optional[str] = None
 

--- a/fileglancer/user_worker.py
+++ b/fileglancer/user_worker.py
@@ -41,6 +41,8 @@ from typing import Any, Optional
 
 from loguru import logger
 
+from fileglancer.logconf import InterceptHandler, configure_logging
+
 
 # Length-prefix format: 4-byte big-endian unsigned int
 _HEADER_FMT = "!I"
@@ -1279,31 +1281,19 @@ def main():
     # Set up orphan prevention
     _set_pdeathsig()
 
-    # Configure logging
+    # Configure logging. In text mode this goes to stderr, which the parent
+    # forwards into its own log tagged with the worker's username. In JSON
+    # mode it goes to the inherited stdout instead, so each record reaches the
+    # shipper as the complete JSON object the worker wrote, rather than being
+    # buried inside the parent's message string.
     log_level = os.environ.get("FGC_LOG_LEVEL", "INFO").upper()
+    log_format = os.environ.get("FGC_LOG_FORMAT", "text")
+    configure_logging(log_level, log_format)
 
-    # Use loguru for worker logging, output to stderr
-    logger.remove()
-    logger.add(sys.stderr, level=log_level)
-
-    # Route stdlib logging (used by cluster_api) into loguru so a 
+    # Route stdlib logging (used by cluster_api) into loguru so a
     # single configuration controls levels and formatting, and
     # loguru-only levels like TRACE/SUCCESS work without translation.
-    class _InterceptHandler(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            try:
-                level = logger.level(record.levelname).name
-            except ValueError:
-                level = record.levelno
-            frame, depth = logging.currentframe(), 2
-            while frame and frame.f_code.co_filename == logging.__file__:
-                frame = frame.f_back
-                depth += 1
-            logger.opt(depth=depth, exception=record.exc_info).log(
-                level, record.getMessage()
-            )
-
-    logging.basicConfig(handlers=[_InterceptHandler()], level=0, force=True)
+    logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
 
     # Get the socket fd from environment
     fd = int(os.environ["FGC_WORKER_FD"])

--- a/fileglancer/worker_pool.py
+++ b/fileglancer/worker_pool.py
@@ -144,7 +144,8 @@ _WORKER_ENV_ALLOW_PREFIXES = (
 
 
 def _build_worker_env(base_env: dict, home_dir: str, log_level: str,
-                      child_fd: int, passthrough: Optional[list] = None) -> dict:
+                      child_fd: int, passthrough: Optional[list] = None,
+                      log_format: str = "text") -> dict:
     """Build the environment for a worker subprocess (allowlist).
 
     Keeps only allowlisted variables (see the module constants) plus any
@@ -171,6 +172,7 @@ def _build_worker_env(base_env: dict, home_dir: str, log_level: str,
     env = {k: v for k, v in base_env.items() if _allowed(k)}
     env["HOME"] = home_dir
     env["FGC_LOG_LEVEL"] = log_level
+    env["FGC_LOG_FORMAT"] = log_format
     env["FGC_WORKER_FD"] = str(child_fd)
     return env
 
@@ -463,6 +465,7 @@ class WorkerPool:
         env = _build_worker_env(
             os.environ, home_dir, self.settings.log_level, child_sock.fileno(),
             passthrough=self.settings.apps.worker_env_passthrough,
+            log_format=self.settings.log_format,
         )
 
         logger.info(

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,13 +1,27 @@
 """Tests for the access log middleware."""
 
 import asyncio
+import json
+import logging
 
+import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from loguru import logger
 
 from fileglancer.log import AccessLogMiddleware
+from fileglancer.logconf import configure_logging
 from fileglancer.settings import Settings
+
+
+@pytest.fixture(autouse=True)
+def restore_logging():
+    """JSON mode reroutes stdlib logging globally; undo it between tests."""
+    root = logging.getLogger()
+    handlers, level = root.handlers[:], root.level
+    yield
+    configure_logging("INFO", "text")
+    root.handlers, root.level = handlers, level
 
 
 def _app_and_lines():
@@ -131,3 +145,77 @@ def test_unauthenticated_requests_still_log_a_dash():
 
     assert len(lines) == 1, lines
     assert "[-]" in lines[0], lines[0]
+
+
+def test_json_mode_logs_one_ecs_object_per_request(capsys):
+    """JSON mode must emit a parseable ECS record with a duration to aggregate."""
+    app = FastAPI()
+    app.add_middleware(AccessLogMiddleware, settings=Settings())
+
+    @app.get("/api/files/{name}")
+    async def files(name: str, request: Request):
+        request.state.fg_username = "alice"
+        request.state.fg_token_id = "a1b2c3d4e5f6"
+        logger.info("handling the request")
+        return {"ok": True}
+
+    configure_logging("INFO", "json")
+    try:
+        with TestClient(app) as client:
+            response = client.get("/api/files/share?x=1")
+    finally:
+        configure_logging("INFO", "text")
+
+    records = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    access = [r for r in records if r.get("event.dataset") == "fileglancer.access"]
+    assert len(access) == 1, records
+    record = access[0]
+
+    assert record["service.name"] == "fileglancer"
+    assert record["http.request.method"] == "GET"
+    assert record["http.response.status_code"] == 200
+    assert record["url.path"] == "/api/files/share"
+    assert record["url.query"] == "x=1"
+    assert record["user.name"] == "alice"
+    assert record["labels.token_id"] == "a1b2c3d4e5f6"
+    assert record["labels.endpoint"] == "files"
+    # The whole point: a number Kibana can take percentiles of.
+    assert isinstance(record["event.duration"], int) and record["event.duration"] > 0
+
+    # The id is returned to the client and shared with every line logged while
+    # serving the request, so both can be found from a single bug report.
+    assert response.headers["x-request-id"] == record["trace.id"]
+    handler_line = [r for r in records if r["message"] == "handling the request"]
+    assert handler_line and handler_line[0]["trace.id"] == record["trace.id"]
+
+
+def test_json_mode_records_exceptions(capsys):
+    """A logged exception must arrive as ECS error fields, not a wall of text."""
+    configure_logging("INFO", "json")
+    try:
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            logger.exception("it broke")
+    finally:
+        configure_logging("INFO", "text")
+
+    record = json.loads(capsys.readouterr().out.strip())
+    assert record["error.type"] == "ValueError"
+    assert record["error.message"] == "boom"
+    assert "ValueError: boom" in record["error.stack_trace"]
+
+
+def test_text_mode_is_the_default_and_stays_human_readable(capsys):
+    """Default settings must log exactly as before, not JSON."""
+    assert Settings().log_format == "text"
+
+    app, lines, sink_id = _app_and_lines()
+    try:
+        with TestClient(app) as client:
+            client.get("/api/content/share/file.txt")
+    finally:
+        logger.remove(sink_id)
+
+    assert '"GET /api/content/share/file.txt HTTP/1.1" 200 - ' in lines[0]
+    assert "{" not in lines[0], lines[0]

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -95,6 +95,7 @@ class TestBuildWorkerEnv:
         for key in list(env):
             assert not key.upper().startswith("FGC_") or key in (
                 "FGC_LOG_LEVEL",
+                "FGC_LOG_FORMAT",
                 "FGC_WORKER_FD",
             ), f"secret leaked: {key}"
         # The specific secrets are gone regardless of case.
@@ -143,6 +144,7 @@ class TestBuildWorkerEnv:
         # Operational vars the worker needs are set explicitly.
         assert env["HOME"] == "/home/alice"
         assert env["FGC_LOG_LEVEL"] == "DEBUG"
+        assert env["FGC_LOG_FORMAT"] == "text"
         assert env["FGC_WORKER_FD"] == "9"
 
     def test_passthrough_allows_site_specific_names_and_prefixes(self):


### PR DESCRIPTION
Response times only ever existed in the text access log, where they could not be aggregated. Setting `log_format: json` (or `FGC_LOG_FORMAT=json`) now writes one [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html) object per line to stdout, which a shipper parses straight off the container's logs — so p95/p99 can be charted from `event.duration` and broken down by endpoint, user or status code.

**Text remains the default and stays human-readable**; nothing changes unless you turn this on. Turn it on in production, leave it off for development.

Companion to JaneliaSciComp/x2s3#31, which does the same thing for x2s3 so both services land in Kibana with the same field names.

## What's in it

The access log middleware keeps emitting exactly the line it emitted before, and additionally binds the same facts as ECS fields, which text mode ignores. Each line carries `event.duration` (nanoseconds, the ECS unit), `http.request.method`, `http.response.status_code`, `url.path`, `client.ip`, `user.name`, `labels.token_id` on API-token requests, and `labels.endpoint` — the handler function name, since raw paths have unbounded cardinality and are useless to aggregate over.

Each request also gets an id, returned in the `x-request-id` header and bound as `trace.id` to every line logged while serving it, so a bug report quoting the id finds the whole request, not just its access line.

ECS fields are written as dotted keys rather than nested dicts; Elasticsearch expands them on ingest, so the indexed document is the same one without any dict-building in the code.

Output configuration lives in a new `fileglancer/logconf.py`, deliberately free of Fileglancer imports so the setuid user worker can configure its logging without pulling in the server's auth stack. Workers inherit the format over `FGC_LOG_FORMAT` (added to the env allowlist — it is a literal `text`/`json`, not a secret). In text mode a worker's output is forwarded through the parent tagged `[worker:username]` as before; in JSON mode it writes its own complete records to the shared stdout, identifiable by `process.pid`.

## Known limitation, and a possible follow-up

`event.duration` here is **time-to-first-byte, not transfer time**, because `BaseHTTPMiddleware` returns as soon as the response starts. That is fine for the API, and x2s3 serves the bulk data and does measure full transfer time.

If download latency ever needs charting, the follow-up is to rewrite `AccessLogMiddleware` as pure ASGI, the way x2s3's is — it can then measure to the last body chunk and count bytes off the wire. A comment marks the spot. Deliberately out of scope here.

## Testing

`tests/test_log.py` gains coverage for both formats: JSON mode emits one parseable ECS object per request with a numeric duration, the handler's own log lines share the access line's `trace.id`, exceptions arrive as `error.type`/`error.message`/`error.stack_trace` rather than a wall of text, and text mode is confirmed to still be the default and still human-readable. 930 pass.

## Docs

`docs/StructuredLogging.md` covers the field list, a Filebeat input snippet, and the Kibana side (set `event.duration`'s field format to Duration/nanoseconds and a percentile agg reads as p95/p99 directly).

@StephanPreibisch @JaneliaSciComp/fileglancer 