### PR TITLE
fix: make the ~/.fileglancer state directory owner-only

### DIFF
--- a/docs/config.yaml.template
+++ b/docs/config.yaml.template
@@ -226,7 +226,12 @@ session_cookie_secure: true
 # See: https://github.com/JaneliaSciComp/py-cluster-api
 #
 cluster:
-  executor: local            # "local" or "lsf"
+  executor: local            # "local" or "lsf". "local" is for single-user
+                             # deployments (dev, CLI mode) only: its poll loop
+                             # reads job state from the work directory in the
+                             # server process, and work directories are private
+                             # to the user who owns the job. A multi-user
+                             # deployment must use "lsf".
 #   job_name_prefix: fg        # Prefix for cluster job names. REQUIRED for job
 #                              # reconnection after server restarts. Without this,
 #                              # active jobs will not be re-tracked and will

--- a/fileglancer/alembic/versions/e4d1b7a92c58_strip_credentials_from_job_service_urls.py
+++ b/fileglancer/alembic/versions/e4d1b7a92c58_strip_credentials_from_job_service_urls.py
@@ -1,0 +1,62 @@
+"""strip credentials from stored job service URLs
+
+jobs.service_url held the whole published URL, and its query string carries the
+service's own access token. Nothing ever read that back: the column's only
+consumer is /api/apps/resolve, which keeps the authority and discards the rest.
+Rewrite existing rows to scheme://host:port so tokens already stored do not
+outlive the fix, nulling any row with no usable authority -- the next
+job-detail load repopulates it. Mirrors
+fileglancer.apps.serviceproxy.service_url_origin, inlined here so the migration
+stays self-contained.
+
+Revision ID: e4d1b7a92c58
+Revises: c3e9b7f41a28
+Create Date: 2026-09-08 00:00:00.000000
+
+"""
+from urllib.parse import urlsplit, urlunsplit
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e4d1b7a92c58'
+down_revision = 'c3e9b7f41a28'
+branch_labels = None
+depends_on = None
+
+
+def _origin(service_url):
+    if not service_url:
+        return None
+    try:
+        parts = urlsplit(service_url)
+    except ValueError:
+        return None
+    if not parts.scheme or not parts.netloc or '@' in parts.netloc:
+        return None
+    return urlunsplit((parts.scheme, parts.netloc, '', '', ''))
+
+
+def _strip_stored_credentials(conn):
+    rows = conn.execute(sa.text(
+        "SELECT id, service_url FROM jobs WHERE service_url IS NOT NULL"
+    )).fetchall()
+    for r in rows:
+        origin = _origin(r.service_url)
+        if origin != r.service_url:
+            conn.execute(
+                sa.text("UPDATE jobs SET service_url = :url WHERE id = :id"),
+                {"url": origin, "id": r.id},
+            )
+
+
+def upgrade() -> None:
+    _strip_stored_credentials(op.get_bind())
+
+
+def downgrade() -> None:
+    # The discarded query string is where the token lived, so there is nothing
+    # to put back. A running service repopulates the row on its next detail load.
+    pass

--- a/fileglancer/apps/jobfiles.py
+++ b/fileglancer/apps/jobfiles.py
@@ -7,6 +7,8 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
+from loguru import logger
+
 from fileglancer import database as db
 from fileglancer.settings import get_settings
 
@@ -49,18 +51,36 @@ def ensure_private_dir(path: Path) -> None:
     Every level from ``path`` up to and including ``~/.fileglancer`` is locked
     down, so the state root stays private however it was first created and
     subtrees made before this was enforced are covered too. Nothing above the
