### PR TITLE
Fix client validation and API Tokens page link

### DIFF
--- a/fileglancer/client.py
+++ b/fileglancer/client.py
@@ -44,11 +44,15 @@ class Fileglancer:
 
     def __init__(self, url: Optional[str] = None, token: Optional[str] = None,
                  timeout: float = 60.0):
-        url = url or os.environ.get("FILEGLANCER_URL")
-        token = token or os.environ.get("FILEGLANCER_TOKEN")
+        url = (url or os.environ.get("FILEGLANCER_URL") or "").strip()
+        token = (token or os.environ.get("FILEGLANCER_TOKEN") or "").strip()
         if not url:
             raise FileglancerError(
                 "No Fileglancer server URL. Pass url= or set FILEGLANCER_URL.")
+        if not url.startswith(("http://", "https://")):
+            raise FileglancerError(
+                f"Invalid Fileglancer server URL {url!r}: must start with "
+                "http:// or https://.")
         if not token:
             raise FileglancerError(
                 "No API token. Pass token= or set FILEGLANCER_TOKEN. Create a "

--- a/frontend/src/components/ApiTokens.tsx
+++ b/frontend/src/components/ApiTokens.tsx
@@ -59,10 +59,10 @@ export default function ApiTokens() {
       <Typography className="mb-6 text-foreground">
         API tokens let scripts and notebooks use Fileglancer through the{' '}
         <FgExternalLink href="https://pypi.org/project/fileglancer">
-          authoring guide
+          Python package
         </FgExternalLink>
-        Python package. A token acts on your behalf, limited to the scopes you
-        grant it. The token is shown only once, when you create it.
+        . A token acts on your behalf, limited to the scopes you grant it.
+        The token is shown only once, when you create it.
       </Typography>
 
       {isLoading ? (

--- a/frontend/src/components/ApiTokens.tsx
+++ b/frontend/src/components/ApiTokens.tsx
@@ -61,8 +61,8 @@ export default function ApiTokens() {
         <FgExternalLink href="https://pypi.org/project/fileglancer">
           Python package
         </FgExternalLink>
-        . A token acts on your behalf, limited to the scopes you grant it.
-        The token is shown only once, when you create it.
+        . A token acts on your behalf, limited to the scopes you grant it. The
+        token is shown only once, when you create it.
       </Typography>
 
       {isLoading ? (


### PR DESCRIPTION
## Summary
- Strip whitespace from `FILEGLANCER_URL`/`FILEGLANCER_TOKEN` (and constructor args) before use, and require an `http://`/`https://` scheme, so bad input fails fast with a clear message instead of an opaque `httpx`/`h11` error on the first request.
- Fix the "authoring guide" link on the API Tokens page, which pointed at the PyPI package page and rendered as "authoring guidePython package." — now reads "Python package" and links correctly.

Follow-up to #435, whose branch was deleted after merge.

## Test plan
- [x] Manually verified `Fileglancer(url=..., token=...)` raises `FileglancerError` for a scheme-less URL, a typo'd scheme, and succeeds with whitespace-padded url/token.
- [x] Frontend Prettier/ESLint checks pass (via pre-push hook).

@StephanPreibisch @JaneliaSciComp/fileglancer 