### PR TITLE
fix: run the Prettier pre-push hook through bash

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,10 @@ pre-push:
   jobs:
     - name: Run Prettier check; fix if check fails
       root: frontend/
-      run: pixi run ./prettier-check-and-fix.sh
+      # Invoked through bash explicitly: on Windows, pixi hands the script to
+      # the OS to execute and gets `os error 193` (not a valid Win32
+      # application), so the hook could never run there.
+      run: pixi run bash ./prettier-check-and-fix.sh
 
     - name: Run ESLint check
       root: frontend/


### PR DESCRIPTION
Split out of #443, where it was unrelated to the subject.

\`pixi run ./prettier-check-and-fix.sh\` hands the script to the OS to execute, which on Windows fails with \`os error 193\` -- not a valid Win32 application. lefthook fails the push when a job fails, so no push from a Windows checkout could succeed either. Naming \`bash\` explicitly runs the same script the same way everywhere.

This is about the machine a contributor edits and pushes from, not about a platform fileglancer runs on -- unaffected by #439 dropping Windows from fileglancer's own supported platforms.

@krokicki @JaneliaSciComp/fileglancer