-    state root is touched.
+    state root is touched. An ancestor that cannot be chmod'ed (owned by another
+    uid) is warned about rather than raised, since the leaf is private either
+    way; failing to lock the leaf itself does raise.
 
     Must run as the owner of the tree (in the user worker, or as the user in CLI
     mode). Chmod rather than ``mkdir(mode=...)``: that mode is masked by the
     umask, and ignored entirely when the directory already exists.
     """
     path.mkdir(parents=True, exist_ok=True)
-    os.chmod(path, 0o700)
+    try:
+        os.chmod(path, 0o700)
+    except OSError as e:
+        raise PermissionError(
+            f"Cannot make {path} private, so it is not safe to write job "
+            f"credentials there: {e}"
+        ) from e
     for parent in path.parents:
         if _STATE_DIRNAME not in parent.parts:
             break  # above ~/.fileglancer (or outside it): not ours to touch
-        os.chmod(parent, 0o700)
+        try:
+            os.chmod(parent, 0o700)
+        except OSError as e:
+            # A state root owned by someone else is not ours to repair, and the
+            # directory we just locked is the one that holds the secrets. Say so
+            # and stop, rather than failing the caller over an ancestor.
+            logger.warning(
+                f"Could not make {parent} private ({e}); anything directly "
+                f"inside it stays readable by other users"
+            )
+            break
 
 
 def _resolve_work_dir(db_job: db.JobDB) -> Path:

--- a/fileglancer/apps/jobfiles.py
+++ b/fileglancer/apps/jobfiles.py
@@ -48,12 +48,12 @@ def ensure_private_dir(path: Path) -> None:
     0755 on a shared filesystem publishes them, and with the token the ability
     to act as that user, to everyone on the site.
 
-    Every level from ``path`` up to and including ``~/.fileglancer`` is locked
-    down, so the state root stays private however it was first created and
-    subtrees made before this was enforced are covered too. Nothing above the
-    state root is touched. An ancestor that cannot be chmod'ed (owned by another
-    uid) is warned about rather than raised, since the leaf is private either
-    way; failing to lock the leaf itself does raise.
+    Every level from ``path`` up to and including the state root is locked down,
+    so that root stays private however it was first created and subtrees made
+    before this was enforced are covered too. Nothing above it is touched. An
+    ancestor that cannot be chmod'ed (owned by another uid) is warned about
+    rather than raised, since the leaf is private either way; failing to lock
+    the leaf itself does raise.
 
     Must run as the owner of the tree (in the user worker, or as the user in CLI
     mode). Chmod rather than ``mkdir(mode=...)``: that mode is masked by the
@@ -67,9 +67,16 @@ def ensure_private_dir(path: Path) -> None:
             f"Cannot make {path} private, so it is not safe to write sensitive "
             f"Fileglancer state there: {e}"
         ) from e
+    # The state root is the innermost ``.fileglancer`` above the leaf. Found
+    # lexically, not by resolving the path: a relocated state directory (a
+    # symlinked ``~/.fileglancer``) resolves to somewhere with no
+    # ``.fileglancer`` component at all, and its real tree still wants locking.
+    state_root = next(
+        (p for p in path.parents if p.name == _STATE_DIRNAME), None
+    )
+    if state_root is None:
+        return  # not under a state directory, so there is nothing above to fix
     for parent in path.parents:
-        if _STATE_DIRNAME not in parent.parts:
-            break  # above ~/.fileglancer (or outside it): not ours to touch
         try:
             os.chmod(parent, 0o700)
         except OSError as e:
@@ -81,6 +88,8 @@ def ensure_private_dir(path: Path) -> None:
                 f"inside it stays readable by other users"
             )
             break
+        if parent == state_root:
+            break  # never ascend past the state root
 
 
 def _resolve_work_dir(db_job: db.JobDB) -> Path:

--- a/fileglancer/apps/jobfiles.py
+++ b/fileglancer/apps/jobfiles.py
@@ -64,8 +64,8 @@ def ensure_private_dir(path: Path) -> None:
         os.chmod(path, 0o700)
     except OSError as e:
         raise PermissionError(
-            f"Cannot make {path} private, so it is not safe to write job "
-            f"credentials there: {e}"
+            f"Cannot make {path} private, so it is not safe to write sensitive "
+            f"Fileglancer state there: {e}"
         ) from e
     for parent in path.parents:
         if _STATE_DIRNAME not in parent.parts:

--- a/fileglancer/apps/jobfiles.py
+++ b/fileglancer/apps/jobfiles.py
@@ -33,6 +33,36 @@ def _build_work_dir(job_id: int, app_name: str, entry_point_id: str,
 
 # --- Job File Access ---
 
+_STATE_DIRNAME = ".fileglancer"
+
+
+def ensure_private_dir(path: Path) -> None:
+    """Create a directory under ``~/.fileglancer`` that only its owner can enter.
+
+    Fileglancer's state directory holds things no other user should see: a
+    service job's access token (in ``service_url``, and routinely echoed into
+    ``stdout.log`` by the service itself) and clones of app repositories, which
+    may be private. The directory mode is what keeps them secret — the default
+    0755 on a shared filesystem publishes them, and with the token the ability
+    to act as that user, to everyone on the site.
+
+    Every level from ``path`` up to and including ``~/.fileglancer`` is locked
+    down, so the state root stays private however it was first created and
+    subtrees made before this was enforced are covered too. Nothing above the
+    state root is touched.
+
+    Must run as the owner of the tree (in the user worker, or as the user in CLI
+    mode). Chmod rather than ``mkdir(mode=...)``: that mode is masked by the
+    umask, and ignored entirely when the directory already exists.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    os.chmod(path, 0o700)
+    for parent in path.parents:
+        if _STATE_DIRNAME not in parent.parts:
+            break  # above ~/.fileglancer (or outside it): not ours to touch
+        os.chmod(parent, 0o700)
+
+
 def _resolve_work_dir(db_job: db.JobDB) -> Path:
     """Resolve a job's work directory to an absolute path."""
     if db_job.work_dir:

--- a/fileglancer/apps/jobs.py
+++ b/fileglancer/apps/jobs.py
@@ -357,6 +357,14 @@ def _poll_local_jobs(session, jobs_to_poll: list) -> bool:
     exit code to ``{work_dir}/exit_code`` via an EXIT trap.
 
     Returns True if there are still active jobs, False otherwise.
+
+    ponytail: single-user only. This runs in the server process and reads the
+    work directory directly, but work directories are 0700 and owned by the job's
+    user (see ensure_private_dir), so the server can only poll jobs it owns
+    itself -- a job belonging to anyone else would never leave PENDING. That is
+    why the config template restricts ``executor: local`` to single-user
+    deployments. To lift it, move these two reads into a worker action, the way
+    read_job_file already does, and poll through the owning user's worker.
     """
     still_active = False
 

--- a/fileglancer/apps/jobs.py
+++ b/fileglancer/apps/jobs.py
@@ -525,7 +525,11 @@ def _build_service_url_publisher(suffix: str = "") -> str:
         "(",
         "  for _ in $(seq 1 3600); do",
         '    if (exec 3<>"/dev/tcp/127.0.0.1/$FG_SERVICE_PORT") 2>/dev/null; then',
-        f'      printf \'http://%s:%s%s\' "$FG_HOSTNAME" "$FG_SERVICE_PORT" "{suffix}" > "$SERVICE_URL_PATH"',
+        # umask in a subshell: the URL usually carries the service's access
+        # token, so the file is 0600 regardless of the user's umask. The work
+        # directory's own 0700 is the real barrier (see ensure_private_dir);
+        # this keeps the secret covered if the file outlives that directory.
+        f'      (umask 077; printf \'http://%s:%s%s\' "$FG_HOSTNAME" "$FG_SERVICE_PORT" "{suffix}" > "$SERVICE_URL_PATH")',
         "      exit 0",
         "    fi",
         "    sleep 1",

--- a/fileglancer/apps/jobs.py
+++ b/fileglancer/apps/jobs.py
@@ -533,11 +533,13 @@ def _build_service_url_publisher(suffix: str = "") -> str:
         "(",
         "  for _ in $(seq 1 3600); do",
         '    if (exec 3<>"/dev/tcp/127.0.0.1/$FG_SERVICE_PORT") 2>/dev/null; then',
-        # umask in a subshell: the URL usually carries the service's access
-        # token, so the file is 0600 regardless of the user's umask. The work
-        # directory's own 0700 is the real barrier (see ensure_private_dir);
-        # this keeps the secret covered if the file outlives that directory.
-        f'      (umask 077; printf \'http://%s:%s%s\' "$FG_HOSTNAME" "$FG_SERVICE_PORT" "{suffix}" > "$SERVICE_URL_PATH")',
+        # The URL usually carries the service's access token, so the file is
+        # 0600 whatever the user's umask: the umask covers creating it, and the
+        # chmod covers a redirect into a file that somehow already exists, since
+        # that keeps the mode it was created with. The work directory's own 0700
+        # is the real barrier (see ensure_private_dir); this keeps the secret
+        # covered if the file outlives that directory.
+        f'      (umask 077; printf \'http://%s:%s%s\' "$FG_HOSTNAME" "$FG_SERVICE_PORT" "{suffix}" > "$SERVICE_URL_PATH" && chmod 600 "$SERVICE_URL_PATH")',
         "      exit 0",
         "    fi",
         "    sleep 1",

--- a/fileglancer/apps/manifest.py
+++ b/fileglancer/apps/manifest.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from fileglancer import database as db
 from fileglancer.apps.adapters import try_adapt
+from fileglancer.apps.jobfiles import ensure_private_dir
 # GitHub URL parsing/canonicalization lives in fileglancer.giturls (which has no
 # fileglancer deps) so the database layer can reuse it without an import cycle.
 # Re-exported for the apps module's internal callers and existing imports.
@@ -349,6 +350,10 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
     lock = _get_repo_lock(owner, repo, branch)
 
     async with lock:
+        # Before the cache-hit check, not just on the clone path: this is the
+        # call every user reaches, so it is what locks down a state directory
+        # left world-readable by an earlier version.
+        ensure_private_dir(repo_dir.parent)
         if repo_dir.exists():
             logger.debug(f"Repo cache hit: {owner}/{repo} ({branch})")
             if pull:
@@ -367,7 +372,6 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
                 )
         else:
             logger.info(f"Cloning {owner}/{repo} ({branch}) into {repo_dir}")
-            repo_dir.parent.mkdir(parents=True, exist_ok=True)
             await _clone_repo(owner, repo, branch, repo_dir)
 
     return repo_dir
@@ -418,7 +422,7 @@ async def _create_snapshot(owner: str, repo: str, repo_dir: Path, sha: str,
                 f"pin it to the current revision. ({e})"
             )
 
-    snapshot_dir.parent.mkdir(parents=True, exist_ok=True)
+    ensure_private_dir(snapshot_dir.parent)
     tmp_dir = snapshot_dir.parent / f".tmp-{sha}"
     shutil.rmtree(tmp_dir, ignore_errors=True)
     try:

--- a/fileglancer/apps/manifest.py
+++ b/fileglancer/apps/manifest.py
@@ -345,7 +345,13 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
     euid = os.geteuid() if hasattr(os, "geteuid") else "n/a"
     logger.debug(f"ensure_repo running in-process as euid={euid}")
     cache_base = _repo_cache_base()
-    repo_dir = (cache_base / owner / repo / branch).resolve()
+    # Kept alongside the resolved path because the two are not interchangeable:
+    # containment and git want the real location, while the permission walk
+    # needs to still see the .fileglancer component that resolve() collapses
+    # away when any part of the path (a relocated state directory, an
+    # automounted home) is a symlink.
+    lexical_repo_dir = cache_base / owner / repo / branch
+    repo_dir = lexical_repo_dir.resolve()
     repo_dir.relative_to(cache_base.resolve())
     lock = _get_repo_lock(owner, repo, branch)
 
@@ -353,7 +359,7 @@ async def _ensure_repo_cache(url: str, pull: bool = False,
         # Before the cache-hit check, not just on the clone path: this is the
         # call every user reaches, so it is what locks down a state directory
         # left world-readable by an earlier version.
-        ensure_private_dir(repo_dir.parent)
+        ensure_private_dir(lexical_repo_dir.parent)
         if repo_dir.exists():
             logger.debug(f"Repo cache hit: {owner}/{repo} ({branch})")
             if pull:

--- a/fileglancer/apps/manifest.py
+++ b/fileglancer/apps/manifest.py
@@ -483,6 +483,10 @@ async def ensure_repo_snapshot(url: str, sha: str | None = None,
         if (snapshot_dir / ".git").exists():
             with suppress(OSError):
                 os.utime(snapshot_dir)
+            # Launching a pinned app reaches neither _ensure_repo_cache nor
+            # _create_snapshot, so for a user whose snapshots all predate this
+            # it is the only place the tree gets locked down.
+            ensure_private_dir(snapshot_dir.parent)
             return snapshot_dir, sha
 
     repo_dir = await _ensure_repo_cache(url, pull=pull)

--- a/fileglancer/apps/serviceproxy.py
+++ b/fileglancer/apps/serviceproxy.py
@@ -85,6 +85,37 @@ def build_proxied_service_url(service_url: Optional[str], job_id: int,
     ))
 
 
+def service_url_origin(service_url: Optional[str]) -> Optional[str]:
+    """The ``scheme://host:port`` prefix of a published service URL.
+
+    This is the only part of the URL worth persisting. The path and query carry
+    the service's own access token, and nothing reads them back out of the
+    database: the column's one consumer is /api/apps/resolve, which keeps the
+    authority and discards the rest. Storing the whole URL would leave a live
+    credential somewhere the work directory's 0700 cannot reach, since a
+    multi-user deployment's database is MySQL, with its own dumps and backups.
+
+    The scheme is kept because urlsplit needs one to find an authority at all: a
+    bare ``host:port`` parses as a scheme plus path, leaving netloc empty, and
+    upstream_from_service_url reads netloc.
+
+    Returns None when there is no authority to keep, and for an authority
+    carrying userinfo -- that is a credential too, and upstream_from_service_url
+    refuses such an authority anyway, so dropping the row loses nothing. Note
+    that urlsplit strips CR/LF, so a header-injection attempt is not preserved
+    here; what remains is still refused downstream by the upstream gate.
+    """
+    if not service_url:
+        return None
+    try:
+        parts = urlsplit(service_url)
+    except ValueError:
+        return None
+    if not parts.scheme or not parts.netloc or '@' in parts.netloc:
+        return None
+    return urlunsplit((parts.scheme, parts.netloc, '', '', ''))
+
+
 def job_id_from_host(host: Optional[str], proxy_domain: str,
                      secret: str) -> Optional[int]:
     """Extract the job id from a proxy hostname, or None if it isn't one.

--- a/fileglancer/cli.py
+++ b/fileglancer/cli.py
@@ -168,6 +168,15 @@ def start(host, port, reload, workers, ssl_keyfile, ssl_certfile,
         data_dir = Path.home() / '.local' / 'share' / 'fileglancer'
         data_dir.mkdir(parents=True, exist_ok=True)
         db_path = data_dir / 'fileglancer.db'
+        # The database holds session ids and service URLs, both of which are
+        # live credentials, so it must not be readable by other users on a
+        # shared home. The directory mode is what covers SQLite's -wal and -shm
+        # sidecars too; the file mode is set as well so a copy of it stays
+        # private. Both run unconditionally, to fix an install created before
+        # this or under a laxer umask.
+        os.chmod(data_dir, 0o700)
+        db_path.touch(mode=0o600, exist_ok=True)
+        os.chmod(db_path, 0o600)
         os.environ['FGC_DB_URL'] = f'sqlite:///{db_path}'
         logger.debug(f"Setting FGC_DB_URL=sqlite:///{db_path}")
 

--- a/fileglancer/database.py
+++ b/fileglancer/database.py
@@ -1208,11 +1208,21 @@ def get_job_by_id(session: Session, job_id: int) -> Optional[JobDB]:
 
 
 def set_job_service_url(session: Session, job_id: int, service_url: str) -> None:
-    """Cache a job's published service URL on its row."""
+    """Cache the origin of a job's published service URL on its row.
+
+    Only the origin is stored: the rest of the URL carries the service's access
+    token, and the column's one reader wants the authority. Normalizing here
+    rather than at the call site keeps the token out of the column no matter who
+    writes it. Imported inside the function because fileglancer.apps imports
+    this module, so a module-level import would close a cycle.
+    """
+    from fileglancer.apps.serviceproxy import service_url_origin
+
+    origin = service_url_origin(service_url)
     job = session.query(JobDB).filter_by(id=job_id).first()
-    if job is None or job.service_url == service_url:
+    if job is None or job.service_url == origin:
         return
-    job.service_url = service_url
+    job.service_url = origin
     session.commit()
 
 

--- a/fileglancer/user_worker.py
+++ b/fileglancer/user_worker.py
@@ -1013,6 +1013,7 @@ def _get_executor(request: dict):
 def _action_submit(request: dict, ctx: WorkerContext) -> dict:
     """Create work dir, symlink repo, submit job via py-cluster-api."""
     from cluster_api import ResourceSpec
+    from fileglancer.apps.jobfiles import ensure_private_dir
 
     executor = _get_executor(request)
 
@@ -1021,7 +1022,7 @@ def _action_submit(request: dict, ctx: WorkerContext) -> dict:
     fsps = _file_share_paths_from_request(request)
 
     work_dir = Path(request["work_dir"])
-    work_dir.mkdir(parents=True, exist_ok=True)
+    ensure_private_dir(work_dir)
 
     cached_repo_dir = request["cached_repo_dir"]
     repo_link = work_dir / "repo"

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1000,7 +1000,9 @@ class TestServiceUrlPublisher:
         assert result.returncode == 0, result.stderr
         assert "SERVICE_URL_PATH" in snippet and "3600" in snippet
 
-    def test_publishes_tokenized_url_only_once_port_is_up(self, tmp_path):
+    @pytest.mark.parametrize("preexisting", [False, True])
+    def test_publishes_tokenized_url_only_once_port_is_up(self, tmp_path,
+                                                          preexisting):
         import socket
         # Bind a real port so the probe's TCP connect succeeds.
         srv = socket.socket()
@@ -1010,6 +1012,11 @@ class TestServiceUrlPublisher:
         srv.listen()
         try:
             url_file = tmp_path / "service_url"
+            if preexisting:
+                # Redirection keeps the mode of a file that already exists, so
+                # the umask alone would leave this one readable.
+                url_file.touch()
+                os.chmod(url_file, 0o644)
             env = (
                 f'export FG_HOSTNAME=h1 FG_SERVICE_PORT={port} '
                 f'FG_SERVICE_TOKEN=deadbeef SERVICE_URL_PATH={url_file}\n'
@@ -1109,7 +1116,7 @@ class TestPrivateStateDir:
 
         monkeypatch.setattr(jobfiles.os, "chmod", fake_chmod)
         leaf = tmp_path / ".fileglancer" / "jobs" / "1-demo-run"
-        with pytest.raises(PermissionError, match="not safe to write job"):
+        with pytest.raises(PermissionError, match="not safe to write sensitive"):
             jobfiles.ensure_private_dir(leaf)
 
     def test_outside_the_state_dir_locks_the_leaf_only(self, tmp_path):

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1022,6 +1022,8 @@ class TestServiceUrlPublisher:
                                     capture_output=True, text=True, timeout=30)
             assert result.returncode == 0, result.stderr
             assert url_file.read_text() == f"http://h1:{port}/?access_token=deadbeef"
+            # The URL carries the access token: never group/world readable.
+            assert url_file.stat().st_mode & 0o077 == 0
         finally:
             srv.close()
 
@@ -1041,6 +1043,56 @@ class TestServiceUrlPublisher:
                                 capture_output=True, text=True, timeout=30)
         assert not url_file.exists()
         assert "never opened" in result.stderr
+
+
+class TestPrivateStateDir:
+    """~/.fileglancer holds service tokens and private clones: owner-only."""
+
+    def _chain(self, leaf):
+        """leaf and every ancestor up to (and including) .fileglancer."""
+        chain = [leaf]
+        while chain[-1].name != ".fileglancer":
+            chain.append(chain[-1].parent)
+        return chain
+
+    @pytest.mark.parametrize("subpath", [
+        ".fileglancer/jobs/1-demo-run",          # job work dir
+        ".fileglancer/apps/org/demo",            # repo clone
+        ".fileglancer/apps/org/demo/.snapshots",  # pinned checkouts
+    ])
+    def test_locks_down_the_whole_chain(self, tmp_path, subpath):
+        from fileglancer.apps.jobfiles import ensure_private_dir
+
+        # tmp_path stands in for $HOME: its mode must survive the walk upward.
+        os.chmod(tmp_path, 0o755)
+        leaf = tmp_path / subpath
+        ensure_private_dir(leaf)
+        for path in self._chain(leaf):
+            assert path.stat().st_mode & 0o077 == 0, path
+        assert tmp_path.stat().st_mode & 0o777 == 0o755
+
+    def test_fixes_an_already_world_readable_tree(self, tmp_path):
+        from fileglancer.apps.jobfiles import ensure_private_dir
+
+        leaf = tmp_path / ".fileglancer" / "jobs" / "1-demo-run"
+        leaf.mkdir(parents=True)
+        for path in self._chain(leaf):
+            os.chmod(path, 0o755)
+        ensure_private_dir(leaf)
+        for path in self._chain(leaf):
+            assert path.stat().st_mode & 0o077 == 0, path
+
+    def test_outside_the_state_dir_locks_the_leaf_only(self, tmp_path):
+        """A relocated cache base (as in tests) still gets a private leaf."""
+        from fileglancer.apps.jobfiles import ensure_private_dir
+
+        leaf = tmp_path / "somewhere" / "else"
+        ensure_private_dir(leaf)
+        assert leaf.stat().st_mode & 0o077 == 0
+        # The walk stops immediately: an unrelated parent keeps its mode.
+        os.chmod(tmp_path / "somewhere", 0o755)
+        ensure_private_dir(leaf)
+        assert (tmp_path / "somewhere").stat().st_mode & 0o777 == 0o755
 
 
 class TestServicePhase:

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1082,6 +1082,36 @@ class TestPrivateStateDir:
         for path in self._chain(leaf):
             assert path.stat().st_mode & 0o077 == 0, path
 
+    def test_an_unfixable_ancestor_warns_instead_of_failing(self, tmp_path,
+                                                            monkeypatch):
+        """A state root owned by someone else must not break job submission."""
+        from fileglancer.apps import jobfiles
+
+        real_chmod = os.chmod
+
+        def fake_chmod(target, mode):
+            if os.path.basename(target) == ".fileglancer":
+                raise PermissionError(1, "Operation not permitted")
+            real_chmod(target, mode)
+
+        monkeypatch.setattr(jobfiles.os, "chmod", fake_chmod)
+        leaf = tmp_path / ".fileglancer" / "jobs" / "1-demo-run"
+        jobfiles.ensure_private_dir(leaf)
+        assert leaf.stat().st_mode & 0o077 == 0
+        assert leaf.parent.stat().st_mode & 0o077 == 0
+
+    def test_an_unlockable_leaf_raises_a_readable_error(self, tmp_path,
+                                                        monkeypatch):
+        from fileglancer.apps import jobfiles
+
+        def fake_chmod(target, mode):
+            raise PermissionError(1, "Operation not permitted")
+
+        monkeypatch.setattr(jobfiles.os, "chmod", fake_chmod)
+        leaf = tmp_path / ".fileglancer" / "jobs" / "1-demo-run"
+        with pytest.raises(PermissionError, match="not safe to write job"):
+            jobfiles.ensure_private_dir(leaf)
+
     def test_outside_the_state_dir_locks_the_leaf_only(self, tmp_path):
         """A relocated cache base (as in tests) still gets a private leaf."""
         from fileglancer.apps.jobfiles import ensure_private_dir

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1089,6 +1089,24 @@ class TestPrivateStateDir:
         for path in self._chain(leaf):
             assert path.stat().st_mode & 0o077 == 0, path
 
+    def test_the_walk_stops_at_the_innermost_state_root(self, tmp_path):
+        """A ``.fileglancer`` component further up the path is not the root."""
+        from fileglancer.apps.jobfiles import ensure_private_dir
+
+        outer_state = tmp_path / ".fileglancer"
+        leaf = outer_state / "shared" / ".fileglancer" / "jobs" / "1-demo-run"
+        leaf.mkdir(parents=True)
+        os.chmod(outer_state, 0o755)
+        os.chmod(outer_state / "shared", 0o755)
+
+        ensure_private_dir(leaf)
+
+        for path in self._chain(leaf):
+            assert path.stat().st_mode & 0o077 == 0, path
+        # Everything above that root belongs to whoever put it there.
+        assert (outer_state / "shared").stat().st_mode & 0o777 == 0o755
+        assert outer_state.stat().st_mode & 0o777 == 0o755
+
     def test_an_unfixable_ancestor_warns_instead_of_failing(self, tmp_path,
                                                             monkeypatch):
         """A state root owned by someone else must not break job submission."""

--- a/tests/test_service_proxy.py
+++ b/tests/test_service_proxy.py
@@ -133,7 +133,8 @@ def test_set_job_service_url_persists(app_factory):
 
     session = get_db_session(db_url)
     try:
-        assert get_job_by_id(session, job_id).service_url == "http://node01:41235/lab?token=abc"
+        # Only the origin: the token in the query string is never stored.
+        assert get_job_by_id(session, job_id).service_url == "http://node01:41235"
     finally:
         session.close()
 
@@ -175,11 +176,13 @@ def test_get_job_caches_service_url(app_factory, monkeypatch):
     app.dependency_overrides.clear()
 
     assert resp.status_code == 200
+    # The browser gets the tokenized URL from the fresh worker read...
     assert resp.json()["service_url"] == "http://node01:41235/lab?token=abc"
 
     session = get_db_session(db_url)
     try:
-        assert get_job_by_id(session, job_id).service_url == "http://node01:41235/lab?token=abc"
+        # ...while the row keeps only what the proxy needs to dial.
+        assert get_job_by_id(session, job_id).service_url == "http://node01:41235"
     finally:
         session.close()
 
@@ -316,18 +319,21 @@ def test_job_detail_publishes_raw_url_when_proxy_disabled(app_factory, monkeypat
     assert resp.json()["service_url"] == "http://node01:41235/lab?token=abc"
 
 
-def test_job_detail_caches_the_raw_url_not_the_proxied_one(app_factory, monkeypatch):
-    """The cached value is the upstream, so it must stay in its raw form."""
+def test_job_detail_caches_the_raw_origin_not_the_proxied_url(app_factory, monkeypatch):
+    """The cached value is the upstream, so it stays in its raw form rather than
+    the proxied one — but only the origin of it, since the token in the query
+    string is a credential and the resolver never looks past the authority."""
     app, db_url = app_factory(PROXY_DOMAIN)
     job_id = _seed_service_job(db_url)
     _get_job_with_worker_url(
         app, job_id, "http://node01:41235/lab?token=abc", monkeypatch)
     session = get_db_session(db_url)
     try:
-        assert get_job_by_id(session, job_id).service_url == \
-            "http://node01:41235/lab?token=abc"
+        cached = get_job_by_id(session, job_id).service_url
     finally:
         session.close()
+    assert cached == "http://node01:41235"
+    assert "token" not in cached and _host(job_id) not in cached
 
 
 def test_resolve_rejects_malformed_cached_url(app_factory):

--- a/tests/test_service_proxy_urls.py
+++ b/tests/test_service_proxy_urls.py
@@ -9,6 +9,7 @@ from fileglancer.apps.serviceproxy import (
     build_proxied_service_url,
     job_id_from_host,
     service_host_label,
+    service_url_origin,
     upstream_from_service_url,
 )
 
@@ -128,6 +129,39 @@ def test_job_id_from_host_rejects_absurd_job_id():
     turning a bogus hostname into a 500 with a traceback instead of a refusal."""
     assert job_id_from_host(
         f"job-{'9' * 5000}-{'a' * _MAC_CHARS}.{DOMAIN}", DOMAIN, SECRET) is None
+
+
+# --- service_url_origin ---
+
+@pytest.mark.parametrize("url,expected", [
+    # The token lives in the query string, which is the point of all this.
+    ("http://node01:41235/lab?token=abc", "http://node01:41235"),
+    ("http://node01:41235", "http://node01:41235"),
+    ("https://node01:8443/x/y?a=1#f", "https://node01:8443"),
+    # No authority to keep.
+    ("garbage", None),
+    ("node01:41235", None),
+    ("", None),
+    (None, None),
+    # Userinfo is a credential too, and the upstream gate refuses it anyway.
+    ("https://user:pw@node01:8443/x", None),
+])
+def test_origin_keeps_only_scheme_and_authority(url, expected):
+    assert service_url_origin(url) == expected
+
+
+def test_origin_survives_the_upstream_gate_unchanged():
+    """Storing the origin must not change what the proxy resolves to."""
+    url = "http://node01:41235/lab?token=abc"
+    assert upstream_from_service_url(service_url_origin(url)) == \
+        upstream_from_service_url(url) == "node01:41235"
+
+
+def test_origin_of_a_header_injection_attempt_is_still_refused():
+    """urlsplit drops the CR/LF, so the raw bytes never reach the column; what
+    is left must still fail the upstream gate rather than become dialable."""
+    origin = service_url_origin("http://evil.example.org:80\r\nX-Injected: 1/")
+    assert upstream_from_service_url(origin) is None
 
 
 # --- upstream_from_service_url ---

--- a/tests/test_service_url_migration.py
+++ b/tests/test_service_url_migration.py
@@ -1,0 +1,114 @@
+"""Tests for the e4d1b7a92c58 service-URL credential-stripping migration."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from fileglancer.database import Base
+
+
+_MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "fileglancer" / "alembic" / "versions"
+    / "e4d1b7a92c58_strip_credentials_from_job_service_urls.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("_svc_url_mig", _MIGRATION)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mig = _load_migration()
+
+
+@pytest.mark.parametrize("url", [
+    "http://node01:41235/lab?token=abc",
+    "http://node01:41235",
+    "https://node01:8443/x?a=1#f",
+    "https://user:pw@node01:8443/x",
+    "garbage",
+    "",
+    None,
+])
+def test_migration_origin_matches_runtime(url):
+    """The inlined copy must agree with the helper the app writes through."""
+    from fileglancer.apps.serviceproxy import service_url_origin
+
+    assert mig._origin(url) == service_url_origin(url)
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite://")
+    Base.metadata.create_all(eng)
+    yield eng
+    eng.dispose()
+
+
+def _seed(engine, rows):
+    """Insert {job_id: service_url} through the ORM, so the model's own
+    defaults (status, created_at) are applied rather than hand-written."""
+    from sqlalchemy.orm import Session
+
+    from fileglancer.database import JobDB
+
+    with Session(engine) as session:
+        for job_id, service_url in rows.items():
+            session.add(JobDB(
+                id=job_id, username="alice", app_name="demo",
+                app_url="https://github.com/org/demo", entry_point_id="run",
+                entry_point_name="Run", parameters={}, status="RUNNING",
+                service_url=service_url,
+            ))
+        session.commit()
+
+
+def _service_urls(conn):
+    return dict(conn.execute(
+        text("SELECT id, service_url FROM jobs ORDER BY id")).fetchall())
+
+
+def test_upgrade_strips_the_token_and_nulls_unusable_rows(engine):
+    _seed(engine, {
+        1: "http://node01:41235/lab?token=abc",
+        2: "http://node02:8080",
+        3: "garbage",
+        4: "https://user:pw@node03:8443/x",
+        5: None,
+    })
+    with engine.begin() as conn:
+        mig._strip_stored_credentials(conn)
+
+        assert _service_urls(conn) == {
+            1: "http://node01:41235",   # token dropped
+            2: "http://node02:8080",    # already an origin, untouched
+            3: None,                    # no authority to keep
+            4: None,                    # userinfo is a credential too
+            5: None,
+        }
+
+
+def test_upgrade_is_idempotent(engine):
+    _seed(engine, {1: "http://node01:41235/lab?token=abc"})
+    with engine.begin() as conn:
+        mig._strip_stored_credentials(conn)
+        first = _service_urls(conn)
+        mig._strip_stored_credentials(conn)
+        assert _service_urls(conn) == first
+
+
+def test_stripped_row_still_resolves_to_the_same_upstream(engine):
+    """The migration must not break a running service's proxy resolution."""
+    from fileglancer.apps.serviceproxy import upstream_from_service_url
+
+    _seed(engine, {1: "http://node01:41235/lab?token=abc"})
+    with engine.begin() as conn:
+        mig._strip_stored_credentials(conn)
+        stored = _service_urls(conn)[1]
+
+    assert upstream_from_service_url(stored) == "node01:41235"

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -12,6 +12,8 @@ import subprocess
 
 import pytest
 
+from conftest import requires_symlinks
+
 import fileglancer.apps.manifest as m
 
 
@@ -86,6 +88,36 @@ def test_snapshot_of_current_head(repo_setup):
     # Idempotent: asking for the same sha finds the existing snapshot.
     snap_dir2, sha2 = asyncio.run(m.ensure_repo_snapshot(REPO_URL, sha=sha))
     assert (snap_dir2, sha2) == (snap_dir, sha)
+
+
+@requires_symlinks
+def test_repo_cache_locks_a_symlinked_state_root(tmp_path, monkeypatch):
+    """The permission walk has to see the lexical path.
+
+    resolve() collapses the .fileglancer component away whenever part of the
+    path is a symlink -- a state directory relocated to keep multi-GB SIFs off a
+    home quota, or an automounted home -- and the walk would then stop at the
+    repo directory instead of repairing the state root.
+    """
+    real_state = tmp_path / "nrs" / "fg-state"
+    (real_state / "apps").mkdir(parents=True)
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".fileglancer").symlink_to(real_state)
+    cache_base = home / ".fileglancer" / "apps"
+    monkeypatch.setattr(m, "_repo_cache_base", lambda username=None: cache_base)
+    monkeypatch.setattr(m, "_repo_locks", {})
+    # Seed the clone so this is a cache hit and no git runs.
+    (cache_base / "owner" / "repo" / "main").mkdir(parents=True)
+    os.chmod(real_state, 0o755)
+    os.chmod(real_state / "apps", 0o755)
+
+    asyncio.run(m._ensure_repo_cache(REPO_URL, pull=False))
+
+    assert (real_state / "apps").stat().st_mode & 0o077 == 0
+    assert real_state.stat().st_mode & 0o077 == 0, "state root not repaired"
+    # The walk stops at the state root: the home it lives in is not ours.
+    assert home.stat().st_mode & 0o700 == 0o700
 
 
 def test_existing_snapshot_tree_is_locked_down_on_the_hot_path(repo_setup):

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -6,6 +6,7 @@ _ensure_repo_cache/_repo_cache_base monkeypatches, everything below that
 """
 
 import asyncio
+import os
 import shutil
 import subprocess
 
@@ -85,6 +86,21 @@ def test_snapshot_of_current_head(repo_setup):
     # Idempotent: asking for the same sha finds the existing snapshot.
     snap_dir2, sha2 = asyncio.run(m.ensure_repo_snapshot(REPO_URL, sha=sha))
     assert (snap_dir2, sha2) == (snap_dir, sha)
+
+
+def test_existing_snapshot_tree_is_locked_down_on_the_hot_path(repo_setup):
+    """Launching a pinned app reaches neither _ensure_repo_cache nor
+    _create_snapshot, so the hot path is the only chance to make a snapshot tree
+    left world-readable by an older release private again."""
+    _, clone = repo_setup
+    snap_dir, sha = asyncio.run(m.ensure_repo_snapshot(REPO_URL))
+    snapshots = snap_dir.parent
+    os.chmod(snapshots, 0o755)
+
+    snap_dir2, _ = asyncio.run(m.ensure_repo_snapshot(REPO_URL, sha=sha))
+
+    assert snap_dir2 == snap_dir
+    assert snapshots.stat().st_mode & 0o077 == 0
 
 
 def test_snapshot_immutable_when_branch_moves(repo_setup):


### PR DESCRIPTION
## Problem

Fileglancer kept live credentials in three places where other people could read them.

**Job work directories and the app repo cache.** Everything under `~/.fileglancer` was created with the default umask, which on a shared filesystem means world-readable. A service job's work directory contains `service_url`, and that URL carries the access token the service authenticates with; services routinely echo the same URL into `stdout.log` as well. Any user who could read those files could connect to the service and act as its owner. The repo cache under `apps/` is a lesser case of the same thing: clones that may come from private repositories.

**The CLI's SQLite database.** `fileglancer start` created `~/.local/share/fileglancer` with the default umask too, and that database stores session ids verbatim — working login cookies — not just metadata.

**The `jobs.service_url` column.** It held the whole published URL, token and all, and nothing ever read that back. Its only consumer is `/api/apps/resolve`, which keeps the authority and discards the rest; the URL the browser gets from `GET /api/jobs/{id}` comes from that request's own worker read, with no fallback to the column. In a multi-user deployment the database is MySQL, which no file permission reaches, so database access, dumps and backups were a way to recover every running service's token.

## Fix

**The state directory.** `ensure_private_dir()` creates a directory 0700 and then locks every level up to and including the innermost `.fileglancer` above it.

The directory mode is what has to carry this. Chmodding individual files would mean chasing every writer — apps that write `SERVICE_URL_PATH` themselves when `auto_url` is off, and the scheduler writing the job's logs — and would still leave `stdout.log` exposed. One private directory covers all of them.

It is called from the four places the tree is created or first read, all of which already run as the owning user:

- `_action_submit` — the job work directory
- `_ensure_repo_cache` — the repo clone, above the cache-hit check rather than only on the clone path, so it is reached by every user rather than only by those cloning something new
- `_create_snapshot` — the pinned-commit checkouts
- `ensure_repo_snapshot`'s hot path — launching a pinned app reaches neither of the previous two, so for a user whose snapshots all predate this it is the only call that runs

Because it walks up to the state root, the first of those also locks down subtrees left world-readable by an earlier version. It self-heals when a user next launches an app or loads a manifest; nobody has to sweep anything, which matters because root cannot chmod these under root-squash NFS.

The `auto_url` publisher additionally writes `service_url` under `umask 077` and chmods it afterwards, so the file is 0600 on its own merits if it ever outlives its directory.

**The CLI database.** The directory is now 0700, which also covers the `-wal` and `-shm` sidecars SQLite writes beside the database, and the file is 0600 so a copy of it stays private. Both are unconditional, so an install created before this, or under a laxer umask, is repaired on the next start.

**The column.** `set_job_service_url` now stores `scheme://host:port`. Normalizing in the setter rather than at its one call site keeps the token out of the column whoever writes it. Migration `e4d1b7a92c58` rewrites existing rows so tokens already stored do not outlive the fix.

## Notes

- **This carries a data migration**, unlike the rest of the change. It rewrites `jobs.service_url` in place and nulls any row with no usable authority; a nulled row repopulates from the work directory on the next detail-page load. Verified with a full `alembic upgrade head` from an empty database, not just by calling the helper. Earlier revisions of this PR were aimed at a `3.1.1` backport — that is no longer the plan, and everything here ships from main in the next release.
- An authority carrying userinfo stores nothing rather than an origin. That is a credential too, and `upstream_from_service_url` refuses userinfo by design, so stripping it to make the row dialable would have quietly widened the SSRF gate.
- **`executor: local` is now documented as single-user only.** `_poll_local_jobs` runs in the server process and reads `job.pid` and `exit_code` straight from the work directory, so a 0700 work directory would leave another user's job in PENDING forever — the zombie timeout does not catch it, because the job has a `cluster_job_id`. That configuration is not supported, so the config template says so next to the option, and the upgrade path (move both reads into a worker action, the way `read_job_file` already does) is recorded next to the code that would have to change.
- A chmod that fails now explains itself. Failing to lock the leaf raises with a message naming what could not be made private; an ancestor we cannot repair (owned by another uid) is logged as a warning and ends the walk, rather than failing a job submission over a directory whose contents are already covered.
- `fileglancer debug` reading another user's job directory in-process now gets `None` instead of contents. It already swallows `OSError`, and root-squash NFS denied this in production anyway.
- `ensure_private_dir` locks only the leaf when handed a path outside a state directory — otherwise it would dictate where callers may create directories, and the snapshot tests relocate the cache base. The state root is found lexically rather than by resolving the path: a relocated state directory (a symlinked `~/.fileglancer`) resolves to somewhere with no `.fileglancer` component at all, so resolving would drop the walk entirely and leave the real tree unlocked.
- Already-issued tokens are not rotated by any of this, but no services are running, so there is nothing live to re-key.

## Testing

`pixi run -e test test-backend` — 1056 passed.

New coverage: `TestPrivateStateDir` (the whole chain is locked for a job dir, a repo clone and a snapshot dir; an already-755 tree is repaired; `$HOME` above the state root keeps its mode; the walk stops at the innermost state root; an unfixable ancestor warns while still locking the leaf; an unlockable leaf raises a readable error), the snapshot hot path repairing a world-readable tree, the publisher asserting 0600 both for a fresh file and one that already existed 0644, `service_url_origin` against the upstream gate including a header-injection attempt, and `tests/test_service_url_migration.py` for the rewrite, its idempotency, and that a stripped row still resolves to the same upstream.

Each of the regression tests was confirmed to fail with its fix reverted.

The database permissions are the one thing with no automated test — there is no CLI test harness, and standing one up to exercise three straight-line statements is more scaffolding than the fix. The resulting modes and SQLite's willingness to open the pre-created file were verified by hand.

@StephanPreibisch @JaneliaSciComp/fileglancer